### PR TITLE
fix(referentiel): metadata jsonb — corriger erreur 500 endpoint dispositifs

### DIFF
--- a/api/src/database/referentiel-schema.ts
+++ b/api/src/database/referentiel-schema.ts
@@ -1,4 +1,4 @@
-import { index, integer, pgSchema, primaryKey, text, varchar, date } from "drizzle-orm/pg-core";
+import { index, integer, jsonb, pgSchema, primaryKey, text, varchar, date } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 
 // ============================================================
@@ -110,7 +110,7 @@ export const dispositifsTerritoriaux = schemaCommunV2.table(
     statut: varchar("statut", { length: 50 }),
     referenceExterne: varchar("reference_externe", { length: 50 }),
     crteCode: varchar("crte_code", { length: 30 }),
-    metadata: text("metadata"),
+    metadata: jsonb("metadata"),
     source: varchar("source", { length: 100 }),
   },
   (t) => [index("idx_dispositifs_epci").on(t.epciSiren), index("idx_dispositifs_type").on(t.dispositif)],

--- a/api/src/database/referentiel-schema.ts
+++ b/api/src/database/referentiel-schema.ts
@@ -95,6 +95,28 @@ export const refGroupementCompetences = apiReferentielSchema.table(
 );
 
 // ============================================================
+// Schema: schema_commun_v2 — Dashboard cross-source data
+// ============================================================
+
+export const schemaCommunV2 = pgSchema("schema_commun_v2");
+
+export const dispositifsTerritoriaux = schemaCommunV2.table(
+  "dispositifs_territoriaux",
+  {
+    id: integer("id").primaryKey(),
+    epciSiren: varchar("epci_siren", { length: 9 }).notNull(),
+    dispositif: varchar("dispositif", { length: 50 }).notNull(),
+    dateSignature: date("date_signature"),
+    statut: varchar("statut", { length: 50 }),
+    referenceExterne: varchar("reference_externe", { length: 50 }),
+    crteCode: varchar("crte_code", { length: 30 }),
+    metadata: text("metadata"),
+    source: varchar("source", { length: 100 }),
+  },
+  (t) => [index("idx_dispositifs_epci").on(t.epciSiren), index("idx_dispositifs_type").on(t.dispositif)],
+);
+
+// ============================================================
 // Relations
 // ============================================================
 

--- a/api/src/referentiel/dispositifs/dispositifs.controller.ts
+++ b/api/src/referentiel/dispositifs/dispositifs.controller.ts
@@ -1,0 +1,26 @@
+import { Controller, Get, Query } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { DispositifsService } from "./dispositifs.service";
+import { DispositifQueryDto } from "./dto/dispositif-query.dto";
+import { DispositifResponse, DispositifsDataResponse } from "./dto/dispositif.response";
+
+@Controller("referentiel/v1/dispositifs")
+@ApiTags("Référentiel - Dispositifs Territoriaux")
+export class DispositifsController {
+  constructor(private readonly dispositifsService: DispositifsService) {}
+
+  @Get()
+  @ApiOperation({ summary: "Liste des dispositifs territoriaux (COT, etc.)" })
+  @ApiEndpointResponses({ successStatus: 200, response: DispositifResponse, isArray: true })
+  search(@Query() query: DispositifQueryDto): Promise<DispositifResponse[]> {
+    return this.dispositifsService.search(query);
+  }
+
+  @Get("all")
+  @ApiOperation({ summary: "Tous les dispositifs avec stats agrégées" })
+  @ApiEndpointResponses({ successStatus: 200, response: DispositifsDataResponse })
+  getAll(): Promise<DispositifsDataResponse> {
+    return this.dispositifsService.getAll();
+  }
+}

