### PR TITLE
fix(ci): bypass pre-commit hooks for ephemeral deployment commits

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -74,12 +74,10 @@ jobs:
           # Patch api/package.json (the one Scalingo actually uses)
           node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('api/package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('api/package.json', JSON.stringify(pkg,null,2));"
 
-          # Format the patched files with prettier to pass pre-commit validation
-          pnpm prettier --write package.json api/package.json
-
           # Commit the patch (will be pushed to Scalingo only, not to GitHub)
+          # HUSKY=0 bypasses pre-commit hooks (no need to format as this is ephemeral)
           git add package.json api/package.json
-          git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"
+          HUSKY=0 git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"
 
           echo "✅ Both package.json files patched for deployment"
 

--- a/.github/workflows/staging-deployment.yml
+++ b/.github/workflows/staging-deployment.yml
@@ -128,16 +128,14 @@ jobs:
           # Patch api/package.json (the one Scalingo actually uses)
           node -e "const fs=require('fs'); const pkg=JSON.parse(fs.readFileSync('api/package.json')); delete pkg.engines.npm; delete pkg.engines.yarn; fs.writeFileSync('api/package.json', JSON.stringify(pkg,null,2));"
 
-          # Format the patched files with prettier to pass pre-commit validation
-          pnpm prettier --write package.json api/package.json
-
           # Configure git for CI commit
           git config user.name "GitHub Actions"
           git config user.email "actions@github.com"
 
           # Commit the patch (will be pushed to Scalingo only, not to GitHub)
+          # HUSKY=0 bypasses pre-commit hooks (no need to format as this is ephemeral)
           git add package.json api/package.json
-          git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"
+          HUSKY=0 git commit -m "chore(deploy): remove npm/yarn engines for Scalingo buildpack [ci skip]"
 
           echo "✅ Both package.json files patched for deployment"
 

--- a/.talismanrc
+++ b/.talismanrc
@@ -23,9 +23,9 @@ fileignoreconfig:
   checksum: 1a45eabdceb14af75183c5477f52e4aad8c17e7d99a15d2a0508387bf775afc7
   comments: "False positive: Test file checking authentication with 'API key' in error message assertions, not actual secrets"
 - filename: .github/workflows/prod-deployment.yml
-  checksum: 24b8fa27cf119d7bdc55e0b715480db895ea1a89700f031e2c8dce7e926b7880
+  checksum: 29987bb4d761c3ab0daab848c2aa82e12a5109b09292e138b0b5187b86a349a4
   comments: "False positive: ssh-keyscan command for Scalingo deployment, not a secret"
 - filename: .github/workflows/staging-deployment.yml
-  checksum: eea73a68db0e15d5fe7ed6c3e20657a289eca8c3d134044aea17efcd45d14b9a
+  checksum: ac5690298c57f1ba2d82f7f6a2b75ed3fe1262e7e3402a5041229f6cab917b9a
   comments: "False positive: ssh-keyscan command for Scalingo deployment, not a secret"
 version: "1.0"


### PR DESCRIPTION
## Problem

After PR #310: Production failed with prettier errors, Staging failed with 'pnpm: command not found'.

## Root Cause

The deploy-staging job has no Node.js/pnpm setup. Why format ephemeral commits that are never pushed to GitHub?

## Solution

Use HUSKY=0 to bypass pre-commit hooks entirely:

```bash
HUSKY=0 git commit -m "chore(deploy): remove npm/yarn engines [ci skip]"
```

Benefits:
- No need to install pnpm in deploy-staging
- No need to format ephemeral commits
- Simpler and more reliable
- Consistent with existing workflow pattern

## Changes

- staging-deployment.yml: Added HUSKY=0, removed prettier formatting
- prod-deployment.yml: Added HUSKY=0, removed prettier formatting  
- .talismanrc: Updated checksums