### PR TITLE
fix(api): /projets collectiviteNom — fallback groupements pour EPCI

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -357,7 +357,7 @@ export class DashboardTeService {
         p."phaseStatut",
         CAST(NULLIF(p."budgetPrevisionnel", '') AS numeric) AS "budgetPrevisionnel",
         p."collectiviteResponsableSiren" AS "collectiviteSiren",
-        cref.nom AS "collectiviteNom",
+        COALESCE(cref.nom, gref.nom) AS "collectiviteNom",
         cref.code_departement AS "codeDepartement",
         p."competencesM57",
         p."leviersSgpe",
@@ -368,6 +368,7 @@ export class DashboardTeService {
         c.confiance AS "clusterConfiance"
       FROM schema_commun_v2.projets_operationnels p
       LEFT JOIN api_referentiel.communes cref ON cref.siren = p."collectiviteResponsableSiren"
+      LEFT JOIN api_referentiel.groupements gref ON gref.siren = p."collectiviteResponsableSiren"
       ${needsCommuneJoin ? sql`JOIN schema_commun_v2.liens_projets_communes lpc ON lpc.projet_id = p.id` : sql``}
       ${departement ? sql`JOIN api_referentiel.communes ar ON ar.code_insee = lpc.insee_com` : sql``}
       LEFT JOIN schema_commun_v2.clusters_membres cm ON cm.projet_id = p.id


### PR DESCRIPTION
COALESCE communes.nom + groupements.nom. Sans ça, les EPCI (intercommunalités) affichaient leur SIREN brut dans les listes du dashboard V3.