### PR TITLE
fix(api): correctifs batch classification (review + custom_id + limit)

### DIFF
--- a/api/src/batch-classification/batch-classification.processor.spec.ts
+++ b/api/src/batch-classification/batch-classification.processor.spec.ts
@@ -171,14 +171,14 @@ describe("BatchClassificationProcessor", () => {
       // Only 2 axes for proj-1 (missing interventions)
       const asyncResults = (function* () {
         yield {
-          custom_id: "proj-1:thematiques",
+          custom_id: "proj-1--thematiques",
           result: {
             type: "succeeded" as const,
             message: { content: [{ type: "text" as const, text: '{"projet":"p","items":[]}' }] },
           },
         };
         yield {
-          custom_id: "proj-1:sites",
+          custom_id: "proj-1--sites",
           result: {
             type: "succeeded" as const,
             message: { content: [{ type: "text" as const, text: '{"projet":"p","items":[]}' }] },
@@ -197,7 +197,7 @@ describe("BatchClassificationProcessor", () => {
       const asyncResults = (function* () {
         for (const axis of ["thematiques", "sites", "interventions"]) {
           yield {
-            custom_id: `proj-1:${axis}`,
+            custom_id: `proj-1--${axis}`,
             result: {
               type: "succeeded" as const,
               message: {

--- a/api/src/batch-classification/batch-classification.processor.ts
+++ b/api/src/batch-classification/batch-classification.processor.ts
@@ -345,14 +345,14 @@ export class BatchClassificationProcessor extends WorkerHost {
   }
 
   /**
-   * Parse custom_id format "projectId:axis". Uses lastIndexOf to handle
-   * any edge case where the projectId might contain colons.
+   * Parse custom_id format "projectId--axis".
+   * Separator is "--" because Anthropic Batch API only allows [a-zA-Z0-9_-] in custom_id.
    */
   private parseCustomId(customId: string): { projectId: string; axis: ClassificationAxis } {
-    const lastColon = customId.lastIndexOf(":");
+    const separatorIndex = customId.lastIndexOf("--");
     return {
-      projectId: customId.slice(0, lastColon),
-      axis: customId.slice(lastColon + 1) as ClassificationAxis,
+      projectId: customId.slice(0, separatorIndex),
+      axis: customId.slice(separatorIndex + 2) as ClassificationAxis,
     };
   }
 
@@ -360,7 +360,7 @@ export class BatchClassificationProcessor extends WorkerHost {
     return projects.flatMap((p) => {
       const context = `${p.nom}\n${p.description ?? ""}`;
       return CLASSIFICATION_AXES.map((axis) => ({
-        custom_id: `${p.id}:${axis}`,
+        custom_id: `${p.id}--${axis}`,
         params: this.anthropicService.buildMessageParams(context, axis, "projet"),
       }));
     });


### PR DESCRIPTION
## Suite de #420

Correctifs post-merge pour le pipeline de classification batch.

### Changements

1. **custom_id Anthropic** : remplace `:` par `--` comme séparateur (l'API Batch n'accepte que `^[a-zA-Z0-9_-]{1,64}$`)
2. **Paramètre `limit`** : `POST /management/batch-classify?limit=100` pour tester sur un subset
3. **Retours de review** :
   - SELECT paginé (chunks de 5000) au lieu de tout charger en RAM
   - DB writes séquentiels au lieu de `Promise.all(500)`
   - Projets incomplets (< 3 axes) filtrés, pas écrits en DB
   - Sentry.captureException dans les handlers
   - 6 tests unitaires pour le processor

## Test

Le custom_id fix a été identifié en testant sur staging — le submit crashait avec `400 invalid_request_error`.