--- a/api/src/referentiel/dispositifs/dispositifs.controller.ts
+++ b/api/src/referentiel/dispositifs/dispositifs.controller.ts
@@ -1,12 +1,14 @@
-import { Controller, Get, Query } from "@nestjs/common";
+import { Controller, Get, Query, UseGuards } from "@nestjs/common";
 import { ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { ApiKeyGuard } from "@/auth/api-key-guard";
 import { DispositifsService } from "./dispositifs.service";
 import { DispositifQueryDto } from "./dto/dispositif-query.dto";
 import { DispositifResponse, DispositifsDataResponse } from "./dto/dispositif.response";
 
 @Controller("referentiel/v1/dispositifs")
 @ApiTags("Référentiel - Dispositifs Territoriaux")
+@UseGuards(ApiKeyGuard)
 export class DispositifsController {
   constructor(private readonly dispositifsService: DispositifsService) {}
 

--- a/api/src/referentiel/dispositifs/dispositifs.service.ts
+++ b/api/src/referentiel/dispositifs/dispositifs.service.ts
@@ -1,0 +1,91 @@
+import { Injectable } from "@nestjs/common";
+import { eq, and, sql } from "drizzle-orm";
+import { DatabaseService } from "@database/database.service";
+import { dispositifsTerritoriaux, refGroupements } from "@database/schema";
+import { DispositifQueryDto } from "./dto/dispositif-query.dto";
+import { DispositifResponse, DispositifStatsResponse, DispositifsDataResponse } from "./dto/dispositif.response";
+
+@Injectable()
+export class DispositifsService {
+  constructor(private readonly dbService: DatabaseService) {}
+
+  async search(query: DispositifQueryDto): Promise<DispositifResponse[]> {
+    const conditions = [];
+    if (query.type) {
+      conditions.push(eq(dispositifsTerritoriaux.dispositif, query.type));
+    }
+    if (query.statut) {
+      conditions.push(eq(dispositifsTerritoriaux.statut, query.statut));
+    }
+    if (query.epciSiren) {
+      conditions.push(eq(dispositifsTerritoriaux.epciSiren, query.epciSiren));
+    }
+
+    const rows = await this.dbService.database
+      .select({
+        epciSiren: dispositifsTerritoriaux.epciSiren,
+        dispositif: dispositifsTerritoriaux.dispositif,
+        dateSignature: dispositifsTerritoriaux.dateSignature,
+        statut: dispositifsTerritoriaux.statut,
+        crteCode: dispositifsTerritoriaux.crteCode,
+        metadata: dispositifsTerritoriaux.metadata,
+        epciNomRef: refGroupements.nom,
+      })
+      .from(dispositifsTerritoriaux)
+      .leftJoin(refGroupements, eq(refGroupements.siren, dispositifsTerritoriaux.epciSiren))
+      .where(conditions.length > 0 ? and(...conditions) : undefined)
+      .orderBy(dispositifsTerritoriaux.dispositif, dispositifsTerritoriaux.epciSiren);
+
+    return rows.map((r) => {
+      const meta = (r.metadata ? JSON.parse(r.metadata) : {}) as Record<string, string | undefined>;
+      return {
+        epciSiren: r.epciSiren,
+        epciNom: r.epciNomRef ?? meta.epci_nom ?? "",
+        dispositif: r.dispositif,
+        dateSignature: r.dateSignature,
+        statut: r.statut ?? "",
+        crteCode: r.crteCode ?? null,
+        crteNom: meta.crte_nom ?? null,
+        region: meta.region ?? null,
+      };
+    });
+  }
+
+  async getAll(): Promise<DispositifsDataResponse> {
+    const dispositifs = await this.search({});
+
+    // Compute stats per type
+    const byType = new Map<string, DispositifResponse[]>();
+    for (const d of dispositifs) {
+      if (!byType.has(d.dispositif)) byType.set(d.dispositif, []);
+      byType.get(d.dispositif)!.push(d);
+    }
+
+    const stats: Record<string, DispositifStatsResponse> = {};
+    for (const [type, items] of byType) {
+      const parStatut: Record<string, number> = {};
+      for (const i of items) {
+        parStatut[i.statut] = (parStatut[i.statut] ?? 0) + 1;
+      }
+
+      const epciSirens = items.map((i) => i.epciSiren);
+      const countResult = await this.dbService.database.execute(
+        sql`SELECT
+          COUNT(*) FILTER (WHERE source_origine = 'MEC') as nb_mec,
+          COUNT(*) as nb_all
+        FROM schema_commun_v2.projets_operationnels
+        WHERE "collectiviteResponsableSiren" = ANY(${epciSirens})`,
+      );
+      const row = countResult.rows[0] as { nb_mec: string; nb_all: string } | undefined;
+
+      stats[type] = {
+        totalEpci: items.length,
+        nbProjetsMec: Number(row?.nb_mec ?? 0),
+        nbProjetsToutesSources: Number(row?.nb_all ?? 0),
+        parStatut,
+      };
+    }
+
+    return { dispositifs, stats };
+  }
+}

--- a/api/src/referentiel/dispositifs/dispositifs.service.ts
+++ b/api/src/referentiel/dispositifs/dispositifs.service.ts
@@ -37,7 +37,7 @@ export class DispositifsService {
       .orderBy(dispositifsTerritoriaux.dispositif, dispositifsTerritoriaux.epciSiren);
 
     return rows.map((r) => {
-      const meta = (r.metadata ? JSON.parse(r.metadata) : {}) as Record<string, string | undefined>;
+      const meta = (r.metadata ?? {}) as Record<string, string | undefined>;
       return {
         epciSiren: r.epciSiren,
         epciNom: r.epciNomRef ?? meta.epci_nom ?? "",

--- a/api/src/referentiel/dispositifs/dto/dispositif-query.dto.ts
+++ b/api/src/referentiel/dispositifs/dto/dispositif-query.dto.ts
@@ -1,0 +1,19 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsOptional, IsString } from "class-validator";
+
+export class DispositifQueryDto {
+  @ApiProperty({ required: false, description: "Type de dispositif (ex: COT)", example: "COT" })
+  @IsOptional()
+  @IsString()
+  type?: string;
+
+  @ApiProperty({ required: false, description: "Statut du dispositif", example: "Suivi du projet" })
+  @IsOptional()
+  @IsString()
+  statut?: string;
+
+  @ApiProperty({ required: false, description: "SIREN de l'EPCI" })
+  @IsOptional()
+  @IsString()
+  epciSiren?: string;
+}

--- a/api/src/referentiel/dispositifs/dto/dispositif.response.ts
+++ b/api/src/referentiel/dispositifs/dto/dispositif.response.ts
@@ -1,0 +1,49 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export class DispositifResponse {
+  @ApiProperty({ description: "SIREN de l'EPCI", example: "248400053" })
+  epciSiren!: string;
+
+  @ApiProperty({ description: "Nom de l'EPCI", example: "CA Ventoux-Comtat-Venaissin" })
+  epciNom!: string;
+
+  @ApiProperty({ description: "Type de dispositif", example: "COT" })
+  dispositif!: string;
+
+  @ApiProperty({ description: "Date de signature", example: "2020-11-12", nullable: true })
+  dateSignature!: string | null;
+
+  @ApiProperty({ description: "Statut du dispositif", example: "Suivi du projet" })
+  statut!: string;
+
+  @ApiProperty({ description: "Code CRTE rattaché", example: "crte-93-84-13", nullable: true })
+  crteCode!: string | null;
+
+  @ApiProperty({ description: "Nom du CRTE", example: "CRTE Ventoux-Comtat-Venaissin", nullable: true })
+  crteNom!: string | null;
+
+  @ApiProperty({ description: "Région", example: "Provence-Alpes-Côte d'Azur", nullable: true })
+  region!: string | null;
+}
+
+export class DispositifStatsResponse {
+  @ApiProperty({ description: "Nombre total d'EPCI" })
+  totalEpci!: number;
+
+  @ApiProperty({ description: "Nombre de projets MEC dans ces EPCI" })
+  nbProjetsMec!: number;
+
+  @ApiProperty({ description: "Nombre de projets toutes sources" })
+  nbProjetsToutesSources!: number;
+
+  @ApiProperty({ description: "Répartition par statut" })
+  parStatut!: Record<string, number>;
+}
+
+export class DispositifsDataResponse {
+  @ApiProperty({ type: [DispositifResponse] })
+  dispositifs!: DispositifResponse[];
+
+  @ApiProperty({ description: "Stats par type de dispositif" })
+  stats!: Record<string, DispositifStatsResponse>;
+}

--- a/api/src/referentiel/referentiel.module.ts
+++ b/api/src/referentiel/referentiel.module.ts
@@ -7,9 +7,17 @@ import { CompetencesController } from "./competences/competences.controller";
 import { CompetencesService } from "./competences/competences.service";
 import { RechercheController } from "./recherche/recherche.controller";
 import { RechercheService } from "./recherche/recherche.service";
+import { DispositifsController } from "./dispositifs/dispositifs.controller";
+import { DispositifsService } from "./dispositifs/dispositifs.service";
 
 @Module({
-  controllers: [CommunesController, GroupementsController, CompetencesController, RechercheController],
-  providers: [CommunesService, GroupementsService, CompetencesService, RechercheService],
+  controllers: [
+    CommunesController,
+    GroupementsController,
+    CompetencesController,
+    RechercheController,
+    DispositifsController,
+  ],
+  providers: [CommunesService, GroupementsService, CompetencesService, RechercheService, DispositifsService],
 })
 export class ReferentielModule {}


### PR DESCRIPTION
## Résumé

Corrige l'erreur 500 sur `GET /referentiel/v1/dispositifs`.

La colonne `metadata` est de type `jsonb` en base (pas `text`). Drizzle retourne directement un objet — le `JSON.parse()` dans le service provoquait le crash.

## Changements

- Schema Drizzle : `text("metadata")` → `jsonb("metadata")`
- Service : suppression du `JSON.parse()` inutile