### PR TITLE
feat(api): classification batch Anthropic pour ingestion 80k projets CRTE

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -27,6 +27,7 @@ import { ReferentielModule } from "@/referentiel/referentiel.module";
 import { HealthController } from "@/health/health.controller";
 import { PlansFichesModule } from "@/plans-fiches/plans-fiches.module";
 import { ProjetsV2Module } from "@/projets-v2/projets-v2.module";
+import { BatchClassificationModule } from "@/batch-classification/batch-classification.module";
 
 @Module({
   imports: [
@@ -78,6 +79,7 @@ import { ProjetsV2Module } from "@/projets-v2/projets-v2.module";
     ReferentielModule,
     PlansFichesModule,
     ProjetsV2Module,
+    BatchClassificationModule,
   ],
   controllers: [HealthController],
   providers: [AppService, ThrottlerGuardProvider, RequestLoggingInterceptor],

--- a/api/src/batch-classification/batch-classification.const.ts
+++ b/api/src/batch-classification/batch-classification.const.ts
@@ -1,0 +1,20 @@
+export const BATCH_CLASSIFICATION_QUEUE_NAME = "batch-classification";
+export const BATCH_SUBMIT_JOB = "submit";
+export const BATCH_POLL_JOB = "poll";
+export const BATCH_PROCESS_JOB = "process";
+
+/** Max requests per Anthropic batch */
+export const ANTHROPIC_BATCH_MAX_REQUESTS = 100_000;
+
+/** Polling interval for batch status checks */
+export const POLL_DELAY_MS = 5 * 60 * 1000; // 5 minutes
+
+/** Max poll attempts (~25h at 5 min intervals) */
+export const MAX_POLL_ATTEMPTS = 300;
+
+/** DB write chunk size */
+export const DB_WRITE_CHUNK_SIZE = 500;
+
+/** Classification axes */
+export const CLASSIFICATION_AXES = ["thematiques", "sites", "interventions"] as const;
+export type ClassificationAxis = (typeof CLASSIFICATION_AXES)[number];

--- a/api/src/batch-classification/batch-classification.controller.ts
+++ b/api/src/batch-classification/batch-classification.controller.ts
@@ -1,0 +1,28 @@
+import { Controller, Post, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
+import { InjectQueue } from "@nestjs/bullmq";
+import { Queue } from "bullmq";
+import { BATCH_CLASSIFICATION_QUEUE_NAME, BATCH_SUBMIT_JOB } from "./batch-classification.const";
+
+@ApiBearerAuth()
+@ApiTags("Management")
+@Controller("management")
+@UseGuards(ServiceApiKeyGuard)
+export class BatchClassificationController {
+  constructor(@InjectQueue(BATCH_CLASSIFICATION_QUEUE_NAME) private readonly batchQueue: Queue) {}
+
+  @Post("batch-classify")
+  @ApiOperation({
+    summary: "Déclencher la classification batch des projets non classifiés",
+    description:
+      "Soumet tous les projets sans classificationScores à l'API Batch Anthropic. Le traitement est asynchrone (~24h). Suivre la progression dans le Bull Board (/queues).",
+  })
+  async triggerBatchClassification() {
+    await this.batchQueue.add(BATCH_SUBMIT_JOB, {
+      triggeredBy: "management-endpoint",
+    });
+
+    return { message: "Batch classification scheduled", queue: BATCH_CLASSIFICATION_QUEUE_NAME };
+  }
+}

--- a/api/src/batch-classification/batch-classification.controller.ts
+++ b/api/src/batch-classification/batch-classification.controller.ts
@@ -1,5 +1,5 @@
-import { Controller, Post, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Controller, Post, Query, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
 import { InjectQueue } from "@nestjs/bullmq";
 import { Queue } from "bullmq";
@@ -16,13 +16,20 @@ export class BatchClassificationController {
   @ApiOperation({
     summary: "Déclencher la classification batch des projets non classifiés",
     description:
-      "Soumet tous les projets sans classificationScores à l'API Batch Anthropic. Le traitement est asynchrone (~24h). Suivre la progression dans le Bull Board (/queues).",
+      "Soumet les projets sans classificationScores à l'API Batch Anthropic. Le traitement est asynchrone (~24h). Suivre la progression dans le Bull Board (/queues).",
   })
-  async triggerBatchClassification() {
+  @ApiQuery({ name: "limit", required: false, description: "Nombre max de projets à classifier (défaut: tous)" })
+  async triggerBatchClassification(@Query("limit") limit?: string) {
+    const maxProjects = limit ? parseInt(limit, 10) : undefined;
+
     await this.batchQueue.add(BATCH_SUBMIT_JOB, {
       triggeredBy: "management-endpoint",
+      maxProjects,
     });
 
-    return { message: "Batch classification scheduled", queue: BATCH_CLASSIFICATION_QUEUE_NAME };
+    return {
+      message: `Batch classification scheduled${maxProjects ? ` (limit: ${maxProjects})` : ""}`,
+      queue: BATCH_CLASSIFICATION_QUEUE_NAME,
+    };
   }
 }

--- a/api/src/batch-classification/batch-classification.module.ts
+++ b/api/src/batch-classification/batch-classification.module.ts
@@ -1,0 +1,27 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { BullModule } from "@nestjs/bullmq";
+import { BullBoardModule } from "@bull-board/nestjs";
+import { BullMQAdapter } from "@bull-board/api/bullMQAdapter";
+import { ClassificationModule } from "@/projet-qualification/classification/classification.module";
+import { BatchClassificationProcessor } from "./batch-classification.processor";
+import { BatchClassificationController } from "./batch-classification.controller";
+import { BATCH_CLASSIFICATION_QUEUE_NAME } from "./batch-classification.const";
+
+@Module({
+  imports: [
+    ConfigModule,
+    ClassificationModule,
+    BullModule.registerQueue({
+      name: BATCH_CLASSIFICATION_QUEUE_NAME,
+    }),
+    BullBoardModule.forFeature({
+      name: BATCH_CLASSIFICATION_QUEUE_NAME,
+      adapter: BullMQAdapter,
+    }),
+  ],
+  controllers: [BatchClassificationController],
+  providers: [BatchClassificationProcessor],
+  exports: [BullModule],
+})
+export class BatchClassificationModule {}

--- a/api/src/batch-classification/batch-classification.processor.spec.ts
+++ b/api/src/batch-classification/batch-classification.processor.spec.ts
@@ -1,0 +1,227 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+import { BatchClassificationProcessor } from "./batch-classification.processor";
+import { CustomLogger } from "@logging/logger.service";
+import { DatabaseService } from "@database/database.service";
+import { ClassificationAnthropicService } from "@/projet-qualification/classification/llm/classification-anthropic.service";
+import { ClassificationValidationService } from "@/projet-qualification/classification/validation/classification-validation.service";
+import { EnrichmentService } from "@/projet-qualification/classification/post-processing/enrichment.service";
+import { TEProbabilityService } from "@/projet-qualification/classification/post-processing/te-probability.service";
+import { Job, Queue } from "bullmq";
+import { BATCH_POLL_JOB, BATCH_PROCESS_JOB } from "./batch-classification.const";
+
+// Mock Sentry
+jest.mock("@sentry/node", () => ({ captureException: jest.fn() }));
+
+function makeJob<T>(name: string, data: T, attemptsMade = 0): Job<T> {
+  return { name, data, attemptsMade } as unknown as Job<T>;
+}
+
+describe("BatchClassificationProcessor", () => {
+  let processor: BatchClassificationProcessor;
+  let mockDb: jest.Mocked<DatabaseService>;
+  let mockAnthropicService: jest.Mocked<ClassificationAnthropicService>;
+  let mockValidationService: jest.Mocked<ClassificationValidationService>;
+  let mockEnrichmentService: jest.Mocked<EnrichmentService>;
+  let mockTeProbabilityService: jest.Mocked<TEProbabilityService>;
+  let mockQueue: jest.Mocked<Queue>;
+
+  const mockLogger = {
+    log: jest.fn(),
+    warn: jest.fn(),
+    error: jest.fn(),
+  } as unknown as CustomLogger;
+
+  const mockBatchCreate = jest.fn();
+  const mockBatchRetrieve = jest.fn();
+  const mockBatchResults = jest.fn();
+
+  const mockClient = {
+    messages: {
+      batches: {
+        create: mockBatchCreate,
+        retrieve: mockBatchRetrieve,
+        results: mockBatchResults,
+      },
+    },
+  };
+
+  // Mock paginated query builder
+  const mockQueryBuilder = {
+    select: jest.fn().mockReturnThis(),
+    from: jest.fn().mockReturnThis(),
+    where: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    offset: jest.fn(),
+    update: jest.fn().mockReturnThis(),
+    set: jest.fn().mockReturnThis(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default: return empty array (no unclassified projects)
+    mockQueryBuilder.offset.mockResolvedValue([]);
+
+    mockDb = {
+      database: {
+        ...mockQueryBuilder,
+        select: jest.fn().mockReturnValue(mockQueryBuilder),
+        update: jest
+          .fn()
+          .mockReturnValue({ set: jest.fn().mockReturnValue({ where: jest.fn().mockResolvedValue([]) }) }),
+      },
+    } as unknown as jest.Mocked<DatabaseService>;
+
+    mockAnthropicService = {
+      getClient: jest.fn().mockReturnValue(mockClient),
+      buildMessageParams: jest.fn().mockReturnValue({ model: "claude-sonnet-4-6", messages: [] }),
+      parseResponse: jest.fn().mockReturnValue({
+        json: { projet: "test", items: [{ label: "Energies renouvelables", score: 0.9 }] },
+      }),
+    } as unknown as jest.Mocked<ClassificationAnthropicService>;
+
+    mockValidationService = {
+      validateAndCorrect: jest.fn().mockReturnValue({ "Energies renouvelables": 0.9 }),
+    } as unknown as jest.Mocked<ClassificationValidationService>;
+
+    mockEnrichmentService = {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-return
+      enrich: jest.fn().mockImplementation((input) => input),
+    } as unknown as jest.Mocked<EnrichmentService>;
+
+    mockTeProbabilityService = {
+      calculate: jest.fn().mockReturnValue(0.8),
+    } as unknown as jest.Mocked<TEProbabilityService>;
+
+    mockQueue = {
+      add: jest.fn().mockResolvedValue(undefined),
+    } as unknown as jest.Mocked<Queue>;
+
+    processor = new BatchClassificationProcessor(
+      mockDb,
+      mockAnthropicService,
+      mockValidationService,
+      mockEnrichmentService,
+      mockTeProbabilityService,
+      mockQueue,
+      mockLogger,
+    );
+  });
+
+  describe("handleSubmit (via process)", () => {
+    it("should skip when no unclassified projects", async () => {
+      const job = makeJob("submit", { triggeredBy: "test" });
+
+      const result = await processor.process(job);
+
+      expect(result).toEqual({ submitted: 0 });
+      expect(mockBatchCreate).not.toHaveBeenCalled();
+    });
+
+    it("should submit batch and enqueue poll job", async () => {
+      // Return 2 projects on first page, empty on second (end of pagination)
+      mockQueryBuilder.offset
+        .mockResolvedValueOnce([
+          { id: "proj-1", nom: "Projet 1", description: "Desc 1" },
+          { id: "proj-2", nom: "Projet 2", description: "Desc 2" },
+        ])
+        .mockResolvedValueOnce([]);
+
+      mockBatchCreate.mockResolvedValue({ id: "batch_abc", processing_status: "in_progress" });
+
+      const job = makeJob("submit", { triggeredBy: "test", projectCount: 2 });
+      const result = await processor.process(job);
+
+      expect(mockBatchCreate).toHaveBeenCalledTimes(1);
+      expect(mockAnthropicService.buildMessageParams).toHaveBeenCalledTimes(6); // 2 projects × 3 axes
+      expect(mockQueue.add).toHaveBeenCalledWith(
+        BATCH_POLL_JOB,
+        expect.objectContaining({ batchIds: ["batch_abc"], totalProjects: 2 }),
+        expect.any(Object),
+      );
+      expect(result).toEqual(expect.objectContaining({ totalProjects: 2 }));
+    });
+  });
+
+  describe("handlePoll (via process)", () => {
+    it("should throw when batches are not complete (triggers BullMQ retry)", async () => {
+      mockBatchRetrieve.mockResolvedValue({ processing_status: "in_progress" });
+
+      const job = makeJob("poll", { batchIds: ["batch_abc"], totalProjects: 10 });
+
+      await expect(processor.process(job)).rejects.toThrow("Batches not yet complete");
+      expect(mockQueue.add).not.toHaveBeenCalled();
+    });
+
+    it("should enqueue process jobs when all batches ended", async () => {
+      mockBatchRetrieve.mockResolvedValue({ processing_status: "ended" });
+
+      const job = makeJob("poll", { batchIds: ["batch_abc", "batch_def"], totalProjects: 10 });
+      const result = await processor.process(job);
+
+      expect(mockQueue.add).toHaveBeenCalledTimes(2);
+      expect(mockQueue.add).toHaveBeenCalledWith(BATCH_PROCESS_JOB, { batchId: "batch_abc" });
+      expect(mockQueue.add).toHaveBeenCalledWith(BATCH_PROCESS_JOB, { batchId: "batch_def" });
+      expect(result).toEqual(expect.objectContaining({ status: "ended" }));
+    });
+  });
+
+  describe("handleProcess (via process)", () => {
+    it("should skip incomplete projects (< 3 axes)", async () => {
+      // Only 2 axes for proj-1 (missing interventions)
+      const asyncResults = (function* () {
+        yield {
+          custom_id: "proj-1:thematiques",
+          result: {
+            type: "succeeded" as const,
+            message: { content: [{ type: "text" as const, text: '{"projet":"p","items":[]}' }] },
+          },
+        };
+        yield {
+          custom_id: "proj-1:sites",
+          result: {
+            type: "succeeded" as const,
+            message: { content: [{ type: "text" as const, text: '{"projet":"p","items":[]}' }] },
+          },
+        };
+      })();
+      mockBatchResults.mockResolvedValue(asyncResults);
+
+      const job = makeJob("process", { batchId: "batch_abc" });
+      const result = await processor.process(job);
+
+      expect(result).toEqual(expect.objectContaining({ classified: 0 }));
+    });
+
+    it("should process complete projects (3 axes) and write to DB", async () => {
+      const asyncResults = (function* () {
+        for (const axis of ["thematiques", "sites", "interventions"]) {
+          yield {
+            custom_id: `proj-1:${axis}`,
+            result: {
+              type: "succeeded" as const,
+              message: {
+                content: [{ type: "text" as const, text: '{"projet":"p","items":[{"label":"Test","score":0.9}]}' }],
+              },
+            },
+          };
+        }
+      })();
+      mockBatchResults.mockResolvedValue(asyncResults);
+
+      // Mock the chained update().set().where()
+      const mockWhere = jest.fn().mockResolvedValue([]);
+      const mockSet = jest.fn().mockReturnValue({ where: mockWhere });
+      (mockDb.database as unknown as { update: jest.Mock }).update = jest.fn().mockReturnValue({ set: mockSet });
+
+      const job = makeJob("process", { batchId: "batch_abc" });
+      const result = await processor.process(job);
+
+      expect(result).toEqual(expect.objectContaining({ classified: 1 }));
+      expect(mockValidationService.validateAndCorrect).toHaveBeenCalledTimes(3);
+      expect(mockEnrichmentService.enrich).toHaveBeenCalledTimes(1);
+      expect(mockTeProbabilityService.calculate).toHaveBeenCalledTimes(1);
+      expect(mockWhere).toHaveBeenCalledTimes(1); // 1 project written
+    });
+  });
+});

--- a/api/src/batch-classification/batch-classification.processor.ts
+++ b/api/src/batch-classification/batch-classification.processor.ts
@@ -8,6 +8,7 @@ import { ClassificationAnthropicService } from "@/projet-qualification/classific
 import { ClassificationValidationService } from "@/projet-qualification/classification/validation/classification-validation.service";
 import { EnrichmentService } from "@/projet-qualification/classification/post-processing/enrichment.service";
 import { TEProbabilityService } from "@/projet-qualification/classification/post-processing/te-probability.service";
+import * as Sentry from "@sentry/node";
 import {
   BATCH_CLASSIFICATION_QUEUE_NAME,
   BATCH_SUBMIT_JOB,
@@ -20,6 +21,9 @@ import {
   CLASSIFICATION_AXES,
   ClassificationAxis,
 } from "./batch-classification.const";
+
+/** Page size for paginated SELECT of unclassified projects */
+const SELECT_PAGE_SIZE = 5000;
 
 interface ProjectForClassification {
   id: string;
@@ -63,62 +67,67 @@ export class BatchClassificationProcessor extends WorkerHost {
   }
 
   /**
-   * Step 1: Collect unclassified projects, build batch requests, submit to Anthropic.
+   * Step 1: Collect unclassified projects (paginated), build batch requests, submit to Anthropic.
    */
   private async handleSubmit(job: Job<{ triggeredBy?: string; projectCount?: number }>) {
     this.logger.log(
       `Batch classification submit triggered (${job.data.triggeredBy ?? "unknown"}, ~${job.data.projectCount ?? "?"} projects)`,
     );
 
-    // Collect all projects without classification scores
-    const unclassified = await this.dbService.database
-      .select({ id: projets.id, nom: projets.nom, description: projets.description })
-      .from(projets)
-      .where(isNull(projets.classificationScores));
+    try {
+      // Collect unclassified projects with pagination to avoid loading 80k+ rows in RAM
+      const unclassified = await this.fetchUnclassifiedProjects();
 
-    if (unclassified.length === 0) {
-      this.logger.log("No unclassified projects found, skipping batch");
-      return { submitted: 0 };
-    }
+      if (unclassified.length === 0) {
+        this.logger.log("No unclassified projects found, skipping batch");
+        return { submitted: 0 };
+      }
 
-    this.logger.log(`Found ${unclassified.length} unclassified projects`);
+      this.logger.log(`Found ${unclassified.length} unclassified projects`);
 
-    // Build batch requests (3 per project, max 100k per batch)
-    const requestsPerProject = CLASSIFICATION_AXES.length; // 3
-    const projectsPerBatch = Math.floor(ANTHROPIC_BATCH_MAX_REQUESTS / requestsPerProject);
-    const projectChunks = this.chunkArray(unclassified, projectsPerBatch);
+      // Build batch requests (3 per project, max 100k per batch)
+      const requestsPerProject = CLASSIFICATION_AXES.length; // 3
+      const projectsPerBatch = Math.floor(ANTHROPIC_BATCH_MAX_REQUESTS / requestsPerProject);
+      const projectChunks = this.chunkArray(unclassified, projectsPerBatch);
 
-    const client = this.anthropicService.getClient();
-    const batchIds: string[] = [];
+      const client = this.anthropicService.getClient();
+      const batchIds: string[] = [];
 
-    for (let i = 0; i < projectChunks.length; i++) {
-      const chunk = projectChunks[i];
-      const requests = this.buildBatchRequests(chunk);
+      for (let i = 0; i < projectChunks.length; i++) {
+        const chunk = projectChunks[i];
+        const requests = this.buildBatchRequests(chunk);
 
-      this.logger.log(
-        `Submitting batch ${i + 1}/${projectChunks.length} with ${requests.length} requests (${chunk.length} projects)`,
+        this.logger.log(
+          `Submitting batch ${i + 1}/${projectChunks.length} with ${requests.length} requests (${chunk.length} projects)`,
+        );
+
+        const batch = await client.messages.batches.create({ requests });
+        batchIds.push(batch.id);
+
+        this.logger.log(`Batch ${i + 1} submitted: ${batch.id} (status: ${batch.processing_status})`);
+      }
+
+      // Enqueue poll job
+      await this.batchQueue.add(
+        BATCH_POLL_JOB,
+        { batchIds, totalProjects: unclassified.length },
+        {
+          delay: POLL_DELAY_MS,
+          attempts: MAX_POLL_ATTEMPTS,
+          backoff: { type: "fixed", delay: POLL_DELAY_MS },
+        },
       );
 
-      const batch = await client.messages.batches.create({ requests });
-      batchIds.push(batch.id);
+      this.logger.log(`Batch submit complete: ${batchIds.length} batches, poll scheduled in ${POLL_DELAY_MS / 1000}s`);
 
-      this.logger.log(`Batch ${i + 1} submitted: ${batch.id} (status: ${batch.processing_status})`);
+      return { batchIds, totalProjects: unclassified.length };
+    } catch (error) {
+      this.logger.error("Batch submit failed", {
+        error: { message: error instanceof Error ? error.message : "Unknown error" },
+      });
+      Sentry.captureException(error);
+      throw error;
     }
-
-    // Enqueue poll job
-    await this.batchQueue.add(
-      BATCH_POLL_JOB,
-      { batchIds, totalProjects: unclassified.length },
-      {
-        delay: POLL_DELAY_MS,
-        attempts: MAX_POLL_ATTEMPTS,
-        backoff: { type: "fixed", delay: POLL_DELAY_MS },
-      },
-    );
-
-    this.logger.log(`Batch submit complete: ${batchIds.length} batches, poll scheduled in ${POLL_DELAY_MS / 1000}s`);
-
-    return { batchIds, totalProjects: unclassified.length };
   }
 
   /**
@@ -166,70 +175,83 @@ export class BatchClassificationProcessor extends WorkerHost {
 
     this.logger.log(`Processing results for batch ${batchId}`);
 
-    // Stream results and group by project
-    const projectResults = new Map<string, Map<ClassificationAxis, Record<string, number>>>();
-    let succeeded = 0;
-    let failed = 0;
+    try {
+      // Stream results and group by project
+      const projectResults = new Map<string, Map<ClassificationAxis, Record<string, number>>>();
+      let succeeded = 0;
+      let failed = 0;
 
-    const results = await client.messages.batches.results(batchId);
-    for await (const result of results) {
-      const [projectId, axis] = result.custom_id.split(":") as [string, ClassificationAxis];
+      const results = await client.messages.batches.results(batchId);
+      for await (const result of results) {
+        const { projectId, axis } = this.parseCustomId(result.custom_id);
 
-      if (result.result.type !== "succeeded") {
-        failed++;
-        this.logger.warn(`Batch result failed for ${result.custom_id}: ${result.result.type}`);
-        continue;
+        if (result.result.type !== "succeeded") {
+          failed++;
+          this.logger.warn(`Batch result failed for ${result.custom_id}: ${result.result.type}`);
+          continue;
+        }
+
+        const textContent = result.result.message.content.find((b) => b.type === "text");
+        if (textContent?.type !== "text") {
+          failed++;
+          continue;
+        }
+
+        // Parse LLM response using existing parser
+        const parsed = this.anthropicService.parseResponse(textContent.text, projectId);
+        if (parsed.errorMessage) {
+          failed++;
+          this.logger.warn(`Parse error for ${result.custom_id}: ${parsed.errorMessage}`);
+          continue;
+        }
+
+        // Convert items to Record<string, number> for validation service
+        const labelsMap: Record<string, number> = {};
+        for (const item of parsed.json.items) {
+          labelsMap[item.label] = item.score;
+        }
+
+        if (!projectResults.has(projectId)) {
+          projectResults.set(projectId, new Map());
+        }
+        projectResults.get(projectId)!.set(axis, labelsMap);
+        succeeded++;
       }
 
-      const textContent = result.result.message.content.find((b) => b.type === "text");
-      if (textContent?.type !== "text") {
-        failed++;
-        continue;
-      }
+      this.logger.log(`Parsed ${succeeded} results (${failed} failed) for ${projectResults.size} projects`);
 
-      // Parse LLM response using existing parser
-      const parsed = this.anthropicService.parseResponse(textContent.text, projectId);
-      if (parsed.errorMessage) {
-        failed++;
-        this.logger.warn(`Parse error for ${result.custom_id}: ${parsed.errorMessage}`);
-        continue;
-      }
+      // Filter out incomplete projects (need all 3 axes)
+      const completeProjects = Array.from(projectResults.entries()).filter(([projectId, axes]) => {
+        if (axes.size < CLASSIFICATION_AXES.length) {
+          this.logger.warn(
+            `Project ${projectId} has only ${axes.size}/${CLASSIFICATION_AXES.length} axes, skipping (will be retried in next batch)`,
+          );
+          return false;
+        }
+        return true;
+      });
 
-      // Convert items to Record<string, number> for validation service
-      const labelsMap: Record<string, number> = {};
-      for (const item of parsed.json.items) {
-        labelsMap[item.label] = item.score;
-      }
+      this.logger.log(
+        `${completeProjects.length} complete projects (${projectResults.size - completeProjects.length} incomplete, skipped)`,
+      );
 
-      if (!projectResults.has(projectId)) {
-        projectResults.set(projectId, new Map());
-      }
-      projectResults.get(projectId)!.set(axis, labelsMap);
-      succeeded++;
-    }
+      // Apply post-processing and write to DB in chunks (sequential to avoid pool saturation)
+      const chunks = this.chunkArray(completeProjects, DB_WRITE_CHUNK_SIZE);
+      let written = 0;
 
-    this.logger.log(`Parsed ${succeeded} results (${failed} failed) for ${projectResults.size} projects`);
-
-    // Apply post-processing and write to DB in chunks
-    const projectEntries = Array.from(projectResults.entries());
-    const chunks = this.chunkArray(projectEntries, DB_WRITE_CHUNK_SIZE);
-    let written = 0;
-
-    for (const chunk of chunks) {
-      const updates = chunk
-        .filter(([, axes]) => axes.size > 0)
-        .map(([projectId, axes]) => {
+      for (const chunk of chunks) {
+        const updates = chunk.map(([projectId, axes]) => {
           // Validate against referentials (Levenshtein anti-hallucination)
           let thematiques = this.validationService.validateAndCorrect(
-            { projet: projectId, items: this.mapToItems(axes.get("thematiques") ?? {}) },
+            { projet: projectId, items: this.mapToItems(axes.get("thematiques")!) },
             "thematiques",
           );
           let sites = this.validationService.validateAndCorrect(
-            { projet: projectId, items: this.mapToItems(axes.get("sites") ?? {}) },
+            { projet: projectId, items: this.mapToItems(axes.get("sites")!) },
             "sites",
           );
           let interventions = this.validationService.validateAndCorrect(
-            { projet: projectId, items: this.mapToItems(axes.get("interventions") ?? {}) },
+            { projet: projectId, items: this.mapToItems(axes.get("interventions")!) },
             "interventions",
           );
 
@@ -263,10 +285,9 @@ export class BatchClassificationProcessor extends WorkerHost {
           };
         });
 
-      // Write to DB
-      await Promise.all(
-        updates.map((u) =>
-          this.dbService.database
+        // Write to DB sequentially to avoid saturating the connection pool
+        for (const u of updates) {
+          await this.dbService.database
             .update(projets)
             .set({
               classificationScores: u.classificationScores,
@@ -275,17 +296,61 @@ export class BatchClassificationProcessor extends WorkerHost {
               classificationInterventions: u.classificationInterventions,
               probabiliteTE: u.probabiliteTE,
             })
-            .where(eq(projets.id, u.projectId)),
-        ),
-      );
+            .where(eq(projets.id, u.projectId));
+        }
 
-      written += updates.length;
-      this.logger.log(`Batch process progress: ${written}/${projectEntries.length} projects written`);
+        written += updates.length;
+        this.logger.log(`Batch process progress: ${written}/${completeProjects.length} projects written`);
+      }
+
+      this.logger.log(`Batch ${batchId} processing complete: ${written} projects classified`);
+
+      return { batchId, classified: written, failed };
+    } catch (error) {
+      this.logger.error(`Batch process failed for ${batchId}`, {
+        error: { message: error instanceof Error ? error.message : "Unknown error" },
+      });
+      Sentry.captureException(error);
+      throw error;
+    }
+  }
+
+  /**
+   * Fetch unclassified projects with pagination to avoid loading everything in RAM.
+   */
+  private async fetchUnclassifiedProjects(): Promise<ProjectForClassification[]> {
+    const allProjects: ProjectForClassification[] = [];
+    let offset = 0;
+
+    while (true) {
+      const page = await this.dbService.database
+        .select({ id: projets.id, nom: projets.nom, description: projets.description })
+        .from(projets)
+        .where(isNull(projets.classificationScores))
+        .limit(SELECT_PAGE_SIZE)
+        .offset(offset);
+
+      allProjects.push(...page);
+
+      if (page.length < SELECT_PAGE_SIZE) break;
+      offset += SELECT_PAGE_SIZE;
+
+      this.logger.log(`Fetched ${allProjects.length} unclassified projects so far...`);
     }
 
-    this.logger.log(`Batch ${batchId} processing complete: ${written} projects classified`);
+    return allProjects;
+  }
 
-    return { batchId, classified: written, failed };
+  /**
+   * Parse custom_id format "projectId:axis". Uses lastIndexOf to handle
+   * any edge case where the projectId might contain colons.
+   */
+  private parseCustomId(customId: string): { projectId: string; axis: ClassificationAxis } {
+    const lastColon = customId.lastIndexOf(":");
+    return {
+      projectId: customId.slice(0, lastColon),
+      axis: customId.slice(lastColon + 1) as ClassificationAxis,
+    };
   }
 
   private buildBatchRequests(projects: ProjectForClassification[]) {

--- a/api/src/batch-classification/batch-classification.processor.ts
+++ b/api/src/batch-classification/batch-classification.processor.ts
@@ -49,6 +49,7 @@ export class BatchClassificationProcessor extends WorkerHost {
     job: Job<{
       triggeredBy?: string;
       projectCount?: number;
+      maxProjects?: number;
       batchIds?: string[];
       totalProjects?: number;
       batchId?: string;
@@ -69,14 +70,16 @@ export class BatchClassificationProcessor extends WorkerHost {
   /**
    * Step 1: Collect unclassified projects (paginated), build batch requests, submit to Anthropic.
    */
-  private async handleSubmit(job: Job<{ triggeredBy?: string; projectCount?: number }>) {
+  private async handleSubmit(job: Job<{ triggeredBy?: string; projectCount?: number; maxProjects?: number }>) {
+    const { maxProjects } = job.data;
     this.logger.log(
-      `Batch classification submit triggered (${job.data.triggeredBy ?? "unknown"}, ~${job.data.projectCount ?? "?"} projects)`,
+      `Batch classification submit triggered (${job.data.triggeredBy ?? "unknown"}, ~${job.data.projectCount ?? "?"} projects${maxProjects ? `, limit: ${maxProjects}` : ""})`,
     );
 
     try {
       // Collect unclassified projects with pagination to avoid loading 80k+ rows in RAM
-      const unclassified = await this.fetchUnclassifiedProjects();
+      const allUnclassified = await this.fetchUnclassifiedProjects();
+      const unclassified = maxProjects ? allUnclassified.slice(0, maxProjects) : allUnclassified;
 
       if (unclassified.length === 0) {
         this.logger.log("No unclassified projects found, skipping batch");

--- a/api/src/batch-classification/batch-classification.processor.ts
+++ b/api/src/batch-classification/batch-classification.processor.ts
@@ -1,0 +1,318 @@
+import { Processor, WorkerHost, InjectQueue } from "@nestjs/bullmq";
+import { Job, Queue } from "bullmq";
+import { isNull, eq } from "drizzle-orm";
+import { CustomLogger } from "@logging/logger.service";
+import { DatabaseService } from "@database/database.service";
+import { projets } from "@database/schema";
+import { ClassificationAnthropicService } from "@/projet-qualification/classification/llm/classification-anthropic.service";
+import { ClassificationValidationService } from "@/projet-qualification/classification/validation/classification-validation.service";
+import { EnrichmentService } from "@/projet-qualification/classification/post-processing/enrichment.service";
+import { TEProbabilityService } from "@/projet-qualification/classification/post-processing/te-probability.service";
+import {
+  BATCH_CLASSIFICATION_QUEUE_NAME,
+  BATCH_SUBMIT_JOB,
+  BATCH_POLL_JOB,
+  BATCH_PROCESS_JOB,
+  ANTHROPIC_BATCH_MAX_REQUESTS,
+  POLL_DELAY_MS,
+  MAX_POLL_ATTEMPTS,
+  DB_WRITE_CHUNK_SIZE,
+  CLASSIFICATION_AXES,
+  ClassificationAxis,
+} from "./batch-classification.const";
+
+interface ProjectForClassification {
+  id: string;
+  nom: string;
+  description: string | null;
+}
+
+@Processor(BATCH_CLASSIFICATION_QUEUE_NAME)
+export class BatchClassificationProcessor extends WorkerHost {
+  constructor(
+    private readonly dbService: DatabaseService,
+    private readonly anthropicService: ClassificationAnthropicService,
+    private readonly validationService: ClassificationValidationService,
+    private readonly enrichmentService: EnrichmentService,
+    private readonly teProbabilityService: TEProbabilityService,
+    @InjectQueue(BATCH_CLASSIFICATION_QUEUE_NAME) private readonly batchQueue: Queue,
+    private readonly logger: CustomLogger,
+  ) {
+    super();
+  }
+
+  async process(
+    job: Job<{
+      triggeredBy?: string;
+      projectCount?: number;
+      batchIds?: string[];
+      totalProjects?: number;
+      batchId?: string;
+    }>,
+  ) {
+    switch (job.name) {
+      case BATCH_SUBMIT_JOB:
+        return this.handleSubmit(job);
+      case BATCH_POLL_JOB:
+        return this.handlePoll(job as Job<{ batchIds: string[]; totalProjects: number }>);
+      case BATCH_PROCESS_JOB:
+        return this.handleProcess(job as Job<{ batchId: string }>);
+      default:
+        throw new Error(`Unknown job type: ${job.name}`);
+    }
+  }
+
+  /**
+   * Step 1: Collect unclassified projects, build batch requests, submit to Anthropic.
+   */
+  private async handleSubmit(job: Job<{ triggeredBy?: string; projectCount?: number }>) {
+    this.logger.log(
+      `Batch classification submit triggered (${job.data.triggeredBy ?? "unknown"}, ~${job.data.projectCount ?? "?"} projects)`,
+    );
+
+    // Collect all projects without classification scores
+    const unclassified = await this.dbService.database
+      .select({ id: projets.id, nom: projets.nom, description: projets.description })
+      .from(projets)
+      .where(isNull(projets.classificationScores));
+
+    if (unclassified.length === 0) {
+      this.logger.log("No unclassified projects found, skipping batch");
+      return { submitted: 0 };
+    }
+
+    this.logger.log(`Found ${unclassified.length} unclassified projects`);
+
+    // Build batch requests (3 per project, max 100k per batch)
+    const requestsPerProject = CLASSIFICATION_AXES.length; // 3
+    const projectsPerBatch = Math.floor(ANTHROPIC_BATCH_MAX_REQUESTS / requestsPerProject);
+    const projectChunks = this.chunkArray(unclassified, projectsPerBatch);
+
+    const client = this.anthropicService.getClient();
+    const batchIds: string[] = [];
+
+    for (let i = 0; i < projectChunks.length; i++) {
+      const chunk = projectChunks[i];
+      const requests = this.buildBatchRequests(chunk);
+
+      this.logger.log(
+        `Submitting batch ${i + 1}/${projectChunks.length} with ${requests.length} requests (${chunk.length} projects)`,
+      );
+
+      const batch = await client.messages.batches.create({ requests });
+      batchIds.push(batch.id);
+
+      this.logger.log(`Batch ${i + 1} submitted: ${batch.id} (status: ${batch.processing_status})`);
+    }
+
+    // Enqueue poll job
+    await this.batchQueue.add(
+      BATCH_POLL_JOB,
+      { batchIds, totalProjects: unclassified.length },
+      {
+        delay: POLL_DELAY_MS,
+        attempts: MAX_POLL_ATTEMPTS,
+        backoff: { type: "fixed", delay: POLL_DELAY_MS },
+      },
+    );
+
+    this.logger.log(`Batch submit complete: ${batchIds.length} batches, poll scheduled in ${POLL_DELAY_MS / 1000}s`);
+
+    return { batchIds, totalProjects: unclassified.length };
+  }
+
+  /**
+   * Step 2: Poll Anthropic batch status. Throws if not done (BullMQ retries with backoff).
+   */
+  private async handlePoll(job: Job<{ batchIds: string[]; totalProjects: number }>) {
+    const { batchIds } = job.data;
+    const client = this.anthropicService.getClient();
+
+    let allEnded = true;
+    const statuses: string[] = [];
+
+    for (const batchId of batchIds) {
+      const batch = await client.messages.batches.retrieve(batchId);
+      statuses.push(`${batchId}: ${batch.processing_status}`);
+
+      if (batch.processing_status !== "ended") {
+        allEnded = false;
+      }
+    }
+
+    this.logger.log(`Batch poll (attempt ${job.attemptsMade + 1}/${MAX_POLL_ATTEMPTS}): ${statuses.join(", ")}`);
+
+    if (!allEnded) {
+      // Throw to trigger BullMQ retry with backoff
+      throw new Error(`Batches not yet complete: ${statuses.join(", ")}`);
+    }
+
+    // All batches ended — enqueue process jobs (one per batch)
+    for (const batchId of batchIds) {
+      await this.batchQueue.add(BATCH_PROCESS_JOB, { batchId });
+    }
+
+    this.logger.log(`All ${batchIds.length} batches ended, processing jobs enqueued`);
+
+    return { status: "ended", batchIds };
+  }
+
+  /**
+   * Step 3: Stream results from a completed batch, apply post-processing, write to DB.
+   */
+  private async handleProcess(job: Job<{ batchId: string }>) {
+    const { batchId } = job.data;
+    const client = this.anthropicService.getClient();
+
+    this.logger.log(`Processing results for batch ${batchId}`);
+
+    // Stream results and group by project
+    const projectResults = new Map<string, Map<ClassificationAxis, Record<string, number>>>();
+    let succeeded = 0;
+    let failed = 0;
+
+    const results = await client.messages.batches.results(batchId);
+    for await (const result of results) {
+      const [projectId, axis] = result.custom_id.split(":") as [string, ClassificationAxis];
+
+      if (result.result.type !== "succeeded") {
+        failed++;
+        this.logger.warn(`Batch result failed for ${result.custom_id}: ${result.result.type}`);
+        continue;
+      }
+
+      const textContent = result.result.message.content.find((b) => b.type === "text");
+      if (textContent?.type !== "text") {
+        failed++;
+        continue;
+      }
+
+      // Parse LLM response using existing parser
+      const parsed = this.anthropicService.parseResponse(textContent.text, projectId);
+      if (parsed.errorMessage) {
+        failed++;
+        this.logger.warn(`Parse error for ${result.custom_id}: ${parsed.errorMessage}`);
+        continue;
+      }
+
+      // Convert items to Record<string, number> for validation service
+      const labelsMap: Record<string, number> = {};
+      for (const item of parsed.json.items) {
+        labelsMap[item.label] = item.score;
+      }
+
+      if (!projectResults.has(projectId)) {
+        projectResults.set(projectId, new Map());
+      }
+      projectResults.get(projectId)!.set(axis, labelsMap);
+      succeeded++;
+    }
+
+    this.logger.log(`Parsed ${succeeded} results (${failed} failed) for ${projectResults.size} projects`);
+
+    // Apply post-processing and write to DB in chunks
+    const projectEntries = Array.from(projectResults.entries());
+    const chunks = this.chunkArray(projectEntries, DB_WRITE_CHUNK_SIZE);
+    let written = 0;
+
+    for (const chunk of chunks) {
+      const updates = chunk
+        .filter(([, axes]) => axes.size > 0)
+        .map(([projectId, axes]) => {
+          // Validate against referentials (Levenshtein anti-hallucination)
+          let thematiques = this.validationService.validateAndCorrect(
+            { projet: projectId, items: this.mapToItems(axes.get("thematiques") ?? {}) },
+            "thematiques",
+          );
+          let sites = this.validationService.validateAndCorrect(
+            { projet: projectId, items: this.mapToItems(axes.get("sites") ?? {}) },
+            "sites",
+          );
+          let interventions = this.validationService.validateAndCorrect(
+            { projet: projectId, items: this.mapToItems(axes.get("interventions") ?? {}) },
+            "interventions",
+          );
+
+          // Enrichment (domain rules)
+          const enriched = this.enrichmentService.enrich({ thematiques, sites, interventions });
+          thematiques = enriched.thematiques;
+          sites = enriched.sites;
+          interventions = enriched.interventions;
+
+          // TE probability
+          const probabiliteTE = this.teProbabilityService.calculate(thematiques);
+
+          // Build classification scores (all scores, no threshold)
+          const classificationScores = {
+            thematiques: this.toSortedLabels(thematiques),
+            sites: this.toSortedLabels(sites),
+            interventions: this.toSortedLabels(interventions),
+          };
+
+          return {
+            projectId,
+            classificationScores,
+            classificationThematiques: classificationScores.thematiques
+              .filter((t) => t.score >= 0.8)
+              .map((t) => t.label),
+            classificationSites: classificationScores.sites.filter((s) => s.score >= 0.8).map((s) => s.label),
+            classificationInterventions: classificationScores.interventions
+              .filter((i) => i.score >= 0.8)
+              .map((i) => i.label),
+            probabiliteTE: probabiliteTE !== null ? String(probabiliteTE) : null,
+          };
+        });
+
+      // Write to DB
+      await Promise.all(
+        updates.map((u) =>
+          this.dbService.database
+            .update(projets)
+            .set({
+              classificationScores: u.classificationScores,
+              classificationThematiques: u.classificationThematiques,
+              classificationSites: u.classificationSites,
+              classificationInterventions: u.classificationInterventions,
+              probabiliteTE: u.probabiliteTE,
+            })
+            .where(eq(projets.id, u.projectId)),
+        ),
+      );
+
+      written += updates.length;
+      this.logger.log(`Batch process progress: ${written}/${projectEntries.length} projects written`);
+    }
+
+    this.logger.log(`Batch ${batchId} processing complete: ${written} projects classified`);
+
+    return { batchId, classified: written, failed };
+  }
+
+  private buildBatchRequests(projects: ProjectForClassification[]) {
+    return projects.flatMap((p) => {
+      const context = `${p.nom}\n${p.description ?? ""}`;
+      return CLASSIFICATION_AXES.map((axis) => ({
+        custom_id: `${p.id}:${axis}`,
+        params: this.anthropicService.buildMessageParams(context, axis, "projet"),
+      }));
+    });
+  }
+
+  private mapToItems(labels: Record<string, number>) {
+    return Object.entries(labels).map(([label, score]) => ({ label, score }));
+  }
+
+  private toSortedLabels(labels: Record<string, number>) {
+    return Object.entries(labels)
+      .sort(([, a], [, b]) => b - a)
+      .map(([label, score]) => ({ label, score }));
+  }
+
+  private chunkArray<T>(array: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size));
+    }
+    return chunks;
+  }
+}

--- a/api/src/projet-qualification/classification/classification.module.ts
+++ b/api/src/projet-qualification/classification/classification.module.ts
@@ -17,6 +17,12 @@ import { TEProbabilityService } from "./post-processing/te-probability.service";
     EnrichmentService,
     TEProbabilityService,
   ],
-  exports: [ClassificationService],
+  exports: [
+    ClassificationService,
+    ClassificationAnthropicService,
+    ClassificationValidationService,
+    EnrichmentService,
+    TEProbabilityService,
+  ],
 })
 export class ClassificationModule {}

--- a/api/src/projet-qualification/classification/llm/classification-anthropic.service.ts
+++ b/api/src/projet-qualification/classification/llm/classification-anthropic.service.ts
@@ -37,65 +37,115 @@ export class ClassificationAnthropicService {
   }
 
   async analyzeThematiques(context: string, type: "projet" | "aide" = "projet"): Promise<ClassificationAnalysisResult> {
-    const userPrompt = type === "aide" ? USER_PROMPT_THEMATIQUES_AIDE : USER_PROMPT_THEMATIQUES;
-    return this.analyze(context, userPrompt, type, "thematiques");
+    return this.analyze(context, type, "thematiques");
   }
 
   async analyzeSites(context: string, type: "projet" | "aide" = "projet"): Promise<ClassificationAnalysisResult> {
-    const userPrompt = type === "aide" ? USER_PROMPT_SITES_AIDE : USER_PROMPT_SITES;
-    return this.analyze(context, userPrompt, type, "sites");
+    return this.analyze(context, type, "sites");
   }
 
   async analyzeInterventions(
     context: string,
     type: "projet" | "aide" = "projet",
   ): Promise<ClassificationAnalysisResult> {
-    const userPrompt = type === "aide" ? USER_PROMPT_INTERVENTIONS_AIDE : USER_PROMPT_INTERVENTIONS;
-    return this.analyze(context, userPrompt, type, "interventions");
+    return this.analyze(context, type, "interventions");
+  }
+
+  /**
+   * Build the message params for a classification request.
+   * Used by both the real-time single call and the batch API.
+   */
+  buildMessageParams(
+    context: string,
+    axis: "thematiques" | "sites" | "interventions",
+    type: "projet" | "aide" = "projet",
+  ): Anthropic.Messages.MessageCreateParamsNonStreaming {
+    const userPromptMap = {
+      thematiques: type === "aide" ? USER_PROMPT_THEMATIQUES_AIDE : USER_PROMPT_THEMATIQUES,
+      sites: type === "aide" ? USER_PROMPT_SITES_AIDE : USER_PROMPT_SITES,
+      interventions: type === "aide" ? USER_PROMPT_INTERVENTIONS_AIDE : USER_PROMPT_INTERVENTIONS,
+    };
+    const contextLabel = type === "aide" ? "Aide" : "Projet";
+
+    return {
+      model: this.defaultModel,
+      max_tokens: 4096,
+      temperature: 0.4,
+      system: [
+        {
+          type: "text",
+          text: SYSTEM_PROMPT_CLASSIFICATION,
+          cache_control: { type: "ephemeral" },
+        },
+      ],
+      messages: [
+        {
+          role: "user",
+          content: [
+            {
+              type: "text",
+              text: userPromptMap[axis],
+              cache_control: { type: "ephemeral" },
+            },
+            {
+              type: "text",
+              text: `${contextLabel} :\n- "${context}"`,
+            },
+          ],
+        },
+      ],
+    };
+  }
+
+  /**
+   * Parse raw JSON response from Claude — public for batch result processing.
+   */
+  parseResponse(response: string, context: string): ClassificationAnalysisResult {
+    const trimmed = this.stripMarkdownCodeBlock(response.trim());
+
+    try {
+      const jsonData = JSON.parse(trimmed) as ClassificationLLMResponse;
+      return { json: jsonData };
+    } catch {
+      const candidates = this.extractJsonObjects(trimmed);
+      let lastValid: ClassificationLLMResponse | null = null;
+      for (const block of candidates) {
+        try {
+          const jsonData = JSON.parse(block) as ClassificationLLMResponse;
+          if (jsonData.items) {
+            lastValid = jsonData;
+          }
+        } catch {
+          // Try next candidate
+        }
+      }
+      if (lastValid) {
+        return { json: lastValid };
+      }
+
+      this.logger.error("Failed to parse JSON from LLM response", { response: trimmed.slice(0, 500) });
+      return {
+        json: { projet: context, items: [] },
+        errorMessage: "Failed to parse JSON from LLM response",
+      };
+    }
+  }
+
+  /** Expose the Anthropic client for batch API usage. */
+  getClient(): Anthropic {
+    return this.client;
   }
 
   private async analyze(
     context: string,
-    userPrompt: string,
     type: "projet" | "aide",
-    axis: string,
+    axis: "thematiques" | "sites" | "interventions",
   ): Promise<ClassificationAnalysisResult> {
     this.logger.log(`Analyzing ${axis} for ${type} context`);
 
-    // Context label matches Python: "Projet :" or "Aide :"
-    const contextLabel = type === "aide" ? "Aide" : "Projet";
-
     try {
-      const message = await this.client.messages.create({
-        model: this.defaultModel,
-        max_tokens: 4096,
-        temperature: 0.4,
-        system: [
-          {
-            type: "text",
-            text: SYSTEM_PROMPT_CLASSIFICATION,
-            cache_control: { type: "ephemeral" },
-          },
-        ],
-        messages: [
-          {
-            role: "user",
-            content: [
-              // Part 1: User prompt with labels list + rules (cached)
-              {
-                type: "text",
-                text: userPrompt,
-                cache_control: { type: "ephemeral" },
-              },
-              // Part 2: Context (not cached - changes every request)
-              {
-                type: "text",
-                text: `${contextLabel} :\n- "${context}"`,
-              },
-            ],
-          },
-        ],
-      });
+      const params = this.buildMessageParams(context, axis, type);
+      const message = await this.client.messages.create(params);
 
       const textContent = message.content.find((block) => block.type === "text");
       if (textContent?.type !== "text") {
@@ -122,11 +172,6 @@ export class ClassificationAnthropicService {
   }
 
   /**
-   * Parse raw JSON response from Claude
-   * Matches Python extract_json(): tries direct parse, then regex fallback
-   * Prompt says "Aucun texte hors JSON" so response should be pure JSON
-   */
-  private parseResponse(response: string, context: string): ClassificationAnalysisResult {
     // Try direct JSON parse (expected case: response is pure JSON)
     const trimmed = this.stripMarkdownCodeBlock(response.trim());
 

--- a/api/src/projets/projets.module.ts
+++ b/api/src/projets/projets.module.ts
@@ -9,12 +9,16 @@ import { ExtraFieldsService } from "@projets/services/extra-fields/extra-fields.
 import { UpdateProjetsService } from "@projets/services/update-projets/update-projets.service";
 import { BullModule } from "@nestjs/bullmq";
 import { PROJECT_QUALIFICATION_QUEUE_NAME } from "@/projet-qualification/const";
+import { BATCH_CLASSIFICATION_QUEUE_NAME } from "@/batch-classification/batch-classification.const";
 
 @Module({
   imports: [
     GeoModule,
     BullModule.registerQueue({
       name: PROJECT_QUALIFICATION_QUEUE_NAME,
+    }),
+    BullModule.registerQueue({
+      name: BATCH_CLASSIFICATION_QUEUE_NAME,
     }),
   ],
   controllers: [ProjetsController],

--- a/api/src/projets/services/create-projets/create-projets.service.ts
+++ b/api/src/projets/services/create-projets/create-projets.service.ts
@@ -18,6 +18,7 @@ import {
   PROJECT_QUALIFICATION_QUEUE_NAME,
   QualificationJobType,
 } from "@/projet-qualification/const";
+import { BATCH_CLASSIFICATION_QUEUE_NAME } from "@/batch-classification/batch-classification.const";
 
 @Injectable()
 export class CreateProjetsService {
@@ -26,6 +27,7 @@ export class CreateProjetsService {
     private readonly collectivitesService: CollectivitesService,
     private readonly serviceIdentifierService: ServiceIdentifierService,
     @InjectQueue(PROJECT_QUALIFICATION_QUEUE_NAME) private qualificationQueue: Queue,
+    @InjectQueue(BATCH_CLASSIFICATION_QUEUE_NAME) private batchClassificationQueue: Queue,
     private logger: CustomLogger,
   ) {}
 
@@ -38,19 +40,50 @@ export class CreateProjetsService {
   }
 
   async createBulk(bulkCreateProjectsRequest: BulkCreateProjetsRequest, apiKey: string): Promise<{ ids: string[] }> {
-    return this.dbService.database.transaction(async (tx) => {
-      const createdProjets: string[] = [];
+    const allIds: string[] = [];
+    const chunks = this.chunkArray(bulkCreateProjectsRequest.projets, 500);
 
-      for (const projetDto of bulkCreateProjectsRequest.projets) {
-        const result = await this.createOrUpdateProjet(tx, projetDto, apiKey);
-        createdProjets.push(result);
-      }
+    this.logger.log(
+      `Bulk creating ${bulkCreateProjectsRequest.projets.length} projects in ${chunks.length} chunks of 500`,
+    );
 
-      return { ids: createdProjets };
+    for (const chunk of chunks) {
+      const ids = await this.dbService.database.transaction(async (tx) => {
+        const chunkIds: string[] = [];
+        for (const projetDto of chunk) {
+          const id = await this.createOrUpdateProjet(tx, projetDto, apiKey, { skipQualificationJobs: true });
+          chunkIds.push(id);
+        }
+        return chunkIds;
+      });
+      allIds.push(...ids);
+    }
+
+    // Trigger batch classification for newly inserted projects
+    await this.batchClassificationQueue.add("submit", {
+      triggeredBy: "bulk",
+      projectCount: allIds.length,
     });
+
+    this.logger.log(`Bulk insert complete: ${allIds.length} projects, batch classification scheduled`);
+
+    return { ids: allIds };
   }
 
-  private async createOrUpdateProjet(tx: Tx, projectDto: CreateProjetRequest, apiKey: string): Promise<string> {
+  private chunkArray<T>(array: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size));
+    }
+    return chunks;
+  }
+
+  private async createOrUpdateProjet(
+    tx: Tx,
+    projectDto: CreateProjetRequest,
+    apiKey: string,
+    options?: { skipQualificationJobs?: boolean },
+  ): Promise<string> {
     const serviceIdField = this.serviceIdentifierService.getServiceIdFieldFromApiKey(apiKey);
 
     const { externalId, porteur, collectivites, ...otherFields } = projectDto;
@@ -88,32 +121,35 @@ export class CreateProjetsService {
     // Content changed if existing project had a different hash (upsert case)
     const contentChanged = existingProject !== undefined && existingProject.contentHash !== contentHash;
 
-    const needsCompetences = !upsertedProject.competences || upsertedProject.competences.length === 0 || contentChanged;
-    const needsLeviers = !upsertedProject.leviers || upsertedProject.leviers.length === 0 || contentChanged;
-    const needsClassification =
-      !upsertedProject.classificationThematiques ||
-      upsertedProject.classificationThematiques.length === 0 ||
-      contentChanged;
+    if (!options?.skipQualificationJobs) {
+      const needsCompetences =
+        !upsertedProject.competences || upsertedProject.competences.length === 0 || contentChanged;
+      const needsLeviers = !upsertedProject.leviers || upsertedProject.leviers.length === 0 || contentChanged;
+      const needsClassification =
+        !upsertedProject.classificationThematiques ||
+        upsertedProject.classificationThematiques.length === 0 ||
+        contentChanged;
 
-    if (needsCompetences) {
-      this.logger.log(
-        `Triggering competence qualification for projet ${upsertedProject.id}${contentChanged ? " (content changed)" : ""}`,
-      );
-      await this.scheduleProjectQualification(upsertedProject.id, PROJECT_QUALIFICATION_COMPETENCES_JOB);
-    }
+      if (needsCompetences) {
+        this.logger.log(
+          `Triggering competence qualification for projet ${upsertedProject.id}${contentChanged ? " (content changed)" : ""}`,
+        );
+        await this.scheduleProjectQualification(upsertedProject.id, PROJECT_QUALIFICATION_COMPETENCES_JOB);
+      }
 
-    if (needsLeviers) {
-      this.logger.log(
-        `Triggering leviers qualification for projet ${upsertedProject.id}${contentChanged ? " (content changed)" : ""}`,
-      );
-      await this.scheduleProjectQualification(upsertedProject.id, PROJECT_QUALIFICATION_LEVIERS_JOB);
-    }
+      if (needsLeviers) {
+        this.logger.log(
+          `Triggering leviers qualification for projet ${upsertedProject.id}${contentChanged ? " (content changed)" : ""}`,
+        );
+        await this.scheduleProjectQualification(upsertedProject.id, PROJECT_QUALIFICATION_LEVIERS_JOB);
+      }
 
-    if (needsClassification) {
-      this.logger.log(
-        `Triggering classification for projet ${upsertedProject.id}${contentChanged ? " (content changed)" : ""}`,
-      );
-      await this.scheduleProjectQualification(upsertedProject.id, PROJECT_QUALIFICATION_CLASSIFICATION_JOB);
+      if (needsClassification) {
+        this.logger.log(
+          `Triggering classification for projet ${upsertedProject.id}${contentChanged ? " (content changed)" : ""}`,
+        );
+        await this.scheduleProjectQualification(upsertedProject.id, PROJECT_QUALIFICATION_CLASSIFICATION_JOB);
+      }
     }
 
     return upsertedProject.id;


### PR DESCRIPTION
## Contexte

MEC va envoyer 80 000 projets CRTE de toute la France via `POST /projets/bulk`. Le flux actuel (1 job BullMQ par projet × 3 appels API séquentiels) prendrait **5+ jours**. Cette PR implémente un pipeline batch automatique utilisant l'API Batch Anthropic.

## Changements

### 1. Bulk insert par chunks (`create-projets.service.ts`)

- Découpe le bulk en **transactions de 500** projets (évite le timeout)
- Option `skipQualificationJobs` pour ne pas enqueue 240k jobs BullMQ individuels
- Après l'insert, enqueue un job batch-classify "submit"

### 2. Pipeline batch automatique (`batch-classification/`)

Nouveau module BullMQ avec 3 étapes :

```
submit → collecte projets WHERE classification_scores IS NULL
       → soumet à client.messages.batches.create() (max 100k req/batch → 3 batches)

poll   → check status toutes les 5 min (BullMQ retry automatique)
       → quand "ended" → enqueue "process"

process → stream résultats → parse JSON → validation Levenshtein
        → enrichment → probabilité TE → bulk UPDATE DB (chunks de 500)
```

**Zéro intervention manuelle.** MEC appelle le bulk, tout se déroule en ~24h.

Un endpoint management optionnel `POST /management/batch-classify` permet de relancer manuellement.

### 3. Refactor ClassificationAnthropicService

- `buildMessageParams()` : construit les params de message (public, réutilisé par le batch)
- `parseResponse()` : rendu public pour le traitement des résultats batch
- `getClient()` : expose le client Anthropic pour l'API Batch

### 4. ClassificationModule exports

Exporte `ClassificationAnthropicService`, `ClassificationValidationService`, `EnrichmentService`, `TEProbabilityService` pour réutilisation par le batch processor.

## Coût estimé

**~600-700$** pour 80 000 projets (Sonnet 4.6, API Batch = 50% discount).

## Plan de test

- [ ] Tests unitaires passent (typecheck + lint OK)
- [ ] Déployer staging, tester `POST /management/batch-classify` avec un subset (~100 projets)
- [ ] Vérifier le Bull Board (`/queues`) : jobs submit → poll → process
- [ ] Dry-run avec MEC sur staging avant les 80k projets prod
- [ ] Monitoring : logs de progression, erreurs de parsing, projets non classifiés