### PR TITLE
fix(deploy): update Node.js engines to fix Scalingo corepack issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,8 @@
     "vite": "^6.3.2"
   },
   "engines": {
-    "pnpm": ">=10",
-    "node": ">=22"
-  }
+    "pnpm": "10.x",
+    "node": "22.x"
+  },
+  "packageManager": "pnpm@10.10.0"
 }


### PR DESCRIPTION
- Change node version from >=22 to 22.x (safer semver range)
- Change pnpm version from >=10 to 10.x
- Add explicit packageManager field for corepack compatibility

This fixes the 'corepack: command not found' error during Scalingo deployment.