### PR TITLE
fix(ci): remove explicit key types from ssh-keyscan in production deployment

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -56,8 +56,7 @@ jobs:
           mkdir -p ~/.ssh
           echo "${{ secrets.SCALINGO_BETA_GOUV_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          # Explicitly scan for all key types to avoid issues with the host key not being found
-          ssh-keyscan -H -t rsa,ecdsa,ed25519 ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
+          ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
       - name: Prepare package.json for Scalingo
         working-directory: .

--- a/.talismanrc
+++ b/.talismanrc
@@ -23,7 +23,7 @@ fileignoreconfig:
   checksum: 1a45eabdceb14af75183c5477f52e4aad8c17e7d99a15d2a0508387bf775afc7
   comments: "False positive: Test file checking authentication with 'API key' in error message assertions, not actual secrets"
 - filename: .github/workflows/prod-deployment.yml
-  checksum: 329215f80ec28fc736e842b3ba76b8611e4e4cbddc440cf94d04e18db41c590c
+  checksum: 564319e4b958be3ea8fd11ece48ad38ee016599ee67930941cf7ac07b97dc1b1
   comments: "False positive: ssh-keyscan command for Scalingo deployment, not a secret"
 - filename: .github/workflows/staging-deployment.yml
   checksum: ac5690298c57f1ba2d82f7f6a2b75ed3fe1262e7e3402a5041229f6cab917b9a


### PR DESCRIPTION
## Summary
Fixes SSH host key verification failure in production deployment by aligning the ssh-keyscan configuration with the working staging deployment.

## Problem
Production deployment was consistently failing with:
```
No ED25519 host key is known for ssh.osc-fr1.scalingo.com and you have requested strict checking.
Host key verification failed.
fatal: Could not read from remote repository.
```

## Root Cause
The production workflow was using `ssh-keyscan -H -t rsa,ecdsa,ed25519` with explicit key types, which only returned 3 key responses and failed to properly capture the ED25519 host key.

The staging workflow uses `ssh-keyscan -H` without the `-t` flag (default behavior), which returns all 5 available key types from the server and works reliably.

## Solution
Removed the `-t rsa,ecdsa,ed25519` flag from the production workflow's SSH setup step to match the working staging configuration. This allows ssh-keyscan to use its default behavior and properly capture all available host keys.

## Changes
- Removed explicit key type specification from `ssh-keyscan` command in `.github/workflows/prod-deployment.yml`
- Updated `.talismanrc` checksum for the modified workflow file

## Testing
After this change, production deployment should successfully verify the SSH host key and proceed with the git push to Scalingo.