### PR TITLE
fix(api): ajouter retry avec backoff sur les erreurs transitoires AT

### DIFF
--- a/api/src/aides/aides-territoires.service.ts
+++ b/api/src/aides/aides-territoires.service.ts
@@ -2,6 +2,10 @@ import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { CustomLogger } from "@logging/logger.service";
 
+const RETRYABLE_STATUS_CODES = [429, 502, 503, 504];
+const MAX_RETRIES = 3;
+const RETRY_BASE_DELAY_MS = 5000;
+
 /**
  * Client for the Aides-Territoires API
  * Handles authentication (JWT token) and data fetching
@@ -48,6 +52,34 @@ export class AidesTerritoiresService {
   }
 
   /**
+   * Fetch a single page from AT API with retry on transient errors (429, 502, 503, 504).
+   */
+  private async fetchPage(url: string, token: string): Promise<AidesTerritoiresResponse> {
+    for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const response = await fetch(url, {
+        headers: { Authorization: `Bearer ${token}` },
+      });
+
+      if (response.ok) {
+        return (await response.json()) as AidesTerritoiresResponse;
+      }
+
+      if (!RETRYABLE_STATUS_CODES.includes(response.status) || attempt === MAX_RETRIES) {
+        throw new Error(`AT API error: ${response.status} ${response.statusText}`);
+      }
+
+      const backoff = RETRY_BASE_DELAY_MS * Math.pow(2, attempt);
+      this.logger.warn(
+        `AT API ${response.status} on ${url}, retrying in ${backoff / 1000}s (attempt ${attempt + 1}/${MAX_RETRIES})`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, backoff));
+    }
+
+    // Unreachable, but satisfies TypeScript
+    throw new Error("AT API: max retries exhausted");
+  }
+
+  /**
    * Fetch aides from AT API with pagination
    * @param params Query parameters (perimeter, targeted_audiences, etc.)
    * @returns All aides matching the query
@@ -62,15 +94,7 @@ export class AidesTerritoiresService {
       const queryParams = new URLSearchParams({ ...params, page_size: "50", page: String(page) });
       const url = `${this.baseUrl}/aids/?${queryParams}`;
 
-      const response = await fetch(url, {
-        headers: { Authorization: `Bearer ${token}` },
-      });
-
-      if (!response.ok) {
-        throw new Error(`AT API error: ${response.status} ${response.statusText}`);
-      }
-
-      const data = (await response.json()) as AidesTerritoiresResponse;
+      const data = await this.fetchPage(url, token);
       allAides.push(...data.results);
 
       hasMore = data.next !== null;


### PR DESCRIPTION
## Summary
- Le cron `aides-sync` (3h UTC) échouait régulièrement sur des **504 Gateway Time-out** de l'API Aides-Territoires
- Un seul timeout sur une page de pagination faisait crasher tout le job ; les 3 retries BullMQ relançaient le job entier depuis zéro (re-fetch des ~60 pages précédentes)
- Ajoute un retry **par requête** (3 tentatives, backoff exponentiel 5s → 10s → 20s) sur les codes HTTP transitoires (429, 502, 503, 504) dans une nouvelle méthode `fetchPage()`
- Pattern cohérent avec `warmTerritoryWithRetry` qui existe déjà dans le warmup service

## Test plan
- [ ] Vérifier que le cron `aides-sync` passe sans erreur au prochain run (3h UTC)
- [ ] Vérifier les logs : les retries doivent apparaître comme `WARN` avec le status code et le délai
- [ ] Vérifier qu'une erreur non-transitoire (ex: 401, 400) échoue immédiatement sans retry