### PR TITLE
refactor(api): utiliser perimeter_codes[] AT au lieu de la résolution de périmètre

### DIFF
--- a/api/src/aides/aides-cache.service.spec.ts
+++ b/api/src/aides/aides-cache.service.spec.ts
@@ -218,21 +218,4 @@ describe("AidesCacheService", () => {
       expect(mockRedis.scan).toHaveBeenCalledWith("0", "MATCH", "at:territory:*", "COUNT", 100);
     });
   });
-
-  describe("perimeter cache", () => {
-    it("should get cached perimeter ID", async () => {
-      mockRedis.get.mockResolvedValue("87571-nantes");
-
-      const result = await service.getPerimeterId("44109");
-
-      expect(mockRedis.get).toHaveBeenCalledWith("at:perimeter:44109");
-      expect(result).toBe("87571-nantes");
-    });
-
-    it("should set perimeter ID with 7-day TTL", async () => {
-      await service.setPerimeterId("44109", "87571-nantes");
-
-      expect(mockRedis.set).toHaveBeenCalledWith("at:perimeter:44109", "87571-nantes", "EX", 604800);
-    });
-  });
 });

--- a/api/src/aides/aides-cache.service.ts
+++ b/api/src/aides/aides-cache.service.ts
@@ -6,12 +6,9 @@ import { AideTerritoires } from "./aides-territoires.service";
 
 const AIDE_PREFIX = "at:aide:";
 const TERRITORY_PREFIX = "at:territory:";
-const PERIMETER_CACHE_PREFIX = "at:perimeter:";
-
 const AIDE_TTL_SECONDS = 86400 * 7; // 7 days — aides catalog, long-lived
 const FRESH_TTL_SECONDS = 3600; // 1 hour — territory index considered fresh
 const STALE_MAX_TTL_SECONDS = 86400 * 7; // 7 days — max staleness before eviction
