### PR TITLE
fix(ci): patch package.json during deployment to fix Scalingo buildpack

### DIFF
--- a/.buildpack-nodejs
+++ b/.buildpack-nodejs
@@ -1,4 +1,0 @@
-# Scalingo Node.js buildpack configuration
-# Ignore npm and yarn engine restrictions while keeping pnpm requirement
-engines.npm=ignore
-engines.yarn=ignore

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -113,12 +113,32 @@ jobs:
           chmod 600 ~/.ssh/id_rsa
           ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
+      - name: Prepare package.json for Scalingo
+        run: |
+          set -e
+          echo "🔧 Patching package.json for Scalingo buildpack compatibility..."
+
+          # Temporary patch: Remove npm/yarn engine restrictions for Scalingo
+          # Local protection via engine-strict + engines fields is maintained in git
+          node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('package.json', JSON.stringify(pkg,null,2));"
+
+          # Configure git for CI commit
+          git config user.name "GitHub Actions"
+          git config user.email "actions@github.com"
+
+          # Commit the patch (will be pushed to Scalingo only, not to GitHub)
+          git add package.json
+          git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"
+
+          echo "✅ package.json patched for deployment"
+
       - name: Deploy to Scalingo (Staging)
         run: |
           set -e  # Exit on any error
           echo "🚀 Deploying to Scalingo staging environment..."
 
           # Push to Scalingo and capture output
+          # Note: This pushes the patched package.json to Scalingo only (not to GitHub origin)
           if git push git@ssh.osc-fr1.scalingo.com:les-communs-transition-ecologique-api-staging.git main 2>&1 | tee deploy.log; then
             echo "✅ Git push completed"
 


### PR DESCRIPTION
## 🐛 Problem

PR #300 was merged but the `.buildpack-nodejs` solution **does not work** - Scalingo does not support this configuration file.

The deployment is still failing with the same error:
```
Build failed
Multiple package managers declared in package.json
```

## 🔍 Root Cause (Confirmed)

After research and testing:
- ❌ `.buildpack-nodejs` is **NOT supported** by Scalingo's Node.js buildpack
- ❌ No environment variables exist to bypass the check
- ✅ The buildpack hardcodes the validation in `lib/failure.sh`

Our `"use-pnpm-instead"` values **CANNOT be removed** because:
- They are our **ONLY protection** at first `npm install` (before git hooks)
- `engine-strict=true` + these fields = npm/yarn blocked immediately
- Pre-commit hooks install AFTER first install → not primary defense

## ✅ Solution: Temporary Patch in CI

This PR implements a **temporary patch** during deployment:

```yaml
- name: Prepare package.json for Scalingo
  run: |
    # Remove npm/yarn engine restrictions temporarily
    node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('package.json', JSON.stringify(pkg,null,2));"
    
    git config user.name "GitHub Actions"
    git config user.email "actions@github.com"
    
    # Commit patch (pushed to Scalingo only, NOT to GitHub)
    git add package.json
    git commit -m "chore(deploy): remove npm/yarn engines for Scalingo [ci skip]"

- name: Deploy to Scalingo (Staging)
  run: |
    # Push to Scalingo (includes the patch commit)
    git push git@ssh.osc-fr1.scalingo.com:... main
```

**Flow:**
1. GitHub Actions runner checks out `main`
2. Patch removes `engines.npm` and `engines.yarn`
3. Commit created **locally in the runner**
4. Push to Scalingo → commit goes **ONLY to Scalingo**
5. GitHub `main` remains **untouched**

**What we preserve:**
- ✅ Local npm/yarn blocking via `engine-strict` + `engines` fields
- ✅ Supply chain security with `onlyBuiltDependencies: []`
- ✅ Pre-commit hook as secondary defense
- ✅ **No external dependencies** (rejected `only-allow` for security)
- ✅ **Zero supply chain risk**

**Trade-off:**
- ⚠️ Scalingo's git history will have patch commits
- ✅ **Acceptable** - Scalingo is not our source of truth

## 📝 Changes

- Remove `.buildpack-nodejs` (doesn't work)
- Add "Prepare package.json for Scalingo" step
- Keep error detection from PR #300

## 🧪 Testing

When merged, this will:
- ✅ Remove the non-working `.buildpack-nodejs`
- ✅ Apply the patch before each deployment
- ✅ Allow Scalingo buildpack to succeed
- ✅ Maintain all local security protections

## 🔗 Related

- Supersedes: PR #300 (merged but solution didn't work)
- Maintains: Security from PRs #296, #298, #299
- Preserves: `onlyBuiltDependencies`, `engine-strict`, pre-commit hooks