### PR TITLE
feat(security): add 7-day minimum release age for packages

### DIFF
--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -12,3 +12,7 @@ overrides:
   form-data@<2.5.4: '>=2.5.4'
   js-yaml@>=4.0.0 <4.1.1: '>=4.1.1'
   body-parser@>=2.2.0 <2.2.1: '>=2.2.1'
+
+# Security: Require packages to be at least 7 days old before installation
+# This reduces the risk of supply chain attacks by delaying installation of newly published versions
+minimumReleaseAge: 10080


### PR DESCRIPTION
## Summary
Add `minimumReleaseAge` configuration to pnpm-workspace.yaml to require all packages to be at least 7 days (10080 minutes) old before installation.

## Security Benefits
This security measure reduces the attack surface for supply chain attacks by:
- **Preventing immediate installation** of newly published package versions that could be compromised or malicious
- **Creating a cooldown period** of 7 days for the community to identify and report suspicious packages
- **Applying to all dependencies** including transitive ones
- **Mitigating zero-day package attacks** where attackers publish malicious versions immediately

## Changes
- Added `minimumReleaseAge: 10080` to `pnpm-workspace.yaml`
- Added explanatory comments about the security purpose

## Testing
- ✅ All validation checks passed (TypeScript, ESLint, Prettier, Talisman)
- Configuration follows official pnpm documentation: https://pnpm.io/settings

## Impact
- Package installations will now require packages to be at least 7 days old
- May delay installation of very recently published packages
- Can be overridden for specific packages if needed using `minimumReleaseAgeExclude`

## Related
- Supply chain security hardening initiative
- Follows security best practices for dependency management