### PR TITLE
chore(ci): update GitHub Actions to v6 with pnpm caching

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -13,20 +13,20 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - uses: actions/checkout@v4
-      
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           ssh-key: ${{ secrets.SCALINGO_BETA_GOUV_SSH_PRIVATE_KEY }} # needed to bypass protection rules on main branch as per
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
-
       - name: Install pnpm
         shell: bash
         run: npm install -g pnpm@10.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -44,16 +44,17 @@ jobs:
           --health-retries 5
 
     steps:
-      - uses: actions/checkout@v4
-
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '22'
+      - uses: actions/checkout@v6
 
       - name: Install pnpm
         shell: bash
         run: npm install -g pnpm@10.0.0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+          cache: 'pnpm'
 
       - name: Install dependencies
         run: pnpm install
@@ -92,7 +93,7 @@ jobs:
     if: github.event_name == 'push' # Only deploy when the PR is merged
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
 


### PR DESCRIPTION
# GitHub Actions v6 Updates + Performance Optimization

This PR updates our GitHub Actions workflows to use the latest v6 versions with explicit pnpm caching for improved CI performance.

## 📦 Actions Updated

### actions/checkout v4 → v6
- ✅ Node.js 24 support
- 🔐 Improved credential management (persists to separate file under `$RUNNER_TEMP`)
- ⚠️ Requires Actions Runner v2.329.0+ (met by GitHub-hosted runners)

**Occurrences updated:**
- `staging-deployment.yml`: 2x (lint-test-typecheck + deploy-staging jobs)
- `prod-deployment.yml`: 1x (release-and-deploy job)

### actions/setup-node v4 → v6
- ✅ Node.js 24 support
- 🔄 Added explicit `cache: 'pnpm'` configuration
- ⚡ CI performance improvement via dependency caching

**Occurrences updated:**
- `staging-deployment.yml`: 1x (lint-test-typecheck job)
- `prod-deployment.yml`: 1x (release-and-deploy job)

## ⚡ Performance Improvements

By adding explicit pnpm caching:
- Dependencies cached across workflow runs
- Faster CI execution (reduced pnpm install time)
- Lower GitHub Actions minutes consumption

**Cache key**: Based on pnpm-lock.yaml hash
**Cache location**: `~/.pnpm-store`

## 🔄 Replaces Dependabot PRs

This PR consolidates and replaces:
- PR #279 - actions/checkout v4→v6
- PR #269 - actions/setup-node v4→v6

Manual implementation chosen for:
- Better control over changes
- Ability to test both updates together
- Addition of pnpm caching optimization

## ✅ Validation

- ✅ All workflow files validated
- ✅ Syntax correct (yml linting)
- ✅ Pre-commit hooks passed
- ⏳ Awaiting CI test results

## 📋 Post-Merge Actions

After merging this PR:
1. Close Dependabot PR #279
2. Close Dependabot PR #269
3. Monitor first workflow runs with new actions