### PR TITLE
chore(deps): update dependencies (safe updates)

### DIFF
--- a/.talismanrc
+++ b/.talismanrc
@@ -1,6 +1,6 @@
 fileignoreconfig:
 - filename: pnpm-lock.yaml
-  checksum: b71e6e613f136c87aee3546d5748d0051350ffd5286b24a25a1c76953657ce75
+  checksum: 90bcfe93bd3fecf8850993515b0b71c88ee2bf98c48d51b2fc91b1d2aa1d950f
   comments: "Package lock file with SHA512 checksums (not secrets)"
 - filename: api/README.md
   checksum: 9c4ec1309eea835caba8bb3cc9e3d0bd8453e0e772057a7a6130dd82bb61dd9d

--- a/api/package.json
+++ b/api/package.json
@@ -50,7 +50,7 @@
     "sentry:sourcemaps": "sentry-cli sourcemaps inject --org betagouv --project communs-de-la-transition-eco-api ./dist && sentry-cli --url https://sentry.incubateur.net/ sourcemaps upload --org betagouv --project communs-de-la-transition-eco-api ./dist"
   },
   "dependencies": {
-    "@anthropic-ai/sdk": "^0.65.0",
+    "@anthropic-ai/sdk": "^0.71.0",
     "@bull-board/api": "^6.9.6",
     "@bull-board/express": "^6.9.6",
     "@bull-board/nestjs": "^6.9.6",
@@ -96,7 +96,7 @@
     "cross-env": "^7.0.3",
     "docker-compose": "^1.2.0",
     "jest": "^29.7.0",
-    "openapi-fetch": "^0.13.5",
+    "openapi-fetch": "^0.15.0",
     "openapi-typescript": "^7.6.1",
     "source-map-support": "^0.5.21",
     "supertest": "^7.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
   api:
     dependencies:
       '@anthropic-ai/sdk':
-        specifier: ^0.65.0
-        version: 0.65.0(zod@4.1.13)
+        specifier: ^0.71.0
+        version: 0.71.0(zod@4.1.13)
       '@bull-board/api':
         specifier: ^6.9.6
         version: 6.14.2(@bull-board/ui@6.14.2)
@@ -215,8 +215,8 @@ importers:
         specifier: ^29.7.0
         version: 29.7.0(@types/node@24.10.1)(babel-plugin-macros@3.1.0)(ts-node@10.9.2(@types/node@24.10.1)(typescript@5.9.3))
       openapi-fetch:
-        specifier: ^0.13.5
-        version: 0.13.8
+        specifier: ^0.15.0
+        version: 0.15.0
       openapi-typescript:
         specifier: ^7.6.1
         version: 7.10.1(typescript@5.9.3)
@@ -289,22 +289,22 @@ importers:
         version: 1.29.0
       '@emotion/react':
         specifier: ^11.14.0
-        version: 11.14.0(@types/react@19.2.7)(react@19.1.0)
+        version: 11.14.0(@types/react@19.2.7)(react@19.2.0)
       '@iframe-resizer/react':
         specifier: ^5.4.5
-        version: 5.5.7(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 5.5.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@tanstack/react-query':
         specifier: ^5.74.4
-        version: 5.90.11(react@19.1.0)
+        version: 5.90.11(react@19.2.0)
       classnames:
         specifier: ^2.5.1
         version: 2.5.1
       openapi-fetch:
-        specifier: ^0.13.5
-        version: 0.13.8
+        specifier: ^0.15.0
+        version: 0.15.0
       tss-react:
         specifier: ^4.9.16
-        version: 4.9.19(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.1.0))(@types/react@19.2.7)(react@19.1.0)
+        version: 4.9.19(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0)
     devDependencies:
       '@changesets/cli':
         specifier: ^2.29.2
@@ -314,7 +314,7 @@ importers:
         version: 6.9.1
       '@testing-library/react':
         specifier: ^16.3.0
-        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
+        version: 16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)
       '@testing-library/user-event':
         specifier: ^14.6.1
         version: 14.6.1(@testing-library/dom@10.4.0)
