### PR TITLE
fix(ci): patch both package.json files for Scalingo deployment

### DIFF
--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -116,21 +116,26 @@ jobs:
       - name: Prepare package.json for Scalingo
         run: |
           set -e
-          echo "🔧 Patching package.json for Scalingo buildpack compatibility..."
+          echo "🔧 Patching package.json files for Scalingo buildpack compatibility..."
 
           # Temporary patch: Remove npm/yarn engine restrictions for Scalingo
           # Local protection via engine-strict + engines fields is maintained in git
+
+          # Patch root package.json
           node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('package.json', JSON.stringify(pkg,null,2));"
+
+          # Patch api/package.json (the one Scalingo actually uses)
+          node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('api/package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('api/package.json', JSON.stringify(pkg,null,2));"
 
           # Configure git for CI commit
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
           # Commit the patch (will be pushed to Scalingo only, not to GitHub)
-          git add package.json
+          git add package.json api/package.json
           git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"
 
-          echo "✅ package.json patched for deployment"
+          echo "✅ Both package.json files patched for deployment"
 
       - name: Deploy to Scalingo (Staging)
         run: |


### PR DESCRIPTION
## Problem

PR #301 failed to fix the Scalingo deployment. Investigation revealed the root cause:

**Scalingo reads `api/package.json`, not just the root `package.json`!**

Evidence from failed deployment logs:
```
✅ package.json patched for deployment
...
❌ Build failed
Multiple package managers declared in package.json
- npm version detected in engines.npm (use-pnpm-instead)
- yarn version declared in engines.yarn (use-pnpm-instead)  
- pnpm version declared in engines.pnpm (10.x)
```

The patch WAS being applied successfully, but only to the root package.json. In a monorepo structure, Scalingo's Node.js buildpack reads the `api/package.json` file (lines 109-114) which still contained the `engines.npm` and `engines.yarn` fields.

## Solution

Update the "Prepare package.json for Scalingo" step to patch **BOTH** files:
- Root `package.json` (for consistency)
- `api/package.json` (the one Scalingo actually uses)

The temporary patch:
1. Removes `engines.npm` and `engines.yarn` from both files
2. Commits changes locally in CI
3. Pushes ONLY to Scalingo (not to GitHub origin)
4. Local repo maintains full npm/yarn protection via `engine-strict=true` + engines fields

## Why This Should Work

The Scalingo buildpack will now see a clean `api/package.json` with only:
```json
{
  "engines": {
    "pnpm": "10.x",
    "node": "22.x"
  },
  "packageManager": "pnpm@10.10.0"
}
```

This satisfies the buildpack's "multiple package managers" validation (count = 1).

## Security Maintained

All security protections remain intact in the GitHub repository:
- ✅ `engine-strict=true` blocks npm/yarn at first install
- ✅ `onlyBuiltDependencies: []` blocks malicious lifecycle scripts
- ✅ Pre-commit hooks as secondary validation
- ✅ No external dependencies added

The patch only affects the Scalingo deployment, not the local development environment or GitHub repository.

Fixes the deployment issue identified in runs 19747972123 and 19747837253.