### PR TITLE
fix(api): corriger OOM batch classification — cap 5000 projets/job

### DIFF
--- a/api/src/batch-classification/batch-classification.const.ts
+++ b/api/src/batch-classification/batch-classification.const.ts
@@ -3,8 +3,11 @@ export const BATCH_SUBMIT_JOB = "submit";
 export const BATCH_POLL_JOB = "poll";
 export const BATCH_PROCESS_JOB = "process";
 
-/** Max requests per Anthropic batch */
+/** Max requests per Anthropic batch API call */
 export const ANTHROPIC_BATCH_MAX_REQUESTS = 100_000;
+
+/** Max projects per submit job — avoids OOM when building requests in memory */
+export const MAX_PROJECTS_PER_SUBMIT = 5_000;
 
 /** Polling interval for batch status checks */
 export const POLL_DELAY_MS = 5 * 60 * 1000; // 5 minutes

--- a/api/src/batch-classification/batch-classification.processor.ts
+++ b/api/src/batch-classification/batch-classification.processor.ts
@@ -1,6 +1,6 @@
 import { Processor, WorkerHost, InjectQueue } from "@nestjs/bullmq";
 import { Job, Queue } from "bullmq";
-import { isNull, eq } from "drizzle-orm";
+import { isNull, eq, inArray } from "drizzle-orm";
 import { CustomLogger } from "@logging/logger.service";
 import { DatabaseService } from "@database/database.service";
 import { projets } from "@database/schema";
@@ -15,6 +15,7 @@ import {
   BATCH_POLL_JOB,
   BATCH_PROCESS_JOB,
   ANTHROPIC_BATCH_MAX_REQUESTS,
+  MAX_PROJECTS_PER_SUBMIT,
   POLL_DELAY_MS,
   MAX_POLL_ATTEMPTS,
   DB_WRITE_CHUNK_SIZE,
@@ -50,6 +51,7 @@ export class BatchClassificationProcessor extends WorkerHost {
       triggeredBy?: string;
       projectCount?: number;
       maxProjects?: number;
+      projectIds?: string[];
       batchIds?: string[];
       totalProjects?: number;
       batchId?: string;
@@ -68,18 +70,36 @@ export class BatchClassificationProcessor extends WorkerHost {
   }
 
   /**
-   * Step 1: Collect unclassified projects (paginated), build batch requests, submit to Anthropic.
+   * Step 1: Collect unclassified projects, build batch requests, submit to Anthropic.
+   * If there are more projects than MAX_PROJECTS_PER_SUBMIT, enqueue additional submit jobs.
    */
-  private async handleSubmit(job: Job<{ triggeredBy?: string; projectCount?: number; maxProjects?: number }>) {
-    const { maxProjects } = job.data;
+  private async handleSubmit(
+    job: Job<{ triggeredBy?: string; projectCount?: number; maxProjects?: number; projectIds?: string[] }>,
+  ) {
+    const { maxProjects, projectIds } = job.data;
     this.logger.log(
       `Batch classification submit triggered (${job.data.triggeredBy ?? "unknown"}, ~${job.data.projectCount ?? "?"} projects${maxProjects ? `, limit: ${maxProjects}` : ""})`,
     );
 
     try {
-      // Collect unclassified projects with pagination to avoid loading 80k+ rows in RAM
-      const allUnclassified = await this.fetchUnclassifiedProjects();
-      const unclassified = maxProjects ? allUnclassified.slice(0, maxProjects) : allUnclassified;
+      // Collect projects to classify: either specific IDs or all unclassified
+      const allUnclassified = projectIds
+        ? await this.fetchProjectsByIds(projectIds)
+        : await this.fetchUnclassifiedProjects();
+
+      const limit = maxProjects ?? MAX_PROJECTS_PER_SUBMIT;
+      const unclassified = allUnclassified.slice(0, limit);
+
+      // If there are more projects, enqueue another submit job for the rest
+      if (allUnclassified.length > limit) {
+        const remainingIds = allUnclassified.slice(limit).map((p) => p.id);
+        await this.batchQueue.add(BATCH_SUBMIT_JOB, {
+          triggeredBy: "continuation",
+          projectCount: remainingIds.length,
+          projectIds: remainingIds,
+        });
+        this.logger.log(`${remainingIds.length} remaining projects scheduled in follow-up job`);
+      }
 
       if (unclassified.length === 0) {
         this.logger.log("No unclassified projects found, skipping batch");
@@ -342,6 +362,26 @@ export class BatchClassificationProcessor extends WorkerHost {
     }
 
     return allProjects;
+  }
+
+  /**
+   * Fetch specific projects by IDs (for bulk-triggered jobs that pass their own IDs).
+   */
+  private async fetchProjectsByIds(ids: string[]): Promise<ProjectForClassification[]> {
+    const allProjects: ProjectForClassification[] = [];
+    const chunks = this.chunkArray(ids, SELECT_PAGE_SIZE);
+
+    for (const chunk of chunks) {
+      const page = await this.dbService.database
+        .select({ id: projets.id, nom: projets.nom, description: projets.description })
+        .from(projets)
+        .where(inArray(projets.id, chunk));
+
+      allProjects.push(...page);
+    }
+
+    // Only return those still needing classification
+    return allProjects.filter((p) => p.nom || p.description);
   }
 
   /**

--- a/api/src/projets/services/create-projets/create-projets.service.ts
+++ b/api/src/projets/services/create-projets/create-projets.service.ts
@@ -59,10 +59,11 @@ export class CreateProjetsService {
       allIds.push(...ids);
     }
 
-    // Trigger batch classification for newly inserted projects
+    // Trigger batch classification for newly inserted projects (pass IDs to avoid classifying everything)
     await this.batchClassificationQueue.add("submit", {
       triggeredBy: "bulk",
       projectCount: allIds.length,
+      projectIds: allIds,
     });
 
     this.logger.log(`Bulk insert complete: ${allIds.length} projects, batch classification scheduled`);


### PR DESCRIPTION
## Problème

Le submit job chargeait **tous** les projets non classifiés (46k+), construisait 99 999 requêtes en mémoire (~300MB) → **OOM → restart en boucle** sur Scalingo.

Visible dans les logs :
```
Submitting batch 1/2 with 99999 requests (33333 projects)
[App restart]
Submitting batch 1/2 with 99999 requests (33333 projects)
[App restart]
...
```

## Fix

1. **`MAX_PROJECTS_PER_SUBMIT = 5000`** — cap le nombre de projets par job submit (= 15 000 requêtes, ~50MB)
2. **Continuation automatique** — si > 5000 projets, enqueue un job submit supplémentaire avec les IDs restants
3. **Le bulk passe ses `projectIds`** — au lieu de classifier tous les non-classifiés de la base, ne traite que les projets du bulk
4. **`fetchProjectsByIds()`** — nouvelle méthode pour charger uniquement les projets concernés

## Impact

Après déploiement :
- Les jobs OOM en boucle arrêteront de crasher (plus de 33k projets chargés)
- Il faudra **purger les jobs stale** dans Bull Board (queue `batch-classification`, onglet Failed)
- Puis relancer la classification via `POST /management/batch-classify?limit=5000`