### PR TITLE
fix(referentiel): metadata jsonb — corriger erreur 500 dispositifs

### DIFF
--- a/api/src/database/referentiel-schema.ts
+++ b/api/src/database/referentiel-schema.ts
@@ -1,4 +1,4 @@
-import { index, integer, pgSchema, primaryKey, text, varchar, date } from "drizzle-orm/pg-core";
+import { index, integer, jsonb, pgSchema, primaryKey, text, varchar, date } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 
 // ============================================================
@@ -110,7 +110,7 @@ export const dispositifsTerritoriaux = schemaCommunV2.table(
     statut: varchar("statut", { length: 50 }),
     referenceExterne: varchar("reference_externe", { length: 50 }),
     crteCode: varchar("crte_code", { length: 30 }),
-    metadata: text("metadata"),
+    metadata: jsonb("metadata"),
     source: varchar("source", { length: 100 }),
   },
   (t) => [index("idx_dispositifs_epci").on(t.epciSiren), index("idx_dispositifs_type").on(t.dispositif)],

--- a/api/src/referentiel/dispositifs/dispositifs.service.ts
+++ b/api/src/referentiel/dispositifs/dispositifs.service.ts
@@ -37,7 +37,7 @@ export class DispositifsService {
       .orderBy(dispositifsTerritoriaux.dispositif, dispositifsTerritoriaux.epciSiren);
 
     return rows.map((r) => {
-      const meta = (r.metadata ? JSON.parse(r.metadata) : {}) as Record<string, string | undefined>;
+      const meta = (r.metadata ?? {}) as Record<string, string | undefined>;
       return {
         epciSiren: r.epciSiren,
         epciNom: r.epciNomRef ?? meta.epci_nom ?? "",


### PR DESCRIPTION
Hotfix: la colonne metadata est jsonb en base, pas text. Supprime le JSON.parse inutile qui causait une erreur 500.