### PR TITLE
fix(deploy): remove Python buildpack after TypeScript migration

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,1 @@
-https://github.com/Scalingo/python-buildpack 
 https://github.com/Scalingo/nodejs-buildpack.git


### PR DESCRIPTION
Scalingo deployment was failing because the Python buildpack was still configured while the project no longer has Python dependencies after the migration to TypeScript (commit 68cd603).

Removed Python buildpack, keeping only Node.js buildpack for proper deployment.