### PR TITLE
fix(api): hotfix CSP — débloquer Matomo et Google Fonts

### DIFF
--- a/api/src/matomo/matomo.service.ts
+++ b/api/src/matomo/matomo.service.ts
@@ -1,5 +1,6 @@
 import { Injectable, Logger } from "@nestjs/common";
 import { ConfigService } from "@nestjs/config";
+import { createHash } from "node:crypto";
 
 /**
  * Service for generating Matomo analytics tracking scripts.
@@ -10,6 +11,7 @@ export class MatomoService {
   private readonly logger = new Logger(MatomoService.name);
   private readonly matomoScript: string;
   private readonly inlineScript: string;
+  private readonly inlineScriptCspHash: string;
   private readonly isEnabled: boolean;
 
   constructor(private readonly configService: ConfigService) {
@@ -22,6 +24,7 @@ export class MatomoService {
       this.logger.warn("MATOMO_RESSOURCES_SITE_ID not configured - analytics disabled for static pages");
       this.matomoScript = "";
       this.inlineScript = "";
+      this.inlineScriptCspHash = "";
       return;
     }
 
@@ -45,9 +48,7 @@ _paq.push(['enableLinkTracking']);
   g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
 })();`;
 
-    this.matomoScript = `
-<!-- Matomo Analytics (CNIL exempt - no cookies, opt-out supported) -->
-<script>
+    const injectedScriptBody = `
   var _paq = window._paq = window._paq || [];
   _paq.push(['disableCookies']);
   if (localStorage.getItem('matomo-opt-out') === 'true') {
@@ -62,10 +63,27 @@ _paq.push(['enableLinkTracking']);
     var d=document, g=d.createElement('script'), s=d.getElementsByTagName('script')[0];
     g.async=true; g.src=u+'matomo.js'; s.parentNode.insertBefore(g,s);
   })();
-</script>
+`;
+
+    this.matomoScript = `
+<!-- Matomo Analytics (CNIL exempt - no cookies, opt-out supported) -->
+<script>${injectedScriptBody}</script>
 <!-- End Matomo Analytics -->`;
 
+    const digest = createHash("sha256").update(injectedScriptBody, "utf8").digest("base64");
+    this.inlineScriptCspHash = `'sha256-${digest}'`;
+
     this.logger.log(`Matomo analytics enabled with site ID: ${siteId} (cookies disabled for CNIL compliance)`);
+  }
+
+  /**
+   * Returns the CSP script-src hash source for the injected Matomo inline script,
+   * e.g. "'sha256-xxxx='". Empty string when Matomo is disabled.
+   * Use this to build a strict CSP that whitelists the inline tag without
+   * falling back to 'unsafe-inline'.
+   */
+  getInlineScriptCspHash(): string {
+    return this.inlineScriptCspHash;
   }
 
   /**

--- a/api/src/matomo/serve-static-with-matomo.ts
+++ b/api/src/matomo/serve-static-with-matomo.ts
@@ -18,16 +18,21 @@ interface ServeStaticOptions {
 }
 
 const MATOMO_ORIGIN = "https://stats.beta.gouv.fr";
+const GOOGLE_FONTS_CSS = "https://fonts.googleapis.com";
+const GOOGLE_FONTS_FILES = "https://fonts.gstatic.com";
 
-// CSP allows DSFR inline styles (required by @codegouvfr/react-dsfr) and
-// connections to Matomo + this API. Scripts are restricted to 'self' + Matomo.
-const SECURITY_HEADERS: Record<string, string> = {
+// CSP allows DSFR inline styles (required by @codegouvfr/react-dsfr), Marianne
+// webfont from Google Fonts (loaded by the statistics-dashboard index.html),
+// and connections to Matomo. The Matomo inline pageview script is whitelisted
+// via its SHA-256 hash (computed at runtime by MatomoService) to avoid
+// falling back to 'unsafe-inline'.
+const buildSecurityHeaders = (matomoInlineScriptHash: string): Record<string, string> => ({
   "Content-Security-Policy": [
     "default-src 'self'",
-    `script-src 'self' ${MATOMO_ORIGIN}`,
-    "style-src 'self' 'unsafe-inline'",
+    `script-src 'self' ${MATOMO_ORIGIN} ${matomoInlineScriptHash}`.trim(),
+    `style-src 'self' 'unsafe-inline' ${GOOGLE_FONTS_CSS}`,
     "img-src 'self' data: https:",
-    "font-src 'self' data:",
+    `font-src 'self' data: ${GOOGLE_FONTS_FILES}`,
     `connect-src 'self' ${MATOMO_ORIGIN}`,
     "frame-ancestors 'none'",
     "base-uri 'self'",
@@ -38,7 +43,7 @@ const SECURITY_HEADERS: Record<string, string> = {
   "X-Content-Type-Options": "nosniff",
   "Referrer-Policy": "strict-origin-when-cross-origin",
   "Strict-Transport-Security": "max-age=63072000; includeSubDomains; preload",
-};
+});
 
 /**
  * Serves static files with Matomo injection for HTML pages.
@@ -80,7 +85,8 @@ export const serveStaticWithMatomo = (
       }
 
       const htmlWithMatomo = matomoService.injectIntoHtml(html);
-      for (const [header, value] of Object.entries(SECURITY_HEADERS)) {
+      const headers = buildSecurityHeaders(matomoService.getInlineScriptCspHash());
+      for (const [header, value] of Object.entries(headers)) {
         res.setHeader(header, value);
       }
       res.type("html").send(htmlWithMatomo);


### PR DESCRIPTION
## Contexte

Après déploiement de la PR #429 en prod, deux erreurs CSP observées au navigateur :

1. `/statistics/` charge la police **Marianne** depuis `fonts.googleapis.com` → bloqué (fallback sur font système)
2. `/statistics/` ET `/sandbox/` injectent un script Matomo inline pour le pageview → bloqué

Testé via Playwright :
```
[ERROR] Loading the stylesheet 'https://fonts.googleapis.com/css2?family=Marianne...' violates the following CSP directive: "style-src 'self' 'unsafe-inline'"
[ERROR] Executing inline script violates the following CSP directive 'script-src 'self' https://stats.beta.gouv.fr'
```

Le widget sandbox reste fonctionnel (42 trackEvent en 201) car ses appels passent par `POST /analytics/trackEvent`, pas par le script Matomo inline. Mais le pageview tracking Matomo est cassé sur les deux pages servies par l'API.

## Fix

- `style-src` : ajout de `https://fonts.googleapis.com`
- `font-src` : ajout de `https://fonts.gstatic.com`
- `script-src` : ajout du **hash SHA-256** du script Matomo inline, calculé au runtime par `MatomoService` (plutôt que `'unsafe-inline'` qui annulerait le bénéfice du CSP)

Le hash est dérivé du contenu exact du script injecté. Il reste stable tant que le script Matomo ne change pas — toute modif du script (ajout de paramètres, changement de siteId via env) régénère automatiquement le hash correct.

## Test plan

- [ ] CI verte
- [ ] Après deploy : rouvrir `/statistics/` → Marianne chargée, console sans erreur CSP
- [ ] Rouvrir `/sandbox/` → console sans erreur CSP, 42+ trackEvent en 201
- [ ] `curl -D - https://api.collectivites.beta.gouv.fr/statistics/` → le CSP contient bien `'sha256-...'` sur script-src