@@ -331,11 +331,11 @@ importers:
         specifier: ^0.12.7
         version: 0.12.7
       react:
-        specifier: ^19.1.0
-        version: 19.1.0
+        specifier: ^19.2.0
+        version: 19.2.0
       react-dom:
-        specifier: ^19.1.0
-        version: 19.1.0(react@19.1.0)
+        specifier: ^19.2.0
+        version: 19.2.0(react@19.2.0)
       vite-plugin-dts:
         specifier: ^4.5.3
         version: 4.5.4(@types/node@24.10.1)(rollup@4.53.3)(typescript@5.9.3)(vite@7.2.4(@types/node@24.10.1)(jiti@2.6.1)(terser@5.44.1)(yaml@2.7.1))
@@ -397,8 +397,8 @@ packages:
     resolution: {integrity: sha512-J4Jarr0SohdrHcb40gTL4wGPCQ952IMWF1G/MSAQfBAPvA9ZKApYhpxcY7PmehVePve+ujpus1dGsJ7dPxz8Kg==}
     engines: {node: ^18.19.1 || ^20.11.1 || >=22.0.0, npm: ^6.11.0 || ^7.5.6 || >=8.0.0, yarn: '>= 1.13.0'}
 
-  '@anthropic-ai/sdk@0.65.0':
-    resolution: {integrity: sha512-zIdPOcrCVEI8t3Di40nH4z9EoeyGZfXbYSvWdDLsB/KkaSYMnEgC7gmcgWu83g2NTn1ZTpbMvpdttWDGGIk6zw==}
+  '@anthropic-ai/sdk@0.71.0':
+    resolution: {integrity: sha512-go1XeWXmpxuiTkosSXpb8tokLk2ZLkIRcXpbWVwJM6gH5OBtHOVsfPfGuqI1oW7RRt4qc59EmYbrXRZ0Ng06Jw==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -5916,6 +5916,9 @@ packages:
   openapi-fetch@0.13.8:
     resolution: {integrity: sha512-yJ4QKRyNxE44baQ9mY5+r/kAzZ8yXMemtNAOFwOzRXJscdjSxxzWSNlyBAr+o5JjkUw9Lc3W7OIoca0cY3PYnQ==}
 
+  openapi-fetch@0.15.0:
+    resolution: {integrity: sha512-OjQUdi61WO4HYhr9+byCPMj0+bgste/LtSBEcV6FzDdONTs7x0fWn8/ndoYwzqCsKWIxEZwo4FN/TG1c1rI8IQ==}
+
   openapi-typescript-helpers@0.0.15:
     resolution: {integrity: sha512-opyTPaunsklCBpTK8JGef6mfPhLSnyy5a0IN9vKtx3+4aExf+KxEqYwIy3hqkedXIB97u357uLMJsOnm3GVjsw==}
 
@@ -6297,6 +6300,11 @@ packages:
     peerDependencies:
       react: ^19.1.0
 
+  react-dom@19.2.0:
+    resolution: {integrity: sha512-UlbRu4cAiGaIewkPyiRGJk0imDN2T3JjieT6spoL2UeSf5od4n5LB/mQ4ejmxhCFT1tYe8IvaFulzynWovsEFQ==}
+    peerDependencies:
+      react: ^19.2.0
+
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
@@ -6328,6 +6336,10 @@ packages:
 
   react@19.1.0:
     resolution: {integrity: sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg==}
+    engines: {node: '>=0.10.0'}
+
+  react@19.2.0:
+    resolution: {integrity: sha512-tmbWg6W31tQLeB5cdIBOicJDJRR2KzXsV7uSK9iNfLWQ5bIZfxuPEHp7M8wiHyHnn0DD1i7w3Zmin0FtkrwoCQ==}
     engines: {node: '>=0.10.0'}
 
   read-pkg-up@3.0.0:
@@ -6528,6 +6540,9 @@ packages:
 
   scheduler@0.26.0:
     resolution: {integrity: sha512-NlHwttCI/l5gCPR3D1nNXtWABUmBwvZpEQiD4IXSbIDq8BzLIK/7Ir5gTFSGZDUu37K5cMNp0hFtzO38sC7gWA==}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
 
   schema-utils@3.3.0:
     resolution: {integrity: sha512-pN/yOAvcC+5rQ5nERGuwrjLlYvLTbCibnZ1I7B1LaiAz9BRBlE9GMgE/eqV30P7aJQUf7Ddimy/RsbYO/GrVGg==}
@@ -7689,7 +7704,7 @@ snapshots:
     transitivePeerDependencies:
       - chokidar
 
-  '@anthropic-ai/sdk@0.65.0(zod@4.1.13)':
+  '@anthropic-ai/sdk@0.71.0(zod@4.1.13)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
@@ -8343,6 +8358,22 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
+  '@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.27.1
+      '@emotion/babel-plugin': 11.13.5
+      '@emotion/cache': 11.14.0
+      '@emotion/serialize': 1.3.3
+      '@emotion/use-insertion-effect-with-fallbacks': 1.2.0(react@19.2.0)
+      '@emotion/utils': 1.4.2
+      '@emotion/weak-memoize': 0.4.0
+      hoist-non-react-statics: 3.3.2
+      react: 19.2.0
+    optionalDependencies:
+      '@types/react': 19.2.7
+    transitivePeerDependencies:
+      - supports-color
+
   '@emotion/serialize@1.3.3':
     dependencies:
       '@emotion/hash': 0.9.2
@@ -8358,6 +8389,10 @@ snapshots:
   '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.1.0)':
     dependencies:
       react: 19.1.0
+
+  '@emotion/use-insertion-effect-with-fallbacks@1.2.0(react@19.2.0)':
+    dependencies:
+      react: 19.2.0
 
   '@emotion/utils@1.4.2': {}
 
@@ -8619,6 +8654,14 @@ snapshots:
       auto-console-group: 1.2.11
       react: 19.1.0
       react-dom: 19.1.0(react@19.1.0)
+
+  '@iframe-resizer/react@5.5.7(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
+    dependencies:
+      '@babel/runtime': 7.28.4
+      '@iframe-resizer/core': 5.5.7
+      auto-console-group: 1.2.11
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
 
   '@inquirer/ansi@1.0.2': {}
 
@@ -9017,7 +9060,7 @@ snapshots:
 
   '@manypkg/find-root@1.1.0':
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.28.4
       '@types/node': 12.20.55
       find-up: 4.1.0
       fs-extra: 8.1.0
@@ -10188,6 +10231,11 @@ snapshots:
       '@tanstack/query-core': 5.90.11
       react: 19.1.0
 
+  '@tanstack/react-query@5.90.11(react@19.2.0)':
+    dependencies:
+      '@tanstack/query-core': 5.90.11
+      react: 19.2.0
+
   '@testcontainers/postgresql@11.8.1':
     dependencies:
       testcontainers: 11.8.1
@@ -10216,12 +10264,12 @@ snapshots:
       picocolors: 1.1.1
       redent: 3.0.0
 
-  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.1.0(react@19.1.0))(react@19.1.0)':
+  '@testing-library/react@16.3.0(@testing-library/dom@10.4.0)(@types/react-dom@19.2.3(@types/react@19.2.7))(@types/react@19.2.7)(react-dom@19.2.0(react@19.2.0))(react@19.2.0)':
     dependencies:
       '@babel/runtime': 7.27.1
       '@testing-library/dom': 10.4.0
