### PR TITLE
fix(ci): resolve Scalingo deployment failures and add error detection

### DIFF
--- a/.buildpack-nodejs
+++ b/.buildpack-nodejs
@@ -1,0 +1,4 @@
+# Scalingo Node.js buildpack configuration
+# Ignore npm and yarn engine restrictions while keeping pnpm requirement
+engines.npm=ignore
+engines.yarn=ignore

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -115,5 +115,21 @@ jobs:
 
       - name: Deploy to Scalingo (Staging)
         run: |
-          # Push the staging branch to Scalingo's main branch
-          git push git@ssh.osc-fr1.scalingo.com:les-communs-transition-ecologique-api-staging.git main
+          set -e  # Exit on any error
+          echo "🚀 Deploying to Scalingo staging environment..."
+
+          # Push to Scalingo and capture output
+          if git push git@ssh.osc-fr1.scalingo.com:les-communs-transition-ecologique-api-staging.git main 2>&1 | tee deploy.log; then
+            echo "✅ Git push completed"
+
+            # Check if deployment succeeded by looking for error indicators in output
+            if grep -q "Build failed\|Error deploying\|Invalid return code" deploy.log; then
+              echo "❌ Deployment failed! Check logs above for details."
+              exit 1
+            fi
+
+            echo "✅ Deployment successful!"
+          else
+            echo "❌ Git push failed!"
+            exit 1
+          fi


### PR DESCRIPTION
## 🐛 Problem

The staging deployment task was failing silently with two critical issues:

1. **Scalingo buildpack rejection**: The Node.js buildpack detected multiple package managers and refused to build
2. **Silent failures**: Deployments failed on Scalingo but GitHub Actions reported success

## 🔍 Root Causes

### Issue 1: Package Manager Conflict
Scalingo's buildpack was interpreting our local npm/yarn prevention mechanism as actual package manager declarations:
```json
"engines": {
  "npm": "use-pnpm-instead",  // ❌ Scalingo saw this as a real npm declaration
  "yarn": "use-pnpm-instead", // ❌ Scalingo saw this as a real yarn declaration
  "pnpm": "10.x"
}
```

Error from Scalingo logs:
```
Build failed
Multiple package managers declared in package.json
- npm version detected in engines.npm (use-pnpm-instead)
- yarn version declared in engines.yarn (use-pnpm-instead)
- pnpm version declared in engines.pnpm (10.x)
```

### Issue 2: Silent Failure
The `git push` command exits with 0 even when Scalingo's remote build fails, so the workflow step succeeded despite deployment failures.

## ✅ Solutions Implemented

### 1. Created `.buildpack-nodejs` Configuration
Tells Scalingo to ignore npm/yarn engine fields while keeping local protection:
```
engines.npm=ignore
engines.yarn=ignore
```

**Benefits:**
- ✅ Scalingo deployment works
- ✅ Local npm/yarn prevention still active
- ✅ No code changes needed to package.json
- ✅ Clean, configuration-based solution

### 2. Enhanced Deployment Error Detection
Updated the deployment step to:
- Capture deployment output to a log file
- Check for error indicators: `Build failed`, `Error deploying`, `Invalid return code`
- Fail the workflow explicitly when errors are detected
- Provide clear success/failure messages with emojis

**Before:**
```yaml
- name: Deploy to Scalingo (Staging)
  run: |
    git push git@ssh.osc-fr1.scalingo.com:les-communs-transition-ecologique-api-staging.git main
```
Deployment fails → Workflow shows ✅ success

**After:**
```yaml
- name: Deploy to Scalingo (Staging)
  run: |
    set -e
    echo "🚀 Deploying to Scalingo staging environment..."
    
    if git push ... 2>&1 | tee deploy.log; then
      if grep -q "Build failed\|Error deploying" deploy.log; then
        echo "❌ Deployment failed! Check logs above for details."
        exit 1
      fi
      echo "✅ Deployment successful!"
    else
      echo "❌ Git push failed!"
      exit 1
    fi
```
Deployment fails → Workflow shows ❌ failure with clear message

## 🧪 Testing

This PR will test the fixes by triggering a deployment to staging when merged.

Expected behavior:
- ✅ Scalingo buildpack accepts the configuration
- ✅ Deployment succeeds (no package manager conflicts)
- ✅ Future deployment failures are properly reported

## 📝 Related

- Maintains npm/yarn prevention from PRs #298, #299
- Fixes silent deployment failures that have been occurring