### PR TITLE
fix(api): augmenter limite body /projets/bulk de 2MB à 50MB

### DIFF
--- a/api/src/setup-app.ts
+++ b/api/src/setup-app.ts
@@ -18,8 +18,8 @@ export function setupApp(app: INestApplication) {
 
   app.useLogger(logger);
 
-  // could not find a satisfying way to handle this through middleware
-  app.use("/projets/bulk", json({ limit: "2mb" }));
+  // Bulk endpoint accepts large payloads (80k+ projects from MEC CRTE)
+  app.use("/projets/bulk", json({ limit: "50mb" }));
   app.use(json({ limit: "100kb" }));
 
   app.useGlobalFilters(new GlobalExceptionFilter(logger));


### PR DESCRIPTION
Les 500 de MEC étaient causées par un body > 2MB. Le chunking serveur gère la mémoire, la limite body ne sert qu'à accepter le payload HTTP.