### PR TITLE
feat(api): centraliser les types aides dans dto/aides.dto.ts

### DIFF
--- a/api/src/aides/aide-classification.service.ts
+++ b/api/src/aides/aide-classification.service.ts
@@ -5,13 +5,7 @@ import { DatabaseService } from "@database/database.service";
 import { aideClassifications } from "@database/schema";
 import { CustomLogger } from "@logging/logger.service";
 import { ClassificationService } from "@/projet-qualification/classification/classification.service";
-import { AideTerritoires } from "./aides-territoires.service";
-
-interface ClassificationScores {
-  thematiques: { label: string; score: number }[];
-  sites: { label: string; score: number }[];
-  interventions: { label: string; score: number }[];
-}
+import { Aide, AideClassification } from "./dto/aides.dto";
 
 /**
  * Manages classification of aides: LLM classification + cache via content hash
@@ -28,7 +22,7 @@ export class AideClassificationService {
   /**
    * Get classification for an aide, classifying if needed (cache miss or content changed)
    */
-  async getOrClassify(aide: AideTerritoires): Promise<ClassificationScores | null> {
+  async getOrClassify(aide: Aide): Promise<AideClassification | null> {
     const idAt = String(aide.id);
     const hash = this.computeHash(aide);
 
@@ -51,12 +45,12 @@ export class AideClassificationService {
    * Get cached classifications for multiple aides (batch lookup)
    * Returns a map of id_at -> scores (only for aides that are already classified)
    */
-  async getCachedClassifications(aideIds: string[]): Promise<Map<string, ClassificationScores>> {
+  async getCachedClassifications(aideIds: string[]): Promise<Map<string, AideClassification>> {
     if (aideIds.length === 0) return new Map();
 
     const rows = await this.dbService.database.select().from(aideClassifications);
 
-    const map = new Map<string, ClassificationScores>();
+    const map = new Map<string, AideClassification>();
     for (const row of rows) {
       if (aideIds.includes(row.idAt)) {
         map.set(row.idAt, row.classificationScores);
@@ -69,7 +63,7 @@ export class AideClassificationService {
    * Sync classifications for a batch of aides
    * Only classifies new or modified aides (based on content hash)
    */
-  async syncClassifications(aides: AideTerritoires[]): Promise<{ classified: number; cached: number }> {
+  async syncClassifications(aides: Aide[]): Promise<{ classified: number; cached: number }> {
     let classified = 0;
     let cached = 0;
 
@@ -100,13 +94,13 @@ export class AideClassificationService {
     return { classified, cached };
   }
 
-  private async classifyAndStore(aide: AideTerritoires, idAt: string, hash: string): Promise<ClassificationScores> {
+  private async classifyAndStore(aide: Aide, idAt: string, hash: string): Promise<AideClassification> {
     const context = this.buildContext(aide);
     this.logger.log(`Classifying aide ${idAt}: ${aide.name.slice(0, 60)}`);
 
     const result = await this.classificationService.classify(context, "aide");
 
-    const scores: ClassificationScores = {
+    const scores: AideClassification = {
       thematiques: result.thematiques,
       sites: result.sites,
       interventions: result.interventions,
@@ -133,12 +127,12 @@ export class AideClassificationService {
     return scores;
   }
 
-  private computeHash(aide: AideTerritoires): string {
+  private computeHash(aide: Aide): string {
     const content = `${aide.name}|${aide.description ?? ""}`;
     return createHash("sha256").update(content).digest("hex");
   }
 
-  private buildContext(aide: AideTerritoires): string {
+  private buildContext(aide: Aide): string {
     const parts = [`TITRE: ${aide.name}`];
     if (aide.description) {
       parts.push(`DESCRIPTION: ${aide.description}`);

--- a/api/src/aides/aides-cache.service.spec.ts
+++ b/api/src/aides/aides-cache.service.spec.ts
@@ -1,7 +1,7 @@
 import { AidesCacheService } from "./aides-cache.service";
 import { ConfigService } from "@nestjs/config";
 import { CustomLogger } from "@logging/logger.service";
-import { AideTerritoires } from "./aides-territoires.service";
+import { Aide } from "./dto/aides.dto";
 
 // Mock ioredis
 const mockRedis = {
@@ -23,7 +23,7 @@ jest.mock("ioredis", () => {
   return jest.fn().mockImplementation(() => mockRedis);
 });
 
-function makeAide(id: number, name = `Aide ${id}`): AideTerritoires {
+function makeAide(id: number, name = `Aide ${id}`): Aide {
   return {
     id,
     slug: `aide-${id}`,

--- a/api/src/aides/aides-cache.service.ts
+++ b/api/src/aides/aides-cache.service.ts
@@ -2,7 +2,7 @@ import { Injectable, OnModuleDestroy } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { CustomLogger } from "@logging/logger.service";
 import Redis from "ioredis";
-import { AideTerritoires } from "./aides-territoires.service";
+import { Aide } from "./dto/aides.dto";
 
 const AIDE_PREFIX = "at:aide:";
 const TERRITORY_PREFIX = "at:territory:";
@@ -22,7 +22,7 @@ interface TerritoryEntry {
 export type CacheStatus = "fresh" | "stale" | "miss";
 
 export interface CacheResult {
-  aides: AideTerritoires[];
+  aides: Aide[];
   status: CacheStatus;
 }
 
@@ -84,7 +84,7 @@ export class AidesCacheService implements OnModuleDestroy {
    * Store aides for a territory. Writes individual aides then the territory index.
    * Aides are written first so the index never points to missing keys.
    */
-  async set(queryKey: string, aides: AideTerritoires[]): Promise<void> {
+  async set(queryKey: string, aides: Aide[]): Promise<void> {
     if (aides.length === 0) return;
 
     // 1. Bulk upsert individual aides
@@ -107,7 +107,7 @@ export class AidesCacheService implements OnModuleDestroy {
   /**
    * Bulk store individual aides in Redis via pipeline.
    */
-  private async setAides(aides: AideTerritoires[]): Promise<void> {
+  private async setAides(aides: Aide[]): Promise<void> {
     const pipeline = this.redis.pipeline();
     for (const aide of aides) {
       pipeline.set(`${AIDE_PREFIX}${aide.id}`, JSON.stringify(aide), "EX", AIDE_TTL_SECONDS);
@@ -118,16 +118,16 @@ export class AidesCacheService implements OnModuleDestroy {
   /**
    * Retrieve aides by ID list using MGET. Silently skips expired/missing keys.
    */
-  private async getAidesByIds(ids: number[]): Promise<AideTerritoires[]> {
+  private async getAidesByIds(ids: number[]): Promise<Aide[]> {
     if (ids.length === 0) return [];
 
     const keys = ids.map((id) => `${AIDE_PREFIX}${id}`);
     const values = await this.redis.mget(...keys);
 
-    const aides: AideTerritoires[] = [];
+    const aides: Aide[] = [];
     for (const v of values) {
       if (v) {
-        aides.push(JSON.parse(v) as AideTerritoires);
+        aides.push(JSON.parse(v) as Aide);
       }
     }
     return aides;

--- a/api/src/aides/aides-matching.service.ts
+++ b/api/src/aides/aides-matching.service.ts
@@ -28,27 +28,7 @@
 
 import { Injectable } from "@nestjs/common";
 import { CustomLogger } from "@logging/logger.service";
-
-interface ScoredLabels {
-  thematiques: { label: string; score: number }[];
-  sites: { label: string; score: number }[];
-  interventions: { label: string; score: number }[];
-}
-
-export interface MatchResult {
-  idAt: string;
-  score: number;
-  normalizedScore: number;
-  scoreThematiques: number;
-  scoreSites: number;
-  scoreInterventions: number;
-  axesMatched: number;
-  labelsCommuns: {
-    thematiques: string[];
-    sites: string[];
-    interventions: string[];
-  };
-}
+import { AideClassification, AideMatchResult } from "./dto/aides.dto";
 
 /**
  * Matching engine for projects and aides
@@ -72,7 +52,7 @@ export class AidesMatchingService {
    * @param limit Max number of results
    * @returns Sorted list of matching aides with scores
    */
-  match(projetScores: ScoredLabels, aidesScores: Map<string, ScoredLabels>, limit = 10): MatchResult[] {
+  match(projetScores: AideClassification, aidesScores: Map<string, AideClassification>, limit = 10): AideMatchResult[] {
     // Filter project labels by threshold
     const pThematiques = this.filterByThreshold(projetScores.thematiques);
     const pSites = this.filterByThreshold(projetScores.sites);
@@ -84,7 +64,7 @@ export class AidesMatchingService {
     const candidates = this.findCandidates(pThematiques, pSites, pInterventions, aidesScores);
 
     // Score each candidate
-    const results: MatchResult[] = [];
+    const results: AideMatchResult[] = [];
 
     for (const idAt of candidates) {
       const aideScores = aidesScores.get(idAt)!;
@@ -169,7 +149,7 @@ export class AidesMatchingService {
     pTh: Map<string, number>,
     pSi: Map<string, number>,
     pIn: Map<string, number>,
-    aidesScores: Map<string, ScoredLabels>,
+    aidesScores: Map<string, AideClassification>,
   ): Set<string> {
     const candidates = new Set<string>();
     const projectLabels = new Set([...pTh.keys(), ...pSi.keys(), ...pIn.keys()]);

--- a/api/src/aides/aides-territoires.service.ts
+++ b/api/src/aides/aides-territoires.service.ts
@@ -1,6 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
 import { CustomLogger } from "@logging/logger.service";
+import { Aide } from "./dto/aides.dto";
 
 const RETRYABLE_STATUS_CODES = [429, 502, 503, 504];
 const MAX_RETRIES = 3;
@@ -84,9 +85,9 @@ export class AidesTerritoiresService {
    * @param params Query parameters (perimeter, targeted_audiences, etc.)
    * @returns All aides matching the query
    */
-  async fetchAides(params: Record<string, string> = {}): Promise<AideTerritoires[]> {
+  async fetchAides(params: Record<string, string> = {}): Promise<Aide[]> {
     const token = await this.getBearerToken();
-    const allAides: AideTerritoires[] = [];
+    const allAides: Aide[] = [];
     let page = 1;
     let hasMore = true;
 
@@ -112,48 +113,9 @@ export class AidesTerritoiresService {
   }
 }
 
-/**
- * Shape of an aide from the AT API (subset of 48 fields)
- */
-export interface AideTerritoires {
-  id: number;
-  slug: string;
-  url: string;
-  name: string;
-  name_initial: string;
-  short_title: string | null;
-  financers: string[];
-  financers_full: { id: number; name: string; logo: string | null }[];
-  instructors: string[];
-  programs: string[];
-  description: string | null;
-  eligibility: string | null;
-  perimeter: string;
-  perimeter_id: number;
-  perimeter_scale: string;
-  categories: string[];
-  targeted_audiences: string[];
-  aid_types: string[];
-  aid_types_full: { id: number; name: string; group: { id: number; name: string } }[];
-  mobilization_steps: string[];
-  origin_url: string | null;
-  application_url: string | null;
-  is_call_for_project: boolean | null;
-  start_date: string | null;
-  submission_deadline: string | null;
-  subvention_rate_lower_bound: number | null;
-  subvention_rate_upper_bound: number | null;
-  subvention_comment: string | null;
-  contact: string | null;
-  recurrence: string | null;
-  project_examples: string | null;
-  date_created: string | null;
-  date_updated: string | null;
-}
-
 interface AidesTerritoiresResponse {
   count: number;
   next: string | null;
   previous: string | null;
-  results: AideTerritoires[];
+  results: Aide[];
 }

--- a/api/src/aides/aides-warmup.service.spec.ts
+++ b/api/src/aides/aides-warmup.service.spec.ts
@@ -2,10 +2,11 @@
 import { AidesWarmupService } from "./aides-warmup.service";
 import { CustomLogger } from "@logging/logger.service";
 import { DatabaseService } from "@database/database.service";
-import { AidesTerritoiresService, AideTerritoires } from "./aides-territoires.service";
+import { AidesTerritoiresService } from "./aides-territoires.service";
 import { AidesCacheService } from "./aides-cache.service";
+import { Aide } from "./dto/aides.dto";
 
-function makeAide(id: number): AideTerritoires {
+function makeAide(id: number): Aide {
   return {
     id,
     slug: `aide-${id}`,

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -1,14 +1,15 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { AidesController } from "./aides.controller";
-import { AidesTerritoiresService, AideTerritoires } from "./aides-territoires.service";
+import { AidesTerritoiresService } from "./aides-territoires.service";
 import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
 import { AidesCacheService, CacheResult } from "./aides-cache.service";
 import { AidesWarmupService } from "./aides-warmup.service";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { CustomLogger } from "@logging/logger.service";
+import { Aide } from "./dto/aides.dto";
 
-function makeAide(id: number): AideTerritoires {
+function makeAide(id: number): Aide {
   return {
     id,
     slug: `aide-${id}`,

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -4,27 +4,13 @@ import { ApiKeyGuard } from "@/auth/api-key-guard";
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
 import { CustomLogger } from "@logging/logger.service";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
-import { AidesTerritoiresService, AideTerritoires } from "./aides-territoires.service";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { AidesTerritoiresService } from "./aides-territoires.service";
 import { AideClassificationService } from "./aide-classification.service";
-import { AidesMatchingService, MatchResult } from "./aides-matching.service";
+import { AidesMatchingService } from "./aides-matching.service";
 import { AidesCacheService } from "./aides-cache.service";
 import { AidesWarmupService } from "./aides-warmup.service";
-
-interface EnrichedAide extends AideTerritoires {
-  classification?: {
-    thematiques: { label: string; score: number }[];
-    sites: { label: string; score: number }[];
-    interventions: { label: string; score: number }[];
-  };
-  matchingScore?: number;
-  normalizedScore?: number;
-  axesMatched?: number;
-  labelsCommuns?: {
-    thematiques: string[];
-    sites: string[];
-    interventions: string[];
-  };
-}
+import { Aide, AideMatchResult, AidesListResponse, AidesSyncResponse, AideWithClassification } from "./dto/aides.dto";
 
 @ApiBearerAuth()
 @ApiTags("Aides")
@@ -56,10 +42,12 @@ export class AidesController {
     description: "ID projet pour filtrer par territoire et calculer le matching",
   })
   @ApiQuery({ name: "limit", required: false, description: "Nombre max de résultats (défaut: 20)" })
-  async listAides(
-    @Query("projet_id") projetId: string,
-    @Query("limit") limit?: string,
-  ): Promise<{ aides: EnrichedAide[]; total: number }> {
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: AidesListResponse,
+    description: "Liste des aides enrichies avec score de matching",
+  })
+  async listAides(@Query("projet_id") projetId: string, @Query("limit") limit?: string): Promise<AidesListResponse> {
     if (!projetId) {
       throw new BadRequestException("projet_id is required");
     }
@@ -90,14 +78,14 @@ export class AidesController {
     const classifications = await this.classificationService.getCachedClassifications(aideIds);
 
     // 5. Do matching
-    const matchResults = new Map<string, MatchResult>();
+    const matchResults = new Map<string, AideMatchResult>();
     const results = this.matchingService.match(projet.classificationScores, classifications, maxResults);
     for (const r of results) {
       matchResults.set(r.idAt, r);
     }
 
     // 6. Enrich and sort by matching score
-    let enriched: EnrichedAide[] = allAides.map((aide) => {
+    let enriched: AideWithClassification[] = allAides.map((aide) => {
       const idAt = String(aide.id);
       const classification = classifications.get(idAt);
       const match = matchResults.get(idAt);
@@ -128,12 +116,12 @@ export class AidesController {
     description:
       "Déclenche la classification LLM des aides non encore classifiées ou modifiées. Invalide le cache Redis.",
   })
-  async syncClassifications(): Promise<{
-    classified: number;
-    cached: number;
-    total: number;
-    warmupStarted: boolean;
-  }> {
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: AidesSyncResponse,
+    description: "Résultat de la synchronisation",
+  })
+  async syncClassifications(): Promise<AidesSyncResponse> {
     this.logger.log("Starting aide classification sync");
     const aides = await this.atService.fetchAides();
     const result = await this.classificationService.syncClassifications(aides);
@@ -168,7 +156,7 @@ export class AidesController {
    * Fetch aides for a single territory with SWR.
    * Returns aides immediately (from cache if available), triggers background refresh if stale.
    */
-  private async fetchAidesForTerritory(params: Record<string, string>, label: string): Promise<AideTerritoires[]> {
+  private async fetchAidesForTerritory(params: Record<string, string>, label: string): Promise<Aide[]> {
     const cacheKey = this.cacheService.buildKey(params);
     const cached = await this.cacheService.get(cacheKey);
 
@@ -212,13 +200,13 @@ export class AidesController {
    * Fetch aides for multiple territories (union). Deduplicates by aide id.
    * Uses AT's perimeter_codes[] parameter which accepts code INSEE directly.
    */
-  private async fetchAidesForTerritories(codesInsee: string[]): Promise<AideTerritoires[]> {
+  private async fetchAidesForTerritories(codesInsee: string[]): Promise<Aide[]> {
     if (codesInsee.length === 0) {
       return this.fetchAidesForTerritory({}, "no territory filter");
     }
 
     const seenIds = new Set<number>();
-    const allAides: AideTerritoires[] = [];
+    const allAides: Aide[] = [];
 
     for (const codeInsee of codesInsee) {
       const params = { "perimeter_codes[]": codeInsee };

--- a/api/src/aides/dto/aides.dto.ts
+++ b/api/src/aides/dto/aides.dto.ts
@@ -1,0 +1,227 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class AideFinancerFull {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ nullable: true, type: String })
+  logo!: string | null;
+}
+
+export class AideTypeGroup {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+}
+
+export class AideTypeFull {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty({ type: AideTypeGroup })
+  group!: AideTypeGroup;
+}
+
+export class Aide {
+  @ApiProperty()
+  id!: number;
+
+  @ApiProperty()
+  slug!: string;
+
+  @ApiProperty()
+  url!: string;
+
+  @ApiProperty()
+  name!: string;
+
+  @ApiProperty()
+  name_initial!: string;
+
+  @ApiProperty({ nullable: true, type: String })
+  short_title!: string | null;
+
+  @ApiProperty({ type: [String] })
+  financers!: string[];
+
+  @ApiProperty({ type: [AideFinancerFull] })
+  financers_full!: AideFinancerFull[];
+
+  @ApiProperty({ type: [String] })
+  instructors!: string[];
+
+  @ApiProperty({ type: [String] })
+  programs!: string[];
+
+  @ApiProperty({ nullable: true, type: String })
+  description!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  eligibility!: string | null;
+
+  @ApiProperty()
+  perimeter!: string;
+
+  @ApiProperty()
+  perimeter_id!: number;
+
+  @ApiProperty()
+  perimeter_scale!: string;
+
+  @ApiProperty({ type: [String] })
+  categories!: string[];
+
+  @ApiProperty({ type: [String] })
+  targeted_audiences!: string[];
+
+  @ApiProperty({ type: [String] })
+  aid_types!: string[];
+
+  @ApiProperty({ type: [AideTypeFull] })
+  aid_types_full!: AideTypeFull[];
+
+  @ApiProperty({ type: [String] })
+  mobilization_steps!: string[];
+
+  @ApiProperty({ nullable: true, type: String })
+  origin_url!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  application_url!: string | null;
+
+  @ApiProperty({ nullable: true, type: Boolean })
+  is_call_for_project!: boolean | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  start_date!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  submission_deadline!: string | null;
+
+  @ApiProperty({ nullable: true, type: Number })
+  subvention_rate_lower_bound!: number | null;
+
+  @ApiProperty({ nullable: true, type: Number })
+  subvention_rate_upper_bound!: number | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  subvention_comment!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  contact!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  recurrence!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  project_examples!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  date_created!: string | null;
+
+  @ApiProperty({ nullable: true, type: String })
+  date_updated!: string | null;
+}
+
+export class AideClassificationScore {
+  @ApiProperty()
+  label!: string;
+
+  @ApiProperty()
+  score!: number;
+}
+
+export class AideClassification {
+  @ApiProperty({ type: [AideClassificationScore] })
+  thematiques!: AideClassificationScore[];
+
+  @ApiProperty({ type: [AideClassificationScore] })
+  sites!: AideClassificationScore[];
+
+  @ApiProperty({ type: [AideClassificationScore] })
+  interventions!: AideClassificationScore[];
+}
+
+export class AideLabelsCommuns {
+  @ApiProperty({ type: [String] })
+  thematiques!: string[];
+
+  @ApiProperty({ type: [String] })
+  sites!: string[];
+
+  @ApiProperty({ type: [String] })
+  interventions!: string[];
+}
+
+export class AideMatchResult {
+  @ApiProperty()
+  idAt!: string;
+
+  @ApiProperty()
+  score!: number;
+
+  @ApiProperty()
+  normalizedScore!: number;
+
+  @ApiProperty()
+  scoreThematiques!: number;
+
+  @ApiProperty()
+  scoreSites!: number;
+
+  @ApiProperty()
+  scoreInterventions!: number;
+
+  @ApiProperty()
+  axesMatched!: number;
+
+  @ApiProperty({ type: AideLabelsCommuns })
+  labelsCommuns!: AideLabelsCommuns;
+}
+
+export class AideWithClassification extends Aide {
+  @ApiProperty({ required: false, type: AideClassification })
+  classification?: AideClassification;
+
+  @ApiProperty({ required: false, type: Number })
+  matchingScore?: number;
+
+  @ApiProperty({ required: false, type: Number })
+  normalizedScore?: number;
+
+  @ApiProperty({ required: false, type: Number })
+  axesMatched?: number;
+
+  @ApiProperty({ required: false, type: AideLabelsCommuns })
+  labelsCommuns?: AideLabelsCommuns;
+}
+
+export class AidesListResponse {
+  @ApiProperty({ type: [AideWithClassification] })
+  aides!: AideWithClassification[];
+
+  @ApiProperty()
+  total!: number;
+}
+
+export class AidesSyncResponse {
+  @ApiProperty()
+  classified!: number;
+
+  @ApiProperty()
+  cached!: number;
+
+  @ApiProperty()
+  total!: number;
+
+  @ApiProperty()
+  warmupStarted!: boolean;
+}

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -13,6 +13,7 @@ import {
   uuid,
 } from "drizzle-orm/pg-core";
 import { eq, relations, sql } from "drizzle-orm";
+import { AideClassification } from "@/aides/dto/aides.dto";
 import { uuidv7 } from "uuidv7";
 
 const projetPhases = ["Idée", "Étude", "Opération"] as const;
@@ -199,11 +200,7 @@ export const apiRequests = pgTable("api_requests", {
 export const aideClassifications = pgTable("aide_classifications", {
   idAt: text("id_at").primaryKey(),
   contentHash: text("content_hash").notNull(),
-  classificationScores: jsonb("classification_scores").notNull().$type<{
-    thematiques: { label: string; score: number }[];
-    sites: { label: string; score: number }[];
-    interventions: { label: string; score: number }[];
-  }>(),
+  classificationScores: jsonb("classification_scores").notNull().$type<AideClassification>(),
   classifiedAt: timestamp("classified_at").notNull().defaultNow(),
 });
 


### PR DESCRIPTION
## Summary
- Centralise les types éparpillés (`AideTerritoires`, `ClassificationScores`, `ScoredLabels`, `MatchResult`, `EnrichedAide`) dans `dto/aides.dto.ts` avec des classes annotées `@ApiProperty` pour Swagger/OpenAPI
- Ajoute `@ApiEndpointResponses` sur `listAides` et `syncClassifications`
- Couple les return types du controller aux DTOs (`AidesListResponse`, `AidesSyncResponse`) pour éviter le drift Swagger ↔ implémentation
- Utilise `AideClassification` dans le schema Drizzle `aideClassifications` au lieu du type inline (single source of truth)

Reprend le travail de la PR #421 de @sylvaingi, rebasée sur `main` avec les suggestions de review intégrées.

## Test plan
- [x] `pnpm validate` passe (typecheck + lint + format)
- [ ] CI (lint-test-typecheck) passe
- [ ] Vérifier la doc Swagger sur `/api/docs` après déploiement staging