### PR TITLE
feat(api): ajouter normalizedScore et axesMatched au matching aides

### DIFF
--- a/api/src/aides/aides-matching.service.spec.ts
+++ b/api/src/aides/aides-matching.service.spec.ts
@@ -16,7 +16,7 @@ describe("AidesMatchingService", () => {
   ) => ({ thematiques: th, sites: si, interventions: int });
 
   describe("match", () => {
-    it("should return matching aides sorted by score", () => {
+    it("should return matching aides sorted by score with normalizedScore and axesMatched", () => {
       const projet = makeScores(
         [
           { label: "Energies renouvelables", score: 0.9 },
@@ -47,9 +47,15 @@ describe("AidesMatchingService", () => {
       // aide-1 should score highest (matches on all 3 axes)
       expect(results[0].idAt).toBe("aide-1");
       expect(results[0].score).toBeGreaterThan(0);
+      expect(results[0].normalizedScore).toBeGreaterThan(0);
+      expect(results[0].normalizedScore).toBeLessThanOrEqual(1);
+      expect(results[0].axesMatched).toBe(3);
 
-      // aide-2 should match on thematiques only
-      expect(results.find((r) => r.idAt === "aide-2")).toBeDefined();
+      // aide-2 should match on thematiques only (1 axis)
+      const aide2 = results.find((r) => r.idAt === "aide-2");
+      expect(aide2).toBeDefined();
+      expect(aide2!.axesMatched).toBe(1);
+      expect(aide2!.normalizedScore).toBeLessThan(results[0].normalizedScore);
 
       // aide-3 should not match (no common labels)
       expect(results.find((r) => r.idAt === "aide-3")).toBeUndefined();
@@ -87,6 +93,33 @@ describe("AidesMatchingService", () => {
 
       const results = service.match(projet, aides);
       expect(results[0].scoreThematiques).toBeCloseTo(0.03, 2);
+    });
+
+    it("should compute normalizedScore as score / projectMax", () => {
+      // 1 label on 1 axis: project max = (0.9 - 0.7) * 0.3 / 1 = 0.06
+      // Aide matches at 1.0: score = (0.9 - 0.7) * (1.0 - 0.7) / 1 = 0.06
+      // normalizedScore = 0.06 / 0.06 = 1.0
+      const projet = makeScores([{ label: "Test", score: 0.9 }]);
+      const aides = new Map([["aide-1", makeScores([{ label: "Test", score: 1.0 }])]]);
+
+      const results = service.match(projet, aides);
+      expect(results[0].normalizedScore).toBeCloseTo(1.0, 2);
+    });
+
+    it("should return normalizedScore < 1 for partial matches", () => {
+      // Project: 2 labels on thematiques. Aide matches only 1.
+      // projectMax(thematiques) = ((0.9-0.7)*0.3 + (0.85-0.7)*0.3) / 2 = (0.06 + 0.045) / 2 = 0.0525
+      // score(thematiques) = (0.9-0.7)*(0.9-0.7) / 2 = 0.04 / 2 = 0.02
+      // normalizedScore = 0.02 / 0.0525 ≈ 0.38
+      const projet = makeScores([
+        { label: "A", score: 0.9 },
+        { label: "B", score: 0.85 },
+      ]);
+      const aides = new Map([["aide-1", makeScores([{ label: "A", score: 0.9 }])]]);
+
+      const results = service.match(projet, aides);
+      expect(results[0].normalizedScore).toBeCloseTo(0.38, 1);
+      expect(results[0].normalizedScore).toBeLessThan(1);
     });
 
     it("should return common labels", () => {

--- a/api/src/aides/aides-matching.service.ts
+++ b/api/src/aides/aides-matching.service.ts
@@ -38,9 +38,11 @@ interface ScoredLabels {
 export interface MatchResult {
   idAt: string;
   score: number;
+  normalizedScore: number;
   scoreThematiques: number;
   scoreSites: number;
   scoreInterventions: number;
+  axesMatched: number;
   labelsCommuns: {
     thematiques: string[];
     sites: string[];
@@ -76,6 +78,8 @@ export class AidesMatchingService {
     const pSites = this.filterByThreshold(projetScores.sites);
     const pInterventions = this.filterByThreshold(projetScores.interventions);
 
+    const projectMax = this.computeProjectMax(pThematiques, pSites, pInterventions);
+
     // Build inverted index for fast candidate lookup
     const candidates = this.findCandidates(pThematiques, pSites, pInterventions, aidesScores);
 
@@ -96,12 +100,19 @@ export class AidesMatchingService {
       const totalScore = thResult.score + siResult.score + inResult.score;
 
       if (totalScore > 0) {
+        const axesMatched =
+          (thResult.commonLabels.length > 0 ? 1 : 0) +
+          (siResult.commonLabels.length > 0 ? 1 : 0) +
+          (inResult.commonLabels.length > 0 ? 1 : 0);
+
         results.push({
           idAt,
           score: Math.round(totalScore * 100) / 100,
+          normalizedScore: projectMax > 0 ? Math.round((totalScore / projectMax) * 100) / 100 : 0,
           scoreThematiques: Math.round(thResult.score * 100) / 100,
           scoreSites: Math.round(siResult.score * 100) / 100,
           scoreInterventions: Math.round(inResult.score * 100) / 100,
+          axesMatched,
           labelsCommuns: {
             thematiques: thResult.commonLabels,
             sites: siResult.commonLabels,
@@ -114,6 +125,28 @@ export class AidesMatchingService {
     // Sort by score descending, take top N
     results.sort((a, b) => b.score - a.score);
     return results.slice(0, limit);
+  }
+
+  /**
+   * Theoretical max score for a project: the score if a hypothetical aide
+   * matched every project label at confidence 1.0.
+   */
+  private computeProjectMax(
+    pThematiques: Map<string, number>,
+    pSites: Map<string, number>,
+    pInterventions: Map<string, number>,
+  ): number {
+    return this.axisMax(pThematiques) + this.axisMax(pSites) + this.axisMax(pInterventions);
+  }
+
+  private axisMax(projectLabels: Map<string, number>): number {
+    if (projectLabels.size === 0) return 0;
+    const maxAideContribution = 1.0 - this.SCORE_THRESHOLD + this.SCORE_OFFSET; // 0.3
+    let sum = 0;
+    for (const pScore of projectLabels.values()) {
+      sum += (pScore - this.SCORE_THRESHOLD + this.SCORE_OFFSET) * maxAideContribution;
+    }
+    return sum / projectLabels.size;
   }
 
   /**

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -17,6 +17,8 @@ interface EnrichedAide extends AideTerritoires {
     interventions: { label: string; score: number }[];
   };
   matchingScore?: number;
+  normalizedScore?: number;
+  axesMatched?: number;
   labelsCommuns?: {
     thematiques: string[];
     sites: string[];
@@ -104,6 +106,8 @@ export class AidesController {
         ...aide,
         classification: classification ?? undefined,
         matchingScore: match?.score,
+        normalizedScore: match?.normalizedScore,
+        axesMatched: match?.axesMatched,
         labelsCommuns: match?.labelsCommuns,
       };
     });


### PR DESCRIPTION
## Contexte

Suite à l'investigation sur l'endpoint `/aides` (#417), le score brut (`matchingScore`) est difficile à exploiter :
- Son max dépend du projet (entre 0.09 et 0.27)
- Impossible de poser un seuil de filtrage universel
- 0.08 ne veut rien dire sans connaître le max du projet

## Changements

Ajoute 2 champs à la réponse `GET /aides` (rétrocompatible — `matchingScore` inchangé) :

### `normalizedScore` (number, 0-1)

Score divisé par le max théorique du projet. Représente le pourcentage du meilleur match possible.

```
project_max = Σ axis_max  (pour chaque axe actif)
axis_max = Σ((pScore - 0.7) × 0.3) / nb_labels
normalizedScore = matchingScore / project_max
```

Seuils universels utilisables par les consommateurs :
- `> 0.3` → pertinent
- `> 0.5` → bon match
- `> 0.7` → excellent match

### `axesMatched` (number, 0-3)

Nombre d'axes (thématiques, sites, interventions) avec au moins 1 label en commun.

### Exemple de réponse

```json
{
  "matchingScore": 0.08,
  "normalizedScore": 0.51,
  "axesMatched": 2,
  "labelsCommuns": { "thematiques": ["Friche"], "sites": [], "interventions": ["Etude/Diagnostic"] }
}
```

## Plan de test

- [ ] Tests unitaires (35 tests passent, +2 nouveaux pour normalizedScore)
- [ ] Déployer sur staging et vérifier la réponse de `GET /aides?projet_id=019d1c45-237d-7851-88f2-dbd527f931d3`
- [ ] Confirmer que le top aide (~0.08 brut) donne un normalizedScore ~0.51