### PR TITLE
fix(ci): set working-directory to root for package.json patching

### DIFF
--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -114,6 +114,7 @@ jobs:
           ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
       - name: Prepare package.json for Scalingo
+        working-directory: .
         run: |
           set -e
           echo "🔧 Patching package.json files for Scalingo buildpack compatibility..."


### PR DESCRIPTION
## Problem

PR #302 failed because the "Prepare package.json for Scalingo" step couldn't find `api/package.json`:

```
Error: ENOENT: no such file or directory, open 'api/package.json'
```

**Root Cause**: The workflow has `defaults.run.working-directory: api` (line 13), so all steps inherit this and run from the `api/` directory by default. When the patch script tries to read `api/package.json`, it's actually looking for `api/api/package.json`.

## Solution

Add `working-directory: .` to the "Prepare package.json for Scalingo" step to run it from the repository root, where it can access both:
- `package.json` (root)
- `api/package.json` (the one Scalingo reads)

## Changes

```yaml
- name: Prepare package.json for Scalingo
  working-directory: .  # ← Added this line
  run: |
    # ... patch both package.json files
```

This follows the same pattern already used in other steps like "Install dependencies", "Setup Git hooks", etc., which also override the default working directory to run from root.

Fixes the deployment failure from run 19748218842.