-      react: 19.1.0
-      react-dom: 19.1.0(react@19.1.0)
+      react: 19.2.0
+      react-dom: 19.2.0(react@19.2.0)
     optionalDependencies:
       '@types/react': 19.2.7
       '@types/react-dom': 19.2.3(@types/react@19.2.7)
@@ -11071,7 +11119,7 @@ snapshots:
 
   babel-plugin-macros@3.1.0:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.28.4
       cosmiconfig: 7.1.0
       resolve: 1.22.10
 
@@ -13519,7 +13567,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.27.1
+      '@babel/runtime': 7.28.4
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
@@ -13996,6 +14044,10 @@ snapshots:
     dependencies:
       openapi-typescript-helpers: 0.0.15
 
+  openapi-fetch@0.15.0:
+    dependencies:
+      openapi-typescript-helpers: 0.0.15
+
   openapi-typescript-helpers@0.0.15: {}
 
   openapi-typescript@7.10.1(typescript@5.9.3):
@@ -14365,6 +14417,11 @@ snapshots:
       react: 19.1.0
       scheduler: 0.26.0
 
+  react-dom@19.2.0(react@19.2.0):
+    dependencies:
+      react: 19.2.0
+      scheduler: 0.27.0
+
   react-is@16.13.1: {}
 
   react-is@17.0.2: {}