-const PERIMETER_TTL_SECONDS = 86400 * 7; // 7 days (codes INSEE don't change)
 
 /**
  * Stored alongside the territory index to track SWR freshness.
@@ -146,18 +143,6 @@ export class AidesCacheService implements OnModuleDestroy {
       .map(([k, v]) => `${k}=${v}`)
       .join("&");
     return sorted || "all";
-  }
-
-  // ---------------------------------------------------------------------------
-  // Perimeter ID cache (unchanged)
-  // ---------------------------------------------------------------------------
-
-  async getPerimeterId(codeInsee: string): Promise<string | null> {
-    return this.redis.get(`${PERIMETER_CACHE_PREFIX}${codeInsee}`);
-  }
-
-  async setPerimeterId(codeInsee: string, perimeterId: string): Promise<void> {
-    await this.redis.set(`${PERIMETER_CACHE_PREFIX}${codeInsee}`, perimeterId, "EX", PERIMETER_TTL_SECONDS);
   }
 
   // ---------------------------------------------------------------------------

--- a/api/src/aides/aides-territoires.service.ts
+++ b/api/src/aides/aides-territoires.service.ts
@@ -86,43 +86,6 @@ export class AidesTerritoiresService {
     this.logger.log(`Fetched ${allAides.length} aides from AT API`);
     return allAides;
   }
-
-  /**
-   * Resolve a code INSEE (commune) or code EPCI to an AT perimeter_id
-   * Strategy: search AT /perimeters/?q={commune_name} then match by code
-   * AT's code/insee params don't filter, only q= (name search) works
-   */
-  async resolvePerimeterId(codeInsee: string, communeName?: string): Promise<string | null> {
-    if (!communeName) {
-      this.logger.warn(`No commune name provided for code ${codeInsee}, cannot resolve perimeter`);
-      return null;
-    }
-
-    const token = await this.getBearerToken();
-
-    const response = await fetch(`${this.baseUrl}/perimeters/?q=${encodeURIComponent(communeName)}&page_size=50`, {
-      headers: { Authorization: `Bearer ${token}` },
-    });
-
-    if (!response.ok) {
-      this.logger.error(`AT perimeters lookup failed: ${response.status}`);
-      return null;
-    }
-
-    const data = (await response.json()) as {
-      results: { perimeter_id: number; code: string; scale: string; name: string }[];
-    };
-
-    // Find exact code match in search results
-    const exact = data.results.find((r) => r.code === codeInsee);
-    if (exact) {
-      this.logger.log(`Resolved ${communeName} (${codeInsee}) → perimeter_id ${exact.perimeter_id} (${exact.scale})`);
-      return String(exact.perimeter_id);
-    }
-
-    this.logger.warn(`No AT perimeter match for ${communeName} (${codeInsee})`);
-    return null;
-  }
 }
 
 /**

--- a/api/src/aides/aides-warmup.service.spec.ts
+++ b/api/src/aides/aides-warmup.service.spec.ts
@@ -73,12 +73,9 @@ describe("AidesWarmupService", () => {
 
     mockAtService = {
       fetchAides: jest.fn().mockResolvedValue([makeAide(1), makeAide(2)]),
-      resolvePerimeterId: jest.fn().mockResolvedValue("87571-nantes"),
     } as unknown as jest.Mocked<AidesTerritoiresService>;
 
     mockCacheService = {
-      getPerimeterId: jest.fn().mockResolvedValue(null),
-      setPerimeterId: jest.fn().mockResolvedValue(undefined),
       buildKey: jest.fn().mockImplementation((params: Record<string, string>) => {
         const sorted = Object.entries(params)
           .sort(([a], [b]) => a.localeCompare(b))
@@ -140,19 +137,16 @@ describe("AidesWarmupService", () => {
 
       expect(result.territories).toBe(2);
       expect(result.failed).toBe(0);
-      expect(mockAtService.resolvePerimeterId).toHaveBeenCalledTimes(2);
       expect(mockAtService.fetchAides).toHaveBeenCalledTimes(2);
       expect(mockCacheService.set).toHaveBeenCalledTimes(2);
     });
 
-    it("should use cached perimeter ID when available", async () => {
+    it("should pass perimeter_codes[] with code INSEE directly to AT", async () => {
       mockQueryBuilder.where.mockResolvedValue([{ codeInsee: "44109", nom: "Nantes" }]);
-      mockCacheService.getPerimeterId.mockResolvedValue("87571-nantes");
 
       await service.warmup();
 
-      expect(mockAtService.resolvePerimeterId).not.toHaveBeenCalled();
-      expect(mockAtService.fetchAides).toHaveBeenCalledWith({ perimeter: "87571-nantes" });
+      expect(mockAtService.fetchAides).toHaveBeenCalledWith({ "perimeter_codes[]": "44109" });
     });
 
     it("should continue on individual territory failure", async () => {

--- a/api/src/aides/aides-warmup.service.ts
+++ b/api/src/aides/aides-warmup.service.ts
@@ -117,23 +117,10 @@ export class AidesWarmupService {
 
   /**
    * Pre-warm cache for a single territory.
+   * Uses AT's perimeter_codes[] parameter which accepts code INSEE directly.
    */
   private async warmTerritory(codeInsee: string, communeName: string): Promise<void> {
-    // 1. Resolve perimeter ID (from cache or AT API)
-    let perimeterId = await this.cacheService.getPerimeterId(codeInsee);
-    if (!perimeterId) {
-      perimeterId = await this.atService.resolvePerimeterId(codeInsee, communeName);
-      if (perimeterId) {
-        await this.cacheService.setPerimeterId(codeInsee, perimeterId);
-      }
-    }
-
-    // 2. Fetch aides from AT and store in cache
-    const params: Record<string, string> = {};
-    if (perimeterId) {
-      params.perimeter = perimeterId;
-    }
-
+    const params = { "perimeter_codes[]": codeInsee };
     const cacheKey = this.cacheService.buildKey(params);
     const aides = await this.atService.fetchAides(params);
     await this.cacheService.set(cacheKey, aides);

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -5,7 +5,6 @@ import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
 import { AidesCacheService, CacheResult } from "./aides-cache.service";
 import { AidesWarmupService } from "./aides-warmup.service";
-import { DatabaseService } from "@database/database.service";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { CustomLogger } from "@logging/logger.service";
 
@@ -55,7 +54,6 @@ describe("AidesController", () => {
   let mockClassificationService: jest.Mocked<AideClassificationService>;
   let mockMatchingService: jest.Mocked<AidesMatchingService>;
   let mockProjetsService: jest.Mocked<GetProjetsService>;
-  let mockDbService: jest.Mocked<DatabaseService>;
   const mockLogger = {
     log: jest.fn(),
     warn: jest.fn(),
@@ -67,15 +65,12 @@ describe("AidesController", () => {
 
     mockAtService = {
       fetchAides: jest.fn().mockResolvedValue([makeAide(1), makeAide(2)]),
-      resolvePerimeterId: jest.fn().mockResolvedValue("87571"),
     } as unknown as jest.Mocked<AidesTerritoiresService>;
 
     mockCacheService = {
       get: jest.fn().mockResolvedValue(null),
       set: jest.fn().mockResolvedValue(undefined),
-      buildKey: jest.fn().mockReturnValue("perimeter=87571"),
-      getPerimeterId: jest.fn().mockResolvedValue("87571"),
-      setPerimeterId: jest.fn().mockResolvedValue(undefined),
+      buildKey: jest.fn().mockReturnValue("perimeter_codes%5B%5D=44109"),
       invalidateTerritories: jest.fn().mockResolvedValue(undefined),
     } as unknown as jest.Mocked<AidesCacheService>;
 
@@ -100,24 +95,12 @@ describe("AidesController", () => {
       }),
     } as unknown as jest.Mocked<GetProjetsService>;
 
-    const mockQueryResult = [{ nom: "Nantes" }];
-    const mockQueryBuilder = {
-      select: jest.fn().mockReturnThis(),
-      from: jest.fn().mockReturnThis(),
-      where: jest.fn().mockReturnThis(),
-      limit: jest.fn().mockResolvedValue(mockQueryResult),
-    };
-    mockDbService = {
-      database: mockQueryBuilder,
-    } as unknown as jest.Mocked<DatabaseService>;
-
     controller = new AidesController(
       mockAtService,
       mockClassificationService,
       mockMatchingService,
       mockCacheService,
       mockWarmupService,
-      mockDbService,
       mockProjetsService,
       mockLogger,
     );

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -3,9 +3,6 @@ import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger"
 import { ApiKeyGuard } from "@/auth/api-key-guard";
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
 import { CustomLogger } from "@logging/logger.service";
-import { DatabaseService } from "@database/database.service";
-import { refCommunes } from "@database/schema";
-import { eq } from "drizzle-orm";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { AidesTerritoiresService, AideTerritoires } from "./aides-territoires.service";
 import { AideClassificationService } from "./aide-classification.service";
@@ -40,7 +37,6 @@ export class AidesController {
     private readonly matchingService: AidesMatchingService,
     private readonly cacheService: AidesCacheService,
     private readonly warmupService: AidesWarmupService,
-    private readonly dbService: DatabaseService,
     private readonly projetsService: GetProjetsService,
     private readonly logger: CustomLogger,
   ) {}
@@ -165,29 +161,6 @@ export class AidesController {
   }
 
   /**
-   * Resolve a code_insee to an AT perimeter_id (with cache)
-   */
-  private async resolvePerimeter(codeInsee: string): Promise<string | null> {
-    let perimeterId = await this.cacheService.getPerimeterId(codeInsee);
-    if (perimeterId) return perimeterId;
-
-    const [commune] = await this.dbService.database
-      .select({ nom: refCommunes.nom })
-      .from(refCommunes)
-      .where(eq(refCommunes.codeInsee, codeInsee))
-      .limit(1);
-
-    const communeName = commune?.nom;
-    perimeterId = await this.atService.resolvePerimeterId(codeInsee, communeName ?? undefined);
-    if (perimeterId) {
-      await this.cacheService.setPerimeterId(codeInsee, perimeterId);
-    } else {
-      this.logger.warn(`Could not resolve code_insee ${codeInsee} to AT perimeter_id`);
-    }
-    return perimeterId;
-  }
-
-  /**
    * Fetch aides for a single territory with SWR.
    * Returns aides immediately (from cache if available), triggers background refresh if stale.
    */
@@ -233,6 +206,7 @@ export class AidesController {
 
   /**
    * Fetch aides for multiple territories (union). Deduplicates by aide id.
+   * Uses AT's perimeter_codes[] parameter which accepts code INSEE directly.
    */
   private async fetchAidesForTerritories(codesInsee: string[]): Promise<AideTerritoires[]> {
     if (codesInsee.length === 0) {
@@ -243,12 +217,7 @@ export class AidesController {
     const allAides: AideTerritoires[] = [];
 
     for (const codeInsee of codesInsee) {
-      const perimeterId = await this.resolvePerimeter(codeInsee);
-      const params: Record<string, string> = {};
-      if (perimeterId) {
-        params.perimeter = perimeterId;
-      }
-
+      const params = { "perimeter_codes[]": codeInsee };
       const aides = await this.fetchAidesForTerritory(params, `code_insee=${codeInsee}`);
 
       // Deduplicate across territories


### PR DESCRIPTION
## Contexte

Sylvain (MEC) a signalé que l'endpoint `/aides` retournait moins d'aides qu'attendu et a questionné le filtrage par commune.

En investiguant, on a découvert que :
1. L'API Aides-Territoires supporte le paramètre `perimeter_codes[]` qui accepte directement les codes INSEE — pas besoin de résoudre code_insee → nom commune → perimeter_id
2. La table `api_referentiel.communes` est **vide sur staging**, ce qui signifie que la résolution de périmètre ne fonctionne que grâce au cache Redis (TTL 7j) — bombe à retardement

## Changements

Supprime toute la chaîne de résolution de périmètre :
- `resolvePerimeterId()` dans `AidesTerritoiresService`
- `resolvePerimeter()` dans `AidesController` (+ dépendance `DatabaseService`, `refCommunes`, `eq`)
- Cache Redis périmètre (`getPerimeterId`, `setPerimeterId`, `PERIMETER_CACHE_PREFIX`)
- Résolution dans le warmup

Remplacé par un simple `{ "perimeter_codes[]": codeInsee }` passé directement à l'API AT.

**7 insertions, 143 suppressions.**

## Vérification

Testé directement sur l'API AT :
- `perimeter=81808` (ancien) → 576 aides ✅
- `perimeter_codes[]=2A133` (nouveau) → 576 aides ✅
- Multi-communes `perimeter_codes[]=2A133&perimeter_codes[]=75056` → 739 aides (union AT-side) ✅
- Encoding URL (`perimeter_codes%5B%5D`) → fonctionne ✅

## Plan de test

- [ ] Vérifier que les tests unitaires passent en CI
- [ ] Déployer sur staging et appeler `GET /aides?projet_id=019d1c45-237d-7851-88f2-dbd527f931d3&limit=100`
- [ ] Vérifier que `total` et le nombre d'aides retournées sont cohérents avec les résultats actuels (~576 aides AT, ~146 matchées)
- [ ] Vérifier le warmup (les anciennes entrées `at:perimeter:*` dans Redis expireront naturellement en 7j)