### PR TITLE
fix(ci): add prettier formatting after package.json patching in deployments

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -74,6 +74,9 @@ jobs:
           # Patch api/package.json (the one Scalingo actually uses)
           node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('api/package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('api/package.json', JSON.stringify(pkg,null,2));"
 
+          # Format the patched files with prettier to pass pre-commit validation
+          pnpm prettier --write package.json api/package.json
+
           # Commit the patch (will be pushed to Scalingo only, not to GitHub)
           git add package.json api/package.json
           git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -128,6 +128,9 @@ jobs:
           # Patch api/package.json (the one Scalingo actually uses)
           node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('api/package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('api/package.json', JSON.stringify(pkg,null,2));"
 
+          # Format the patched files with prettier to pass pre-commit validation
+          pnpm prettier --write package.json api/package.json
+
           # Configure git for CI commit
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"

--- a/.talismanrc
+++ b/.talismanrc
@@ -23,6 +23,9 @@ fileignoreconfig:
   checksum: 1a45eabdceb14af75183c5477f52e4aad8c17e7d99a15d2a0508387bf775afc7
   comments: "False positive: Test file checking authentication with 'API key' in error message assertions, not actual secrets"
 - filename: .github/workflows/prod-deployment.yml
-  checksum: eb8200879024f525bff1e371413952032deccbe42523d5cc9c095fa723c9f022
+  checksum: 24b8fa27cf119d7bdc55e0b715480db895ea1a89700f031e2c8dce7e926b7880
+  comments: "False positive: ssh-keyscan command for Scalingo deployment, not a secret"
+- filename: .github/workflows/staging-deployment.yml
+  checksum: eea73a68db0e15d5fe7ed6c3e20657a289eca8c3d134044aea17efcd45d14b9a
   comments: "False positive: ssh-keyscan command for Scalingo deployment, not a secret"
 version: "1.0"


### PR DESCRIPTION
## Problem

Production deployment (run 19852058982) was failing with prettier validation errors during the git commit step:

```
api validate: [warn] package.json
api validate: [warn] Code style issues found in the above file. Run Prettier with --write to fix.
husky - pre-commit script failed (code 1)
```

### Root Cause

In the "Prepare package.json for Scalingo" step:
1. The `node -e` script patches `package.json` and `api/package.json` to remove npm/yarn engine restrictions
2. The patched JSON files are not properly formatted according to prettier rules
3. When `git commit` runs, husky's pre-commit hooks execute prettier validation
4. The validation fails, causing the commit to be rejected and deployment to fail

## Solution

Added a prettier formatting step immediately after the package.json patching:

```bash
# Format the patched files with prettier to pass pre-commit validation
pnpm prettier --write package.json api/package.json
```

This ensures the patched files are properly formatted before the git commit step runs.

## Changes

- ✅ Updated `.github/workflows/prod-deployment.yml` to add prettier formatting after patching
- ✅ Updated `.github/workflows/staging-deployment.yml` to add prettier formatting after patching (consistency)
- ✅ Updated `.talismanrc` with new checksums for both workflow files

## Testing

- Local validation passed (lint, type-check, format:check all successful)
- Talisman security scan passed with expected low-severity warning
- Both production and staging workflows now have identical package.json preparation logic

## Related

This issue was introduced in PR #309 which added the package.json patching step to production deployment. The staging workflow already had this step but was also missing the prettier formatting, so both have been fixed for consistency.