### PR TITLE
fix(ci): resolve silent production deployment failures

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -57,10 +57,51 @@ jobs:
           echo "${{ secrets.SCALINGO_BETA_GOUV_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
           # Explicitly scan for all key types to avoid issues with the host key not being found
-          ssh-keyscan -H -t rsa,ecdsa,ed25519 ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts 
+          ssh-keyscan -H -t rsa,ecdsa,ed25519 ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
+
+      - name: Prepare package.json for Scalingo
+        working-directory: .
+        run: |
+          set -e
+          echo "🔧 Patching package.json files for Scalingo buildpack compatibility..."
+
+          # Temporary patch: Remove npm/yarn engine restrictions for Scalingo
+          # Local protection via engine-strict + engines fields is maintained in git
+
+          # Patch root package.json
+          node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('package.json', JSON.stringify(pkg,null,2));"
+
+          # Patch api/package.json (the one Scalingo actually uses)
+          node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('api/package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('api/package.json', JSON.stringify(pkg,null,2));"
+
+          # Commit the patch (will be pushed to Scalingo only, not to GitHub)
+          git add package.json api/package.json
+          git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"
+
+          echo "✅ Both package.json files patched for deployment"
 
       - name: Deploy to Scalingo Production
         run: |
-          # Push the prod branch to Scalingo's main branch
-          # Add verbose flag to see more details about the SSH connection
-          GIT_SSH_COMMAND="ssh -v" git push git@ssh.osc-fr1.scalingo.com:les-communs-transition-ecologique-api-prod.git main
+          set -e  # Exit on any error
+          echo "🚀 Deploying to Scalingo production environment..."
+
+          # Force push required: ephemeral commit overwrites previous deployment
+          # Each deployment creates a new patch commit that must replace the previous one
+          git push --force git@ssh.osc-fr1.scalingo.com:les-communs-transition-ecologique-api-prod.git main 2>&1 | tee deploy.log
+          PUSH_STATUS=${PIPESTATUS[0]}
+
+          if [ $PUSH_STATUS -ne 0 ]; then
+            echo "❌ Git push failed with exit code $PUSH_STATUS"
+            cat deploy.log
+            exit 1
+          fi
+
+          echo "✅ Git push completed"
+
+          # Check if deployment succeeded by looking for error indicators in output
+          if grep -qE "Build failed|Error deploying|Invalid return code" deploy.log; then
+            echo "❌ Deployment failed during build! Check logs above."
+            exit 1
+          fi
+
+          echo "✅ Deployment successful!"

--- a/.talismanrc
+++ b/.talismanrc
@@ -22,4 +22,7 @@ fileignoreconfig:
 - filename: api/test/qualification.e2e-spec.ts
   checksum: 1a45eabdceb14af75183c5477f52e4aad8c17e7d99a15d2a0508387bf775afc7
   comments: "False positive: Test file checking authentication with 'API key' in error message assertions, not actual secrets"
+- filename: .github/workflows/prod-deployment.yml
+  checksum: eb8200879024f525bff1e371413952032deccbe42523d5cc9c095fa723c9f022
+  comments: "False positive: ssh-keyscan command for Scalingo deployment, not a secret"
 version: "1.0"


### PR DESCRIPTION
## 🐛 Problème

Le dernier déploiement production (workflow_dispatch) a échoué **silencieusement** :
- Le workflow affichait ✅ Exit status 0 (success)
- Mais le build Scalingo avait échoué avec "Build failed"
- Erreur : "Multiple package managers declared in package.json"

## 🔍 Analyse Comparative : Staging vs Production

### État Actuel

| Élément | Staging (Fixé ✅) | Prod (Problème ❌) |
|---------|-------------------|-------------------|
| **Patch package.json** | ✅ Retire npm/yarn engines | ❌ Absent |
| **Commit éphémère** | ✅ Créé et documenté | ❌ Absent |
| **Force push** | ✅ Avec \`--force\` | ❌ Push simple |
| **Détection erreur** | ✅ PIPESTATUS + grep | ❌ Aucune |
| **Logs de deploy** | ✅ Capturés avec \`tee\` | ❌ Non capturés |
| **Validation build** | ✅ Grep "Build failed" | ❌ Aucune |

### Diagnostic des Causes Racines

#### Cause #1 : Build Failure (Pas de Patch package.json)

**Erreur Scalingo** :
```
Multiple package managers declared in package.json
- engines.npm: "use-pnpm-instead"  
- engines.yarn: "use-pnpm-instead"
- engines.pnpm: "10.x"
```

**Problème** : Le workflow prod ne patche pas les package.json avant le déploiement, contrairement à staging.

#### Cause #2 : Fail Silencieux (Pas de Détection d'Erreur)

Le workflow prod ligne 62-66 :
```yaml
- name: Deploy to Scalingo Production
  run: |
    GIT_SSH_COMMAND="ssh -v" git push ... main
```

**Manque** :
- ❌ Pas de capture du code de sortie réel
- ❌ Pas de validation des logs de build
- ❌ Pas de détection de "Build failed"

Résultat : Exit status 0 même en cas de build failed.

## ✅ Solutions Implémentées

### Fix #1 : Ajout du Patch package.json

Nouvelle étape insérée après "Setup SSH" :

```yaml
- name: Prepare package.json for Scalingo
  working-directory: .
  run: |
    # Patch root + api/package.json
    node -e "delete pkg.engines.npm; delete pkg.engines.yarn..."
    
    # Créer commit éphémère
    git commit -m "chore(deploy): remove engines [ci skip]"
```

**Bénéfice** : Résout l'erreur "Multiple package managers" de Scalingo.

### Fix #2 : Détection d'Erreur Complète

Remplacement complet de l'étape "Deploy to Scalingo Production" :

```yaml
- name: Deploy to Scalingo Production
  run: |
    set -e  # Exit on any error
    
    # Force push (commit éphémère)
    git push --force ... main 2>&1 | tee deploy.log
    PUSH_STATUS=${PIPESTATUS[0]}
    
    # Vérifier le code de sortie réel
    if [ $PUSH_STATUS -ne 0 ]; then
      echo "❌ Git push failed"
      exit 1
    fi
    
    # Vérifier les erreurs de build Scalingo
    if grep -qE "Build failed|Error deploying|Invalid return code" deploy.log; then
      echo "❌ Deployment failed"
      exit 1
    fi
    
    echo "✅ Deployment successful!"
```

**Bénéfices** :
1. ✅ Capture du vrai code de sortie avec PIPESTATUS
2. ✅ Détection des erreurs de build dans les logs
3. ✅ Force push pour écraser les commits éphémères précédents
4. ✅ Alignement avec le workflow staging (PR #306)

### Fix #3 : Update Talismanrc

Ajout de l'exception pour prod-deployment.yml dans `.talismanrc` :
```yaml
- filename: .github/workflows/prod-deployment.yml
  checksum: eb8200879024f525bff1e371413952032deccbe42523d5cc9c095fa723c9f022
  comments: "False positive: ssh-keyscan command for Scalingo deployment"
```

## 🧪 Test Plan

1. ✅ Valider que le workflow passe les checks de syntaxe
2. ✅ Merger sur \`main\`
3. 🔧 Déclencher manuellement le déploiement prod via workflow_dispatch
4. ✅ Vérifier dans les logs GitHub Actions que :
   - Le patch package.json s'exécute
   - Le push git réussit avec \`--force\`
   - Aucun message "Build failed" n'apparaît
   - Le déploiement Scalingo se termine correctement
5. ✅ Confirmer que l'API production répond après le déploiement

## 📊 Alignement avec Staging

Cette PR aligne complètement le workflow prod avec staging :

| Fonctionnalité | Staging | Prod (Avant) | Prod (Après) |
|----------------|---------|--------------|--------------|
| Patch engines | ✅ | ❌ | ✅ |
| Force push | ✅ | ❌ | ✅ |
| PIPESTATUS | ✅ | ❌ | ✅ |
| Grep validation | ✅ | ❌ | ✅ |
| Documentation | ✅ | ❌ | ✅ |

## 🔗 Références

- Run en échec silencieux : [19822866035](https://github.com/betagouv/communs-de-la-transition-ecologique-des-collectivites/actions/runs/19822866035/job/56789056575)
- PR Staging équivalente : #306
- Commits de patch précédents : #300, #301, #302, #303

## ⚠️ Notes Importantes

**Commits Éphémères** : Le force push est intentionnel et documenté. Chaque déploiement crée un commit temporaire qui doit écraser le précédent. C'est un pattern valide pour les artefacts de build.

**Sécurité** : Les déploiements manuels directs sur Scalingo sont interdits par le process établi, donc aucun risque d'écraser du travail valide.