@@ -14393,6 +14450,8 @@ snapshots:
       react-dom: 19.1.0(react@19.1.0)
 
   react@19.1.0: {}
+
+  react@19.2.0: {}
 
   read-pkg-up@3.0.0:
     dependencies:
@@ -14698,6 +14757,8 @@ snapshots:
       xmlchars: 2.2.0
 
   scheduler@0.26.0: {}
+
+  scheduler@0.27.0: {}
 
   schema-utils@3.3.0:
     dependencies:
@@ -15334,6 +15395,15 @@ snapshots:
       '@emotion/utils': 1.4.2
       '@types/react': 19.2.7
       react: 19.1.0
+
+  tss-react@4.9.19(@emotion/react@11.14.0(@types/react@19.2.7)(react@19.2.0))(@types/react@19.2.7)(react@19.2.0):
+    dependencies:
+      '@emotion/cache': 11.14.0
+      '@emotion/react': 11.14.0(@types/react@19.2.7)(react@19.2.0)
+      '@emotion/serialize': 1.3.3
+      '@emotion/utils': 1.4.2
+      '@types/react': 19.2.7
+      react: 19.2.0
 
   tunnel-agent@0.6.0:
     dependencies:

--- a/widget/package.json
+++ b/widget/package.json
@@ -44,7 +44,7 @@
     "@iframe-resizer/react": "^5.4.5",
     "@tanstack/react-query": "^5.74.4",
     "classnames": "^2.5.1",
-    "openapi-fetch": "^0.13.5",
+    "openapi-fetch": "^0.15.0",
     "tss-react": "^4.9.16"
   },
   "devDependencies": {
@@ -56,8 +56,8 @@
     "msw": "^2.7.5",
     "openapi-typescript": "^7.6.1",
     "path": "^0.12.7",
-    "react": "^19.1.0",
-    "react-dom": "^19.1.0",
+    "react": "^19.2.0",
+    "react-dom": "^19.2.0",
     "vite-plugin-dts": "^4.5.3",
     "vite-plugin-lib-inject-css": "^2.2.2",
     "vitest": "^3.1.2"


### PR DESCRIPTION
## Summary

Update minor/patch dependency versions from Dependabot PR #318, **excluding drizzle-orm** which causes test failures in CI.

## Changes

### API (`api/package.json`)
- `@anthropic-ai/sdk`: 0.65.0 → 0.71.0
- `openapi-fetch`: 0.13.5 → 0.15.0

### Widget (`widget/package.json`)
- `openapi-fetch`: 0.13.5 → 0.15.0
- `react`: 19.1.0 → 19.2.0
- `react-dom`: 19.1.0 → 19.2.0

## drizzle-orm Exclusion

The `drizzle-orm` update (0.42.0 → 0.44.7) from PR #318 is **excluded** because:
- ❌ Tests fail in CI environment (7/99 tests failing)
- ✅ Tests pass locally (99/99 tests passing)
- Issue appears to be environment-specific (testcontainers)
- Will be addressed in a separate PR after investigation

## Test Results

✅ **Local tests**: All 99 unit tests pass
```
Test Suites: 11 passed, 11 total
Tests:       99 passed, 99 total
```

## Supersedes

This PR consolidates safe updates from:
- PR #318 (Dependabot minor-and-patch group) - partially
- PR #307 (express update) - will close after merge

## Related Issues

Addresses test failures in PR #318 by isolating problematic drizzle-orm update.