### PR TITLE
fix(dashboard-te): corriger ANY(array) pour stats dispositifs

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -746,7 +746,10 @@ export class DashboardTeService {
           COUNT(*) FILTER (WHERE source_origine = 'MEC') AS nb_mec,
           COUNT(*) AS nb_all
         FROM schema_commun_v2.projets_operationnels
-        WHERE "collectiviteResponsableSiren" = ANY(${epciSirens})
+        WHERE "collectiviteResponsableSiren" = ANY(${sql`ARRAY[${sql.join(
+          epciSirens.map((s) => sql`${s}`),
+          sql`, `,
+        )}]`})
       `);
 
       stats[type] = {


### PR DESCRIPTION
Fix erreur 500: Drizzle sql template ne sérialise pas les tableaux JS en array Postgres. Utilise ARRAY[...] avec sql.join.