### PR TITLE
fix(api): budget_previsionnel bigint + body limit 50MB

### DIFF
--- a/api/drizzle/0037_budget_previsionnel_bigint.sql
+++ b/api/drizzle/0037_budget_previsionnel_bigint.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "projets" ALTER COLUMN "budget_previsionnel" SET DATA TYPE bigint;

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -1,4 +1,5 @@
 import {
+  bigint,
   boolean,
   index,
   integer,
@@ -40,7 +41,7 @@ export const projets = pgTable("projets", {
 
   nom: text("nom").notNull(),
   description: text("description"),
-  budgetPrevisionnel: integer("budget_previsionnel"),
+  budgetPrevisionnel: bigint("budget_previsionnel", { mode: "number" }),
   dateDebutPrevisionnelle: text("date_debut_previsionnelle"),
   phase: projetPhasesEnum(),
   phaseStatut: phaseStatutEnum(),


### PR DESCRIPTION
## Fixes pour l'ingestion MEC CRTE

1. **budget_previsionnel integer → bigint** : MEC envoie des valeurs > 2.1 milliards (ex: centimes). Migration SQL déjà appliquée sur prod et staging.
2. **Body limit /projets/bulk : 2MB → 50MB** : les requêtes > 2MB de MEC recevaient des 500.

Note : la migration Drizzle est dans le fichier SQL pour documentation, elle a été appliquée manuellement.