### PR TITLE
feat(api): endpoint recover pour récupérer les résultats batch Anthropic

### DIFF
--- a/api/src/batch-classification/batch-classification.controller.ts
+++ b/api/src/batch-classification/batch-classification.controller.ts
@@ -1,9 +1,9 @@
-import { Controller, Post, Query, UseGuards } from "@nestjs/common";
+import { Controller, Post, Body, Query, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
 import { InjectQueue } from "@nestjs/bullmq";
 import { Queue } from "bullmq";
-import { BATCH_CLASSIFICATION_QUEUE_NAME, BATCH_SUBMIT_JOB } from "./batch-classification.const";
+import { BATCH_CLASSIFICATION_QUEUE_NAME, BATCH_SUBMIT_JOB, BATCH_PROCESS_JOB } from "./batch-classification.const";
 
 @ApiBearerAuth()
 @ApiTags("Management")
@@ -30,6 +30,25 @@ export class BatchClassificationController {
     return {
       message: `Batch classification scheduled${maxProjects ? ` (limit: ${maxProjects})` : ""}`,
       queue: BATCH_CLASSIFICATION_QUEUE_NAME,
+    };
+  }
+
+  @Post("batch-classify/recover")
+  @ApiOperation({
+    summary: "Récupérer les résultats de batches Anthropic déjà terminés",
+    description:
+      "Enqueue un job 'process' pour chaque batch ID fourni. Utile si les jobs poll/process ont été supprimés mais que les batches ont terminé côté Anthropic.",
+  })
+  async recoverBatchResults(@Body() body: { batchIds: string[] }) {
+    const { batchIds } = body;
+
+    for (const batchId of batchIds) {
+      await this.batchQueue.add(BATCH_PROCESS_JOB, { batchId });
+    }
+
+    return {
+      message: `${batchIds.length} process jobs enqueued`,
+      batchIds,
     };
   }
 }


### PR DESCRIPTION
Endpoint POST /management/batch-classify/recover — prend des batch IDs et enqueue des jobs process pour écrire les résultats en DB.