### PR TITLE
fix(ci): add working-directory override to Setup SSH step

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -52,11 +52,12 @@ jobs:
           git push --follow-tags origin main
 
       - name: Setup SSH
+        working-directory: .
         run: |
           mkdir -p ~/.ssh
           echo "${{ secrets.SCALINGO_BETA_GOUV_SSH_PRIVATE_KEY }}" > ~/.ssh/id_rsa
           chmod 600 ~/.ssh/id_rsa
-          ssh-keyscan -H ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
+          ssh-keyscan -H -t rsa,ecdsa,ed25519 ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
       - name: Prepare package.json for Scalingo
         working-directory: .

--- a/.talismanrc
+++ b/.talismanrc
@@ -23,7 +23,7 @@ fileignoreconfig:
   checksum: 1a45eabdceb14af75183c5477f52e4aad8c17e7d99a15d2a0508387bf775afc7
   comments: "False positive: Test file checking authentication with 'API key' in error message assertions, not actual secrets"
 - filename: .github/workflows/prod-deployment.yml
-  checksum: 564319e4b958be3ea8fd11ece48ad38ee016599ee67930941cf7ac07b97dc1b1
+  checksum: 51472cfcd0181970e5ec845137fa10b1b1fdbc7035b0eb04d8215fcb2915237d
   comments: "False positive: ssh-keyscan command for Scalingo deployment, not a secret"
 - filename: .github/workflows/staging-deployment.yml
   checksum: ac5690298c57f1ba2d82f7f6a2b75ed3fe1262e7e3402a5041229f6cab917b9a


### PR DESCRIPTION
## Summary
Fixes production deployment SSH failure by ensuring the Setup SSH step runs from the repository root instead of the `api/` subdirectory. This addresses the actual root cause that previous PRs (#311, #312, #313) missed.

## Root Cause Analysis

### The Problem
Production deployment was failing with:
```
No ED25519 host key is known for ssh.osc-fr1.scalingo.com and you have requested strict checking.
Host key verification failed.
fatal: Could not read from remote repository.
```

### The Real Issue
The production workflow has `defaults.run.working-directory: api` at lines 7-9. When the "Setup SSH" step ran without a `working-directory` override, it inherited this default and executed from the `api/` subdirectory.

This caused:
1. SSH keys created in wrong location (`api/~/.ssh/` instead of `~/.ssh/`)
2. Git push from root directory couldn't find the SSH keys
3. SSH host verification failed

### Why Previous Fixes Didn't Work
- **PR #311**: Added `HUSKY=0` to bypass pre-commit hooks (unrelated to SSH)
- **PR #312**: Added `working-directory: .` to "Prepare package.json" and "Deploy" steps, but **missed the "Setup SSH" step**
- **PR #313**: Removed explicit SSH key types, thinking that was the issue (it wasn't)

## The Fix

Added `working-directory: .` to the "Setup SSH" step (line 55) to ensure it runs from the repository root, matching the pattern used by other deployment steps.

## Additional Change

Reverted PR #313's change by restoring explicit SSH key types (`-t rsa,ecdsa,ed25519`). This configuration was working in the last successful deployment (Dec 1st). PR #313's hypothesis about key types was incorrect - the real issue was the working directory.

## Changes
- `.github/workflows/prod-deployment.yml:55` - Added `working-directory: .` to Setup SSH step
- `.github/workflows/prod-deployment.yml:60` - Restored `-t rsa,ecdsa,ed25519` to ssh-keyscan command
- `.talismanrc` - Updated checksum for modified workflow file

## Testing
After this fix, the Setup SSH step will create SSH keys in the correct location (`~/.ssh/` at repository root), and the deployment step will be able to use them successfully.

## Evidence
Last successful production deployment was on Dec 1st (commit 9bdad8f) with the explicit key types configuration. All failures occurred after subsequent changes that didn't address the working directory issue.