### PR TITLE
feat(api): endpoints dashboard-te (schema_commun_v2 + snapshot_crte)

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -28,6 +28,7 @@ import { HealthController } from "@/health/health.controller";
 import { PlansFichesModule } from "@/plans-fiches/plans-fiches.module";
 import { ProjetsV2Module } from "@/projets-v2/projets-v2.module";
 import { BatchClassificationModule } from "@/batch-classification/batch-classification.module";
+import { DashboardTeModule } from "@/dashboard-te/dashboard-te.module";
 
 @Module({
   imports: [
@@ -80,6 +81,7 @@ import { BatchClassificationModule } from "@/batch-classification/batch-classifi
     PlansFichesModule,
     ProjetsV2Module,
     BatchClassificationModule,
+    DashboardTeModule,
   ],
   controllers: [HealthController],
   providers: [AppService, ThrottlerGuardProvider, RequestLoggingInterceptor],

--- a/api/src/auth/api-key-guard.ts
+++ b/api/src/auth/api-key-guard.ts
@@ -29,6 +29,7 @@ export class ApiKeyGuard implements CanActivate {
       [this.configService.get<string>("URBAN_VITALIZ_API_KEY")!]: "UrbanVitaliz",
       [this.configService.get<string>("SOS_PONTS_API_KEY")!]: "SosPonts",
       [this.configService.get<string>("FOND_VERT_API_KEY")!]: "FondVert",
+      [this.configService.get<string>("DASHBOARD_TE_API_KEY")!]: "DashboardTE",
     };
   }
 

--- a/api/src/dashboard-te/dashboard-te.controller.ts
+++ b/api/src/dashboard-te/dashboard-te.controller.ts
@@ -1,0 +1,154 @@
+import { Controller, Get, NotFoundException, Param, Query, UseGuards } from "@nestjs/common";
+import { ApiTags } from "@nestjs/swagger";
+import { ApiKeyGuard } from "@/auth/api-key-guard";
+import { DashboardTeService } from "./dashboard-te.service";
+
+const toInt = (v: string | undefined, def: number) => {
+  const n = v == null ? NaN : Number(v);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : def;
+};
+
+@ApiTags("Dashboard TE")
+@Controller("dashboard-te")
+@UseGuards(ApiKeyGuard)
+export class DashboardTeController {
+  constructor(private readonly svc: DashboardTeService) {}
+
+  @Get("stats/national")
+  statsNational() {
+    return this.svc.statsNational();
+  }
+
+  @Get("collectivites")
+  collectivites(
+    @Query("region") region?: string,
+    @Query("departement") departement?: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+  ) {
+    return this.svc
+      .collectivites({
+        region,
+        departement,
+        page: toInt(page, 0),
+        limit: Math.min(toInt(limit, 50), 200),
+      })
+      .then((items) => ({ items, page: toInt(page, 0), limit: Math.min(toInt(limit, 50), 200) }));
+  }
+
+  @Get("collectivites/:siren")
+  collectivite(@Param("siren") siren: string) {
+    return this.svc.collectivite(siren);
+  }
+
+  @Get("projets")
+  async projets(
+    @Query("commune") commune?: string,
+    @Query("q") q?: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const items = await this.svc.projets({
+      commune,
+      q,
+      page: toInt(page, 0),
+      limit: Math.min(toInt(limit, 50), 200),
+    });
+    return { items, page: toInt(page, 0), limit: Math.min(toInt(limit, 50), 200) };
+  }
+
+  @Get("fiches")
+  async fiches(
+    @Query("plan") plan?: string,
+    @Query("commune") commune?: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const items = await this.svc.fiches({
+      plan,
+      commune,
+      page: toInt(page, 0),
+      limit: Math.min(toInt(limit, 50), 200),
+    });
+    return { items, page: toInt(page, 0), limit: Math.min(toInt(limit, 50), 200) };
+  }
+
+  @Get("plans")
+  async plans(
+    @Query("siren") siren?: string,
+    @Query("crte") crte?: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const items = await this.svc.plans({
+      siren,
+      crte,
+      page: toInt(page, 0),
+      limit: Math.min(toInt(limit, 50), 200),
+    });
+    return { items, page: toInt(page, 0), limit: Math.min(toInt(limit, 50), 200) };
+  }
+
+  @Get("plans/:id")
+  async plan(@Param("id") id: string) {
+    const plan = await this.svc.plan(id);
+    if (!plan) throw new NotFoundException("plan not found");
+    return plan;
+  }
+
+  @Get("plans/:id/communes")
+  async planCommunes(@Param("id") id: string) {
+    const items = await this.svc.planCommunes(id);
+    return { items };
+  }
+
+  @Get("plans/:id/groupements")
+  async planGroupements(@Param("id") id: string) {
+    const items = await this.svc.planGroupements(id);
+    return { items };
+  }
+
+  @Get("clusters")
+  async clusters(
+    @Query("confidence") confidence?: string,
+    @Query("page") page?: string,
+    @Query("limit") limit?: string,
+  ) {
+    const items = await this.svc.clusters({
+      confidence,
+      page: toInt(page, 0),
+      limit: Math.min(toInt(limit, 50), 200),
+    });
+    return { items, page: toInt(page, 0), limit: Math.min(toInt(limit, 50), 200) };
+  }
+
+  @Get("clusters/:id")
+  async cluster(@Param("id") id: string) {
+    const cluster = await this.svc.cluster(id);
+    if (!cluster) throw new NotFoundException("cluster not found");
+    return cluster;
+  }
+
+  @Get("crte")
+  async crteList(
+    @Query("region") region?: string,
+    @Query("departement") departement?: string,
+    @Query("siren") siren?: string,
+  ) {
+    const items = await this.svc.crteList({ region, departement, siren });
+    return { items };
+  }
+
+  @Get("crte/:id")
+  async crte(@Param("id") id: string) {
+    const crte = await this.svc.crte(id);
+    if (!crte) throw new NotFoundException("crte not found");
+    return crte;
+  }
+
+  @Get("communes/:insee/plans")
+  async communePlans(@Param("insee") insee: string) {
+    const items = await this.svc.communePlans(insee);
+    return { items };
+  }
+}

--- a/api/src/dashboard-te/dashboard-te.module.ts
+++ b/api/src/dashboard-te/dashboard-te.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { DashboardTeController } from "./dashboard-te.controller";
+import { DashboardTeService } from "./dashboard-te.service";
+import { DatabaseModule } from "@database/database.module";
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [DashboardTeController],
+  providers: [DashboardTeService],
+})
+export class DashboardTeModule {}

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -1,0 +1,221 @@
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "@database/database.service";
+import { sql } from "drizzle-orm";
+
+// Dashboard TE API — raw SQL queries against schema_commun_v2 + snapshot_crte + api_referentiel.
+// Called by the dashboard-te Cloudflare Worker (static SPA proxy) via API key.
+
+type Row = Record<string, unknown>;
+
+@Injectable()
+export class DashboardTeService {
+  constructor(private readonly db: DatabaseService) {}
+
+  private async query<T = Row>(q: ReturnType<typeof sql>): Promise<T[]> {
+    const result = await this.db.database.execute(q);
+    return result.rows as T[];
+  }
+
+  async statsNational() {
+    const [row] = await this.query(sql`
+      SELECT
+        (SELECT count(*) FROM schema_commun_v2.projets_operationnels) AS projets,
+        (SELECT count(*) FROM schema_commun_v2.fiches_action) AS fiches,
+        (SELECT count(*) FROM schema_commun_v2.plans_transition) AS plans,
+        (SELECT count(*) FROM schema_commun_v2.clusters) AS clusters,
+        (SELECT count(*) FROM schema_commun_v2.clusters WHERE confiance='CERTAIN') AS clusters_certain,
+        (SELECT count(*) FROM schema_commun_v2.clusters WHERE confiance='PROBABLE') AS clusters_probable
+    `);
+    return row;
+  }
+
+  async collectivites(params: { region?: string; departement?: string; page: number; limit: number }) {
+    const { region, departement, page, limit } = params;
+    return this.query(sql`
+      SELECT siren, nom, type, code_insee, code_epci, code_departements, code_regions
+      FROM api_referentiel.communes
+      WHERE 1=1
+        ${departement ? sql`AND ${departement} = ANY(code_departements)` : sql``}
+        ${region ? sql`AND ${region} = ANY(code_regions)` : sql``}
+      ORDER BY nom
+      LIMIT ${limit} OFFSET ${page * limit}
+    `);
+  }
+
+  async collectivite(siren: string) {
+    const [commune] = await this.query(sql`SELECT * FROM api_referentiel.communes WHERE siren = ${siren} LIMIT 1`);
+    const [groupement] = await this.query(
+      sql`SELECT * FROM api_referentiel.groupements WHERE siren = ${siren} LIMIT 1`,
+    );
+    const projets = await this.query(sql`
+      SELECT id, nom, source_origine, "classificationThematiques" AS thematiques
+      FROM schema_commun_v2.projets_operationnels
+      WHERE "collectiviteResponsableSiren" = ${siren}
+      LIMIT 200
+    `);
+    const fiches = await this.query(sql`
+      SELECT id, nom, source_origine, "classificationThematiques" AS thematiques
+      FROM schema_commun_v2.fiches_action
+      WHERE "collectiviteResponsableSiren" = ${siren}
+      LIMIT 200
+    `);
+    return { siren, commune: commune ?? null, groupement: groupement ?? null, projets, fiches };
+  }
+
+  async projets(params: { commune?: string; q?: string; page: number; limit: number }) {
+    const { commune, q, page, limit } = params;
+    const pattern = q ? `%${q}%` : null;
+    return this.query(sql`
+      SELECT DISTINCT p.id, p.nom, p.source_origine, p."collectiviteResponsableSiren" AS siren
+      FROM schema_commun_v2.projets_operationnels p
+      ${
+        commune
+          ? sql`JOIN schema_commun_v2.liens_projets_communes lpc ON lpc.projet_id = p.id WHERE lpc.insee_com = ${commune}`
+          : pattern
+            ? sql`WHERE p.nom ILIKE ${pattern}`
+            : sql``
+      }
+      ${commune && pattern ? sql`AND p.nom ILIKE ${pattern}` : sql``}
+      ORDER BY p.nom
+      LIMIT ${limit} OFFSET ${page * limit}
+    `);
+  }
+
+  async fiches(params: { plan?: string; commune?: string; page: number; limit: number }) {
+    const { plan, commune, page, limit } = params;
+    return this.query(sql`
+      SELECT DISTINCT f.id, f.nom, f.source_origine, f."collectiviteResponsableSiren" AS siren
+      FROM schema_commun_v2.fiches_action f
+      ${
+        plan
+          ? sql`JOIN schema_commun_v2.liens_plans_fiches lpf ON lpf.fiche_action_id = f.id WHERE lpf.plan_id = ${plan}`
+          : commune
+            ? sql`WHERE f."collectiviteResponsableSiren" IN (SELECT siren FROM api_referentiel.communes WHERE code_insee = ${commune})`
+            : sql``
+      }
+      ORDER BY f.nom
+      LIMIT ${limit} OFFSET ${page * limit}
+    `);
+  }
+
+  async plans(params: { siren?: string; crte?: string; page: number; limit: number }) {
+    const { siren, crte, page, limit } = params;
+    return this.query(sql`
+      SELECT id, nom, type, "collectiviteResponsableSiren" AS siren, source, id_crte
+      FROM schema_commun_v2.plans_transition
+      WHERE 1=1
+        ${siren ? sql`AND "collectiviteResponsableSiren" = ${siren}` : sql``}
+        ${crte ? sql`AND id_crte = ${crte}` : sql``}
+      ORDER BY nom
+      LIMIT ${limit} OFFSET ${page * limit}
+    `);
+  }
+
+  async plan(id: string) {
+    const [plan] = await this.query(sql`
+      SELECT p.*, c.lib_crte AS crte_nom, c.date_signature AS crte_date_signature
+      FROM schema_commun_v2.plans_transition p
+      LEFT JOIN snapshot_crte.contrats c ON c.id_crte = p.id_crte
+      WHERE p.id = ${id}
+      LIMIT 1
+    `);
+    if (!plan) return null;
+    const [{ count }] = await this.query<{ count: string }>(sql`
+      SELECT count(*) FROM schema_commun_v2.liens_plans_fiches WHERE plan_id = ${id}
+    `);
+    return { ...plan, fiches_count: Number(count) };
+  }
+
+  planCommunes(id: string) {
+    return this.query(sql`
+      SELECT ar.code_insee, ar.nom, ar.code_departements, ar.code_regions
+      FROM schema_commun_v2.liens_plans_communes lpc
+      JOIN api_referentiel.communes ar ON ar.code_insee = lpc.insee_com
+      WHERE lpc.plan_id = ${id}
+      ORDER BY ar.nom
+    `);
+  }
+
+  planGroupements(id: string) {
+    return this.query(sql`
+      SELECT ar.siren, ar.nom, ar.nature_juridique
+      FROM schema_commun_v2.liens_plans_groupements lpg
+      JOIN api_referentiel.groupements ar ON ar.siren = lpg.siren_groupement
+      WHERE lpg.plan_id = ${id}
+      ORDER BY ar.nom
+    `);
+  }
+
+  clusters(params: { confidence?: string; page: number; limit: number }) {
+    const { confidence, page, limit } = params;
+    return this.query(sql`
+      SELECT id, confiance, taille
+      FROM schema_commun_v2.clusters
+      ${confidence ? sql`WHERE confiance = ${confidence}` : sql``}
+      ORDER BY taille DESC, id
+      LIMIT ${limit} OFFSET ${page * limit}
+    `);
+  }
+
+  async cluster(id: string) {
+    const [cluster] = await this.query(
+      sql`SELECT id, confiance, taille FROM schema_commun_v2.clusters WHERE id = ${id} LIMIT 1`,
+    );
+    if (!cluster) return null;
+    const projets = await this.query(sql`
+      SELECT p.id, p.nom, p.source_origine, p."collectiviteResponsableSiren" AS siren
+      FROM schema_commun_v2.clusters_membres cm
+      JOIN schema_commun_v2.projets_operationnels p ON p.id = cm.projet_id
+      WHERE cm.cluster_id = ${id}
+    `);
+    const fiches = await this.query(sql`
+      SELECT f.id, f.nom, f.source_origine, f."collectiviteResponsableSiren" AS siren
+      FROM schema_commun_v2.clusters_membres cm
+      JOIN schema_commun_v2.fiches_action f ON f.id = cm.fiche_action_id
+      WHERE cm.cluster_id = ${id}
+    `);
+    return { ...cluster, projets, fiches };
+  }
+
+  async crte(id: string) {
+    const [c] = await this.query(sql`SELECT * FROM snapshot_crte.contrats WHERE id_crte = ${id} LIMIT 1`);
+    if (!c) return null;
+    const groupements = await this.query(sql`
+      SELECT siren_groupement, lib_groupement, nature_juridique, lib_reg, lib_dep
+      FROM snapshot_crte.groupements WHERE id_crte = ${id}
+    `);
+    const communes = await this.query(sql`
+      SELECT insee_com, lib_com FROM snapshot_crte.communes WHERE id_crte = ${id}
+    `);
+    return { ...c, groupements, communes };
+  }
+
+  crteList(params: { region?: string; departement?: string; siren?: string }) {
+    const { region, departement, siren } = params;
+    const useJoin = Boolean(region ?? departement ?? siren);
+    return this.query(sql`
+      SELECT DISTINCT c.id_crte, c.lib_crte, c.date_signature
+      FROM snapshot_crte.contrats c
+      ${
+        useJoin
+          ? sql`LEFT JOIN snapshot_crte.groupements g ON g.id_crte = c.id_crte WHERE 1=1
+        ${region ? sql`AND g.insee_reg = ${region}` : sql``}
+        ${departement ? sql`AND g.dep_chef_file = ${departement}` : sql``}
+        ${siren ? sql`AND g.siren_groupement = ${siren}` : sql``}
+      `
+          : sql``
+      }
+      ORDER BY c.lib_crte
+      LIMIT 200
+    `);
+  }
+
+  communePlans(insee: string) {
+    return this.query(sql`
+      SELECT p.id, p.nom, p.type, p.source, p.id_crte
+      FROM schema_commun_v2.liens_plans_communes lpc
+      JOIN schema_commun_v2.plans_transition p ON p.id = lpc.plan_id
+      WHERE lpc.insee_com = ${insee}
+    `);
+  }
+}

--- a/api/src/shared/types.ts
+++ b/api/src/shared/types.ts
@@ -1,7 +1,7 @@
 import { leviers } from "@/shared/const/leviers";
 import { competenceCodes, competencesFromM57Referentials } from "@/shared/const/competences-list";
 
-export type ServiceType = "MEC" | "TeT" | "Recoco" | "UrbanVitaliz" | "SosPonts" | "FondVert";
+export type ServiceType = "MEC" | "TeT" | "Recoco" | "UrbanVitaliz" | "SosPonts" | "FondVert" | "DashboardTE";
 export type ServiceTypeIds = "mecId" | "tetId" | "recocoId" | "urbanVitalizId" | "sosPontsId" | "fondVertId";
 
 export type CompetenceCode = (typeof competenceCodes)[number];


### PR DESCRIPTION
## Contexte

Le dashboard TE externe (repo `dashboard-te`, déployé sur Cloudflare Workers) a besoin d'exposer les données agrégées du `schema_commun_v2` (157k projets + 81k fiches + 3k plans + 20k clusters). Pour éviter d'exposer la DB Postgres directement à internet (reco Scalingo), l'API REST est ajoutée comme module NestJS dans l'app API Collectivités existante.

## Architecture

```
[Browser] → [CF Worker dashboard-te] → [API Collectivités /dashboard-te/*] → [Postgres private network]
               ↓ Turnstile + JWT                  ↓ ApiKeyGuard (bearer)
```

Le Worker proxifie `/api/*` vers `/dashboard-te/*` en injectant `Authorization: Bearer <DASHBOARD_TE_API_KEY>` côté serveur (jamais exposé au browser).

## Changements

- Nouveau module `DashboardTeModule` avec controller + service
- Raw SQL via Drizzle pool (schemas : `schema_commun_v2`, `snapshot_crte`, `api_referentiel`) — pas de modélisation exhaustive, cette API est read-only
- `ApiKeyGuard` : ajout `DASHBOARD_TE_API_KEY` → `ServiceType "DashboardTE"`

## Endpoints

- `GET /dashboard-te/stats/national` — totaux projets/fiches/plans/clusters
- `GET /dashboard-te/collectivites[/:siren]` — liste + détails commune/groupement
- `GET /dashboard-te/projets|fiches|plans` — filtres + pagination
- `GET /dashboard-te/plans/:id[/communes|/groupements]` — enrichi CRTE (nom, date signature)
- `GET /dashboard-te/clusters[/:id]` — membres projets + fiches
- `GET /dashboard-te/crte[/:id]` — détails CRTE + liste EPCI/communes
- `GET /dashboard-te/communes/:insee/plans` — reverse lookup

## Variable env à ajouter sur Scalingo

`DASHBOARD_TE_API_KEY=<valeur à venir en prod>` — bearer attendu dans `Authorization` sur tous les endpoints `/dashboard-te/*`.

## Test plan

- [ ] Merge + déploiement auto Scalingo
- [ ] `scalingo env-set DASHBOARD_TE_API_KEY=...` (la clé générée est dans le canal privé)
- [ ] `curl -H "Authorization: Bearer <key>" https://api.collectivites.beta.gouv.fr/dashboard-te/stats/national`
- [ ] Déploiement Worker `dashboard-te` (déjà prêt, config `wrangler.toml` pointe sur cet endpoint)