### PR TITLE
feat(mec): endpoint dédié /mec/v1/projets + schema data_mec

### DIFF
--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -29,6 +29,7 @@ import { PlansFichesModule } from "@/plans-fiches/plans-fiches.module";
 import { ProjetsV2Module } from "@/projets-v2/projets-v2.module";
 import { BatchClassificationModule } from "@/batch-classification/batch-classification.module";
 import { DashboardTeModule } from "@/dashboard-te/dashboard-te.module";
+import { MecModule } from "@/mec/mec.module";
 
 @Module({
   imports: [
@@ -82,6 +83,7 @@ import { DashboardTeModule } from "@/dashboard-te/dashboard-te.module";
     ProjetsV2Module,
     BatchClassificationModule,
     DashboardTeModule,
+    MecModule,
   ],
   controllers: [HealthController],
   providers: [AppService, ThrottlerGuardProvider, RequestLoggingInterceptor],

--- a/api/src/database/mec-schema.ts
+++ b/api/src/database/mec-schema.ts
@@ -1,0 +1,170 @@
+import {
+  boolean,
+  doublePrecision,
+  index,
+  integer,
+  jsonb,
+  pgSchema,
+  primaryKey,
+  text,
+  timestamp,
+  uuid,
+} from "drizzle-orm/pg-core";
+import { relations } from "drizzle-orm";
+import { uuidv7 } from "uuidv7";
+
+// ============================================================
+// Schema: data_mec — Projets opérationnels from MEC ingestion
+// Aligned with schema v0.2.0 (projets-operationnels)
+// https://api-collectivites-roadmap.pages.dev/schema-commun-v0.2.0
+// ============================================================
+
+export const dataMecSchema = pgSchema("data_mec");
+
+// --- External IDs ---
+// Generic junction table for platform-specific identifiers.
+export const mecExternalIds = dataMecSchema.table(
+  "external_ids",
+  {
+    objetId: uuid("objet_id").notNull(),
+    serviceType: text("service_type").notNull(), // e.g. "MEC", "TeT", "FondsVert"
+    externalId: text("external_id").notNull(),
+  },
+  (t) => [
+    primaryKey({ columns: [t.objetId, t.serviceType] }),
+    index("mec_external_ids_external_idx").on(t.serviceType, t.externalId),
+  ],
+);
+
+// --- Plans de transition (schema v0.2 fields) ---
+export const mecPlansTransition = dataMecSchema.table(
+  "plans_transition",
+  {
+    id: uuid("id")
+      .primaryKey()
+      .$defaultFn(() => uuidv7()),
+
+    // Schema v0.2 fields
+    nom: text("nom"),
+    type: text("type"),
+    description: text("description"),
+    periodeDebut: text("periode_debut"),
+    periodeFin: text("periode_fin"),
+    collectiviteResponsableSiren: text("collectivite_responsable_siren"),
+    territoireCommunes: text("territoire_communes").array(),
+
+    // Lifecycle
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [index("mec_plans_siren_idx").on(t.collectiviteResponsableSiren)],
+);
+
+// --- Projets opérationnels (schema v0.2 + classification + CRTE + MEC-specific) ---
+export const mecProjetsOperationnels = dataMecSchema.table(
+  "projets_operationnels",
+  {
+    // ID preserved from public.projets — NO auto-generation
+    id: uuid("id").primaryKey(),
+
+    // Schema v0.2 fields
+    nom: text("nom").notNull(),
+    description: text("description"),
+    budgetPrevisionnel: integer("budget_previsionnel"),
+    dateDebut: text("date_debut"),
+    dateFin: text("date_fin"),
+    phase: text("phase"),
+    phaseStatut: text("phase_statut"),
+    collectiviteResponsableSiren: text("collectivite_responsable_siren"),
+    porteurOperationnelSiret: text("porteur_operationnel_siret"),
+    territoireCommunes: text("territoire_communes").array(),
+    competencesM57: text("competences_m57").array(),
+    leviersSgpe: text("leviers_sgpe").array(),
+    programmesRattachement: text("programmes_rattachement").array(),
+    localisationLatitude: doublePrecision("localisation_latitude"),
+    localisationLongitude: doublePrecision("localisation_longitude"),
+    localisationAdresse: text("localisation_adresse"),
+    localisationBanId: text("localisation_ban_id"),
+
+    // Classification v0.2 (auto-populated via LLM)
+    classificationThematiques: text("classification_thematiques").array(),
+    classificationSites: text("classification_sites").array(),
+    classificationInterventions: text("classification_interventions").array(),
+
+    // Classification LLM scores
+    classificationScores: jsonb("classification_scores").$type<{
+      thematiques: { label: string; score: number }[];
+      sites: { label: string; score: number }[];
+      interventions: { label: string; score: number }[];
+    }>(),
+    probabiliteTe: doublePrecision("probabilite_te"),
+
+    // CRTE first-class fields
+    crteId: text("crte_id"),
+    crteAnneeInscription: integer("crte_annee_inscription"),
+    crteOrientationStrategique: text("crte_orientation_strategique"),
+
+    // MEC-specific fields
+    sourceMec: text("source_mec"),
+    pcaetOperationInscrite: boolean("pcaet_operation_inscrite"),
+    fnvThematiques: text("fnv_thematiques"),
+    motsCles: text("mots_cles"),
+    besoins: text("besoins"),
+    planRattachement: text("plan_rattachement"),
+    sourceMetadata: jsonb("source_metadata").$type<Record<string, unknown>>(),
+
+    // Lifecycle
+    contentHash: text("content_hash"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [
+    index("mec_projets_siren_idx").on(t.collectiviteResponsableSiren),
+    index("mec_projets_crte_idx").on(t.crteId),
+    index("mec_projets_source_mec_idx").on(t.sourceMec),
+    index("mec_projets_content_hash_idx").on(t.contentHash),
+  ],
+);
+
+// --- N:N projets_operationnels <-> plans_transition ---
+export const mecProjetsToPlans = dataMecSchema.table(
+  "projets_to_plans",
+  {
+    projetId: uuid("projet_id")
+      .notNull()
+      .references(() => mecProjetsOperationnels.id),
+    planTransitionId: uuid("plan_transition_id")
+      .notNull()
+      .references(() => mecPlansTransition.id),
+  },
+  (t) => [primaryKey({ columns: [t.projetId, t.planTransitionId] })],
+);
+
+// ============================================================
+// Relations
+// ============================================================
+
+export const mecPlansTransitionRelations = relations(mecPlansTransition, ({ many }) => ({
+  projets: many(mecProjetsToPlans),
+}));
+
+export const mecProjetsOperationnelsRelations = relations(mecProjetsOperationnels, ({ many }) => ({
+  plans: many(mecProjetsToPlans),
+}));
+
+export const mecProjetsToPlansRelations = relations(mecProjetsToPlans, ({ one }) => ({
+  projet: one(mecProjetsOperationnels, {
+    fields: [mecProjetsToPlans.projetId],
+    references: [mecProjetsOperationnels.id],
+  }),
+  planTransition: one(mecPlansTransition, {
+    fields: [mecProjetsToPlans.planTransitionId],
+    references: [mecPlansTransition.id],
+  }),
+}));

--- a/api/src/database/mec-schema.ts
+++ b/api/src/database/mec-schema.ts
@@ -128,7 +128,6 @@ export const mecProjetsOperationnels = dataMecSchema.table(
     index("mec_projets_siren_idx").on(t.collectiviteResponsableSiren),
     index("mec_projets_crte_idx").on(t.crteId),
     index("mec_projets_source_mec_idx").on(t.sourceMec),
-    index("mec_projets_content_hash_idx").on(t.contentHash),
   ],
 );
 

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -248,3 +248,4 @@ export const serviceExtraFieldsRelations = relations(serviceExtraFields, ({ one 
 export * from "./referentiel-schema";
 export * from "./plans-fiches-schema";
 export * from "./tet-schema";
+export * from "./mec-schema";

--- a/api/src/mec/dto/create-mec-projet.dto.ts
+++ b/api/src/mec/dto/create-mec-projet.dto.ts
@@ -186,6 +186,135 @@ export class BulkCreateMecProjetsRequest {
   projets!: CreateMecProjetRequest[];
 }
 
+export class UpdateMecProjetRequest {
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  nom?: string;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  budgetPrevisionnel?: number | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  dateDebut?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  dateFin?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  phase?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  phaseStatut?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  porteurSiret?: string | null;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  competences?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  leviers?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  programmes?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  territoireCommunes?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  classificationThematiques?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  classificationSites?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String] })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  classificationInterventions?: string[] | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  crteId?: string | null;
+
+  @ApiPropertyOptional({ type: Number })
+  @IsOptional()
+  @IsNumber()
+  crteAnneeInscription?: number | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  crteOrientationStrategique?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  sourceMec?: string | null;
+
+  @ApiPropertyOptional({ type: Boolean })
+  @IsOptional()
+  @IsBoolean()
+  pcaetOperationInscrite?: boolean | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  fnvThematiques?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  motsCles?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  besoins?: string | null;
+
+  @ApiPropertyOptional({ type: String })
+  @IsOptional()
+  @IsString()
+  planRattachement?: string | null;
+}
+
 export class CreateMecProjetResponse {
   @ApiProperty()
   id!: string;

--- a/api/src/mec/dto/create-mec-projet.dto.ts
+++ b/api/src/mec/dto/create-mec-projet.dto.ts
@@ -1,0 +1,197 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsBoolean,
+  IsNotEmpty,
+  IsNumber,
+  IsOptional,
+  IsString,
+  ValidateNested,
+} from "class-validator";
+import { Type } from "class-transformer";
+import { CollectiviteReference } from "@projets/dto/collectivite.dto";
+
+export class MecPlanReference {
+  @ApiProperty({ description: "ID externe du plan côté MEC" })
+  @IsString()
+  @IsNotEmpty()
+  externalId!: string;
+
+  @ApiPropertyOptional({ description: "Nom du plan" })
+  @IsOptional()
+  @IsString()
+  nom?: string;
+
+  @ApiPropertyOptional({ description: "Type de plan (PCAET, CRTE, PAT...)" })
+  @IsOptional()
+  @IsString()
+  type?: string;
+}
+
+export class CreateMecProjetRequest {
+  @ApiProperty({ description: "Nom du projet" })
+  @IsString()
+  @IsNotEmpty()
+  nom!: string;
+
+  @ApiProperty({ required: true, description: "ID externe (MEC)" })
+  @IsString()
+  @IsNotEmpty()
+  externalId!: string;
+
+  @ApiProperty({ type: [CollectiviteReference], description: "Collectivités concernées (SIREN ou code INSEE)" })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CollectiviteReference)
+  @ArrayNotEmpty()
+  collectivites!: CollectiviteReference[];
+
+  @ApiPropertyOptional({ type: String, description: "Description du projet" })
+  @IsOptional()
+  @IsString()
+  description?: string | null;
+
+  @ApiPropertyOptional({ type: Number, description: "Budget prévisionnel en euros" })
+  @IsOptional()
+  @IsNumber()
+  budgetPrevisionnel?: number | null;
+
+  @ApiPropertyOptional({ type: String, description: "Date de début (ISO)" })
+  @IsOptional()
+  @IsString()
+  dateDebut?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "Date de fin (ISO)" })
+  @IsOptional()
+  @IsString()
+  dateFin?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "Phase (Idée, Étude, Opération)" })
+  @IsOptional()
+  @IsString()
+  phase?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "Statut de la phase" })
+  @IsOptional()
+  @IsString()
+  phaseStatut?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "SIRET du porteur opérationnel" })
+  @IsOptional()
+  @IsString()
+  porteurSiret?: string | null;
+
+  @ApiPropertyOptional({ type: [String], description: "Compétences M57" })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  competences?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String], description: "Leviers SGPE" })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  leviers?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String], description: "Programmes de rattachement" })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  programmes?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String], description: "Codes INSEE des communes du territoire" })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  territoireCommunes?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String], description: "Classification thématiques v0.2" })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  classificationThematiques?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String], description: "Classification sites v0.2" })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  classificationSites?: string[] | null;
+
+  @ApiPropertyOptional({ type: [String], description: "Classification interventions v0.2" })
+  @IsOptional()
+  @IsArray()
+  @IsString({ each: true })
+  classificationInterventions?: string[] | null;
+
+  @ApiPropertyOptional({ type: String, description: "ID du CRTE" })
+  @IsOptional()
+  @IsString()
+  crteId?: string | null;
+
+  @ApiPropertyOptional({ type: Number, description: "Année d'inscription au CRTE" })
+  @IsOptional()
+  @IsNumber()
+  crteAnneeInscription?: number | null;
+
+  @ApiPropertyOptional({ type: String, description: "Orientation stratégique CRTE" })
+  @IsOptional()
+  @IsString()
+  crteOrientationStrategique?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "Source MEC (crte, pcaet, fnv...)" })
+  @IsOptional()
+  @IsString()
+  sourceMec?: string | null;
+
+  @ApiPropertyOptional({ type: Boolean, description: "Opération inscrite au PCAET" })
+  @IsOptional()
+  @IsBoolean()
+  pcaetOperationInscrite?: boolean | null;
+
+  @ApiPropertyOptional({ type: String, description: "Thématiques Fonds Vert" })
+  @IsOptional()
+  @IsString()
+  fnvThematiques?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "Mots clés" })
+  @IsOptional()
+  @IsString()
+  motsCles?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "Besoins identifiés" })
+  @IsOptional()
+  @IsString()
+  besoins?: string | null;
+
+  @ApiPropertyOptional({ type: String, description: "Plan de rattachement" })
+  @IsOptional()
+  @IsString()
+  planRattachement?: string | null;
+
+  @ApiPropertyOptional({ type: [MecPlanReference], description: "Plans de transition liés" })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => MecPlanReference)
+  plans?: MecPlanReference[];
+}
+
+export class BulkCreateMecProjetsRequest {
+  @ApiProperty({ type: [CreateMecProjetRequest], description: "Liste de projets à créer en masse" })
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CreateMecProjetRequest)
+  @ArrayNotEmpty()
+  projets!: CreateMecProjetRequest[];
+}
+
+export class CreateMecProjetResponse {
+  @ApiProperty()
+  id!: string;
+}
+
+export class BulkCreateMecProjetsResponse {
+  @ApiProperty({ type: [String] })
+  ids!: string[];
+}

--- a/api/src/mec/mec.controller.ts
+++ b/api/src/mec/mec.controller.ts
@@ -8,6 +8,7 @@ import {
   CreateMecProjetResponse,
   BulkCreateMecProjetsRequest,
   BulkCreateMecProjetsResponse,
+  UpdateMecProjetRequest,
 } from "./dto/create-mec-projet.dto";
 import { MecService } from "./mec.service";
 
@@ -65,10 +66,7 @@ export class MecController {
     summary: "Mettre à jour partiellement un projet MEC",
     description: "Met à jour les champs fournis sans écraser les autres. Utilisé pour le backfill CRTE.",
   })
-  async update(
-    @Param("id") id: string,
-    @Body() request: Partial<CreateMecProjetRequest>,
-  ): Promise<CreateMecProjetResponse> {
+  async update(@Param("id") id: string, @Body() request: UpdateMecProjetRequest): Promise<CreateMecProjetResponse> {
     return this.mecService.update(id, request);
   }
 }

--- a/api/src/mec/mec.controller.ts
+++ b/api/src/mec/mec.controller.ts
@@ -1,0 +1,74 @@
+import { Body, Controller, Get, Param, Patch, Post, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ApiKeyGuard } from "@/auth/api-key-guard";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
+import {
+  CreateMecProjetRequest,
+  CreateMecProjetResponse,
+  BulkCreateMecProjetsRequest,
+  BulkCreateMecProjetsResponse,
+} from "./dto/create-mec-projet.dto";
+import { MecService } from "./mec.service";
+
+@ApiBearerAuth()
+@ApiTags("MEC")
+@Controller("mec/v1/projets")
+@UseGuards(ApiKeyGuard)
+export class MecController {
+  constructor(private readonly mecService: MecService) {}
+
+  @TrackApiUsage()
+  @Post()
+  @ApiOperation({
+    summary: "Créer ou mettre à jour un projet MEC",
+    description:
+      "Reçoit un projet opérationnel depuis MEC. Stocke dans le schéma data_mec et déclenche la classification automatique.",
+  })
+  @ApiEndpointResponses({
+    successStatus: 201,
+    response: CreateMecProjetResponse,
+    description: "Projet MEC créé ou mis à jour",
+  })
+  async create(@Body() request: CreateMecProjetRequest): Promise<CreateMecProjetResponse> {
+    return this.mecService.createOrUpdate(request);
+  }
+
+  @TrackApiUsage()
+  @Post("bulk")
+  @ApiOperation({
+    summary: "Créer ou mettre à jour des projets MEC en masse",
+    description: "Traitement par lots de 500. Chaque projet est upsert individuellement.",
+  })
+  @ApiEndpointResponses({
+    successStatus: 201,
+    response: BulkCreateMecProjetsResponse,
+    description: "Projets MEC créés ou mis à jour en masse",
+  })
+  async createBulk(@Body() request: BulkCreateMecProjetsRequest): Promise<BulkCreateMecProjetsResponse> {
+    return this.mecService.createBulk(request.projets);
+  }
+
+  @TrackApiUsage()
+  @Get(":id")
+  @ApiOperation({
+    summary: "Récupérer un projet MEC par ID",
+    description: "Retourne le projet avec ses plans liés, ses IDs externes et sa classification.",
+  })
+  async findOne(@Param("id") id: string) {
+    return this.mecService.findOne(id);
+  }
+
+  @TrackApiUsage()
+  @Patch(":id")
+  @ApiOperation({
+    summary: "Mettre à jour partiellement un projet MEC",
+    description: "Met à jour les champs fournis sans écraser les autres. Utilisé pour le backfill CRTE.",
+  })
+  async update(
+    @Param("id") id: string,
+    @Body() request: Partial<CreateMecProjetRequest>,
+  ): Promise<CreateMecProjetResponse> {
+    return this.mecService.update(id, request);
+  }
+}

--- a/api/src/mec/mec.module.ts
+++ b/api/src/mec/mec.module.ts
@@ -1,0 +1,16 @@
+import { Module } from "@nestjs/common";
+import { BullModule } from "@nestjs/bullmq";
+import { PROJECT_QUALIFICATION_QUEUE_NAME } from "@/projet-qualification/const";
+import { MecController } from "./mec.controller";
+import { MecService } from "./mec.service";
+
+@Module({
+  imports: [
+    BullModule.registerQueue({
+      name: PROJECT_QUALIFICATION_QUEUE_NAME,
+    }),
+  ],
+  controllers: [MecController],
+  providers: [MecService],
+})
+export class MecModule {}

--- a/api/src/mec/mec.module.ts
+++ b/api/src/mec/mec.module.ts
@@ -1,15 +1,10 @@
 import { Module } from "@nestjs/common";
-import { BullModule } from "@nestjs/bullmq";
-import { PROJECT_QUALIFICATION_QUEUE_NAME } from "@/projet-qualification/const";
 import { MecController } from "./mec.controller";
 import { MecService } from "./mec.service";
 
+// FIXME: Re-add BullModule.registerQueue({ name: PROJECT_QUALIFICATION_QUEUE_NAME })
+// when the classification worker is adapted to support data_mec.
 @Module({
-  imports: [
-    BullModule.registerQueue({
-      name: PROJECT_QUALIFICATION_QUEUE_NAME,
-    }),
-  ],
   controllers: [MecController],
   providers: [MecService],
 })

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -9,14 +9,8 @@ import {
   refPerimetres,
 } from "@database/schema";
 import { eq, and } from "drizzle-orm";
-import { InjectQueue } from "@nestjs/bullmq";
-import { Queue } from "bullmq";
 import { CustomLogger } from "@logging/logger.service";
-import {
-  PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
-  PROJECT_QUALIFICATION_QUEUE_NAME,
-} from "@/projet-qualification/const";
-import { CreateMecProjetRequest, MecPlanReference } from "./dto/create-mec-projet.dto";
+import { CreateMecProjetRequest, UpdateMecProjetRequest, MecPlanReference } from "./dto/create-mec-projet.dto";
 import { createHash } from "crypto";
 import { uuidv7 } from "uuidv7";
 
@@ -24,7 +18,6 @@ import { uuidv7 } from "uuidv7";
 export class MecService {
   constructor(
     private readonly dbService: DatabaseService,
-    @InjectQueue(PROJECT_QUALIFICATION_QUEUE_NAME) private qualificationQueue: Queue,
     private readonly logger: CustomLogger,
   ) {}
 
@@ -90,7 +83,7 @@ export class MecService {
 
       // Schedule classification if content changed
       if (existing && existing.contentHash !== contentHash) {
-        await this.scheduleClassification(projetId);
+        this.scheduleClassification(projetId);
       }
     } else {
       projetId = uuidv7();
@@ -108,7 +101,7 @@ export class MecService {
 
       // Schedule classification for new records if classification is empty
       if (!dto.classificationThematiques || dto.classificationThematiques.length === 0) {
-        await this.scheduleClassification(projetId);
+        this.scheduleClassification(projetId);
       }
     }
 
@@ -122,18 +115,31 @@ export class MecService {
 
   async createBulk(dtos: CreateMecProjetRequest[], serviceType = "MEC"): Promise<{ ids: string[] }> {
     const allIds: string[] = [];
+    const errors: { index: number; externalId: string; error: string }[] = [];
     const chunks = this.chunkArray(dtos, 500);
 
     this.logger.log(`Bulk creating ${dtos.length} MEC projets in ${chunks.length} chunks of 500`);
 
+    let globalIndex = 0;
     for (const chunk of chunks) {
       for (const dto of chunk) {
-        const result = await this.createOrUpdate(dto, serviceType);
-        allIds.push(result.id);
+        try {
+          const result = await this.createOrUpdate(dto, serviceType);
+          allIds.push(result.id);
+        } catch (err) {
+          const message = err instanceof Error ? err.message : String(err);
+          this.logger.error(`Bulk insert failed for projet ${dto.externalId} (index ${globalIndex}): ${message}`);
+          errors.push({ index: globalIndex, externalId: dto.externalId, error: message });
+        }
+        globalIndex++;
       }
     }
 
-    this.logger.log(`Bulk insert complete: ${allIds.length} MEC projets`);
+    this.logger.log(`Bulk insert complete: ${allIds.length} succeeded, ${errors.length} failed out of ${dtos.length}`);
+
+    if (errors.length > 0) {
+      this.logger.warn(`Failed projects: ${JSON.stringify(errors.slice(0, 10))}`);
+    }
 
     return { ids: allIds };
   }
@@ -174,7 +180,7 @@ export class MecService {
     };
   }
 
-  async update(id: string, dto: Partial<CreateMecProjetRequest>): Promise<{ id: string }> {
+  async update(id: string, dto: UpdateMecProjetRequest): Promise<{ id: string }> {
     const db = this.dbService.database;
 
     const [existing] = await db
@@ -224,9 +230,9 @@ export class MecService {
   }
 
   /**
-   * Resolve collectivite to SIREN + territory communes from our referential DB
-   * - Commune: code_insee → SIREN via refCommunes, territoireCommunes = [code_insee]
-   * - EPCI: code = SIREN, territoireCommunes from refPerimetres
+   * Resolve collectivite to SIREN + territory communes from our referential DB.
+   * Supports: Commune (code_insee → SIREN), EPCI (code = SIREN, communes from perimetres),
+   * and any other groupement type (Département, Région, Syndicat — code treated as SIREN).
    */
   private async resolveCollectivite(collectivite?: {
     type: string;
@@ -249,19 +255,23 @@ export class MecService {
       };
     }
 
-    if (collectivite.type === "EPCI") {
-      const communes = await db
-        .select({ codeInsee: refPerimetres.codeInseeCommune })
-        .from(refPerimetres)
-        .where(eq(refPerimetres.sirenGroupement, collectivite.code));
+    // EPCI or any groupement type (Département, Région, Syndicat, etc.)
+    // code = SIREN of the groupement, resolve territory communes from perimetres
+    const communes = await db
+      .select({ codeInsee: refPerimetres.codeInseeCommune })
+      .from(refPerimetres)
+      .where(eq(refPerimetres.sirenGroupement, collectivite.code));
 
-      return {
-        siren: collectivite.code,
-        territoireCommunes: communes.length > 0 ? communes.map((c) => c.codeInsee) : null,
-      };
+    if (communes.length === 0 && collectivite.type !== "EPCI") {
+      this.logger.warn(
+        `resolveCollectivite: unknown type "${collectivite.type}" for code ${collectivite.code}, no communes found`,
+      );
     }
 
-    return { siren: null, territoireCommunes: null };
+    return {
+      siren: collectivite.code,
+      territoireCommunes: communes.length > 0 ? communes.map((c) => c.codeInsee) : null,
+    };
   }
 
   private async upsertPlans(projetId: string, plans: MecPlanReference[], serviceType: string): Promise<void> {
@@ -299,16 +309,13 @@ export class MecService {
     }
   }
 
-  private async scheduleClassification(projetId: string): Promise<void> {
-    // TODO: The qualification worker currently reads/writes from public.projets directly.
-    // For now, schedule the classification job the same way — adjust the worker later to support data_mec.
-    this.logger.log(`Scheduling classification for MEC projet ${projetId}`);
-
-    await this.qualificationQueue.add(
-      PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
-      { projetId, schema: "data_mec" },
-      { attempts: 3, backoff: { type: "exponential", delay: 5000 } },
-    );
+  // FIXME: The qualification worker reads/writes from public.projets directly and does not
+  // support data_mec yet. Scheduling a job with schema:"data_mec" would silently fail
+  // (projet not found in public.projets). Classification is disabled until the worker
+  // is adapted to support data_mec. Existing projects keep their classifications from
+  // the SQL migration; only NEW projects added after migration will be unclassified.
+  private scheduleClassification(projetId: string): void {
+    this.logger.warn(`Classification skipped for MEC projet ${projetId} — worker does not support data_mec yet`);
   }
 
   private computeContentHash(nom: string, description: string | null | undefined): string {

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -1,0 +1,326 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { DatabaseService } from "@database/database.service";
+import {
+  mecProjetsOperationnels,
+  mecPlansTransition,
+  mecProjetsToPlans,
+  mecExternalIds,
+  refCommunes,
+  refPerimetres,
+} from "@database/schema";
+import { eq, and } from "drizzle-orm";
+import { InjectQueue } from "@nestjs/bullmq";
+import { Queue } from "bullmq";
+import { CustomLogger } from "@logging/logger.service";
+import {
+  PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+  PROJECT_QUALIFICATION_QUEUE_NAME,
+} from "@/projet-qualification/const";
+import { CreateMecProjetRequest, MecPlanReference } from "./dto/create-mec-projet.dto";
+import { createHash } from "crypto";
+import { uuidv7 } from "uuidv7";
+
+@Injectable()
+export class MecService {
+  constructor(
+    private readonly dbService: DatabaseService,
+    @InjectQueue(PROJECT_QUALIFICATION_QUEUE_NAME) private qualificationQueue: Queue,
+    private readonly logger: CustomLogger,
+  ) {}
+
+  async createOrUpdate(dto: CreateMecProjetRequest, serviceType = "MEC"): Promise<{ id: string }> {
+    const db = this.dbService.database;
+
+    // 1. Resolve collectivite SIREN and territoire communes
+    const { siren, territoireCommunes } = await this.resolveCollectivite(dto.collectivites[0]);
+
+    // 2. Compute content hash
+    const contentHash = this.computeContentHash(dto.nom, dto.description);
+
+    // 3. Build fields to set
+    const fieldsToSet = {
+      nom: dto.nom,
+      description: dto.description ?? null,
+      budgetPrevisionnel: dto.budgetPrevisionnel ?? null,
+      dateDebut: dto.dateDebut ?? null,
+      dateFin: dto.dateFin ?? null,
+      phase: dto.phase ?? null,
+      phaseStatut: dto.phaseStatut ?? null,
+      collectiviteResponsableSiren: siren,
+      porteurOperationnelSiret: dto.porteurSiret ?? null,
+      territoireCommunes: dto.territoireCommunes ?? territoireCommunes,
+      competencesM57: dto.competences ?? null,
+      leviersSgpe: dto.leviers ?? null,
+      programmesRattachement: dto.programmes ?? null,
+      classificationThematiques: dto.classificationThematiques ?? null,
+      classificationSites: dto.classificationSites ?? null,
+      classificationInterventions: dto.classificationInterventions ?? null,
+      crteId: dto.crteId ?? null,
+      crteAnneeInscription: dto.crteAnneeInscription ?? null,
+      crteOrientationStrategique: dto.crteOrientationStrategique ?? null,
+      sourceMec: dto.sourceMec ?? null,
+      pcaetOperationInscrite: dto.pcaetOperationInscrite ?? null,
+      fnvThematiques: dto.fnvThematiques ?? null,
+      motsCles: dto.motsCles ?? null,
+      besoins: dto.besoins ?? null,
+      planRattachement: dto.planRattachement ?? null,
+      contentHash,
+    };
+
+    // 4. Check if projet already exists (via external_ids)
+    const [existingExternal] = await db
+      .select({ objetId: mecExternalIds.objetId })
+      .from(mecExternalIds)
+      .where(and(eq(mecExternalIds.serviceType, serviceType), eq(mecExternalIds.externalId, dto.externalId)))
+      .limit(1);
+
+    let projetId: string;
+
+    if (existingExternal) {
+      projetId = existingExternal.objetId;
+
+      // Check if content changed
+      const [existing] = await db
+        .select({ contentHash: mecProjetsOperationnels.contentHash })
+        .from(mecProjetsOperationnels)
+        .where(eq(mecProjetsOperationnels.id, projetId))
+        .limit(1);
+
+      await db.update(mecProjetsOperationnels).set(fieldsToSet).where(eq(mecProjetsOperationnels.id, projetId));
+
+      // Schedule classification if content changed
+      if (existing && existing.contentHash !== contentHash) {
+        await this.scheduleClassification(projetId);
+      }
+    } else {
+      projetId = uuidv7();
+
+      await db.insert(mecProjetsOperationnels).values({
+        id: projetId,
+        ...fieldsToSet,
+      });
+
+      await db.insert(mecExternalIds).values({
+        objetId: projetId,
+        serviceType,
+        externalId: dto.externalId,
+      });
+
+      // Schedule classification for new records if classification is empty
+      if (!dto.classificationThematiques || dto.classificationThematiques.length === 0) {
+        await this.scheduleClassification(projetId);
+      }
+    }
+
+    // 5. Upsert plans and link them
+    if (dto.plans?.length) {
+      await this.upsertPlans(projetId, dto.plans, serviceType);
+    }
+
+    return { id: projetId };
+  }
+
+  async createBulk(dtos: CreateMecProjetRequest[], serviceType = "MEC"): Promise<{ ids: string[] }> {
+    const allIds: string[] = [];
+    const chunks = this.chunkArray(dtos, 500);
+
+    this.logger.log(`Bulk creating ${dtos.length} MEC projets in ${chunks.length} chunks of 500`);
+
+    for (const chunk of chunks) {
+      for (const dto of chunk) {
+        const result = await this.createOrUpdate(dto, serviceType);
+        allIds.push(result.id);
+      }
+    }
+
+    this.logger.log(`Bulk insert complete: ${allIds.length} MEC projets`);
+
+    return { ids: allIds };
+  }
+
+  async findOne(id: string) {
+    const db = this.dbService.database;
+
+    const [projet] = await db.select().from(mecProjetsOperationnels).where(eq(mecProjetsOperationnels.id, id)).limit(1);
+
+    if (!projet) {
+      throw new NotFoundException(`Projet MEC with ID ${id} not found`);
+    }
+
+    // Get external IDs
+    const externalIds = await db
+      .select({ serviceType: mecExternalIds.serviceType, externalId: mecExternalIds.externalId })
+      .from(mecExternalIds)
+      .where(eq(mecExternalIds.objetId, id));
+
+    // Get linked plans
+    const planLinks = await db
+      .select({
+        planId: mecPlansTransition.id,
+        nom: mecPlansTransition.nom,
+        type: mecPlansTransition.type,
+      })
+      .from(mecProjetsToPlans)
+      .innerJoin(mecPlansTransition, eq(mecProjetsToPlans.planTransitionId, mecPlansTransition.id))
+      .where(eq(mecProjetsToPlans.projetId, id));
+
+    return {
+      ...projet,
+      externalIds: externalIds.reduce(
+        (acc, e) => ({ ...acc, [e.serviceType]: e.externalId }),
+        {} as Record<string, string>,
+      ),
+      plans: planLinks,
+    };
+  }
+
+  async update(id: string, dto: Partial<CreateMecProjetRequest>): Promise<{ id: string }> {
+    const db = this.dbService.database;
+
+    const [existing] = await db
+      .select({ id: mecProjetsOperationnels.id })
+      .from(mecProjetsOperationnels)
+      .where(eq(mecProjetsOperationnels.id, id))
+      .limit(1);
+
+    if (!existing) {
+      throw new NotFoundException(`Projet MEC with ID ${id} not found`);
+    }
+
+    const fieldsToUpdate: Record<string, unknown> = {};
+    if (dto.nom !== undefined) fieldsToUpdate.nom = dto.nom;
+    if (dto.description !== undefined) fieldsToUpdate.description = dto.description;
+    if (dto.budgetPrevisionnel !== undefined) fieldsToUpdate.budgetPrevisionnel = dto.budgetPrevisionnel;
+    if (dto.dateDebut !== undefined) fieldsToUpdate.dateDebut = dto.dateDebut;
+    if (dto.dateFin !== undefined) fieldsToUpdate.dateFin = dto.dateFin;
+    if (dto.phase !== undefined) fieldsToUpdate.phase = dto.phase;
+    if (dto.phaseStatut !== undefined) fieldsToUpdate.phaseStatut = dto.phaseStatut;
+    if (dto.porteurSiret !== undefined) fieldsToUpdate.porteurOperationnelSiret = dto.porteurSiret;
+    if (dto.competences !== undefined) fieldsToUpdate.competencesM57 = dto.competences;
+    if (dto.leviers !== undefined) fieldsToUpdate.leviersSgpe = dto.leviers;
+    if (dto.programmes !== undefined) fieldsToUpdate.programmesRattachement = dto.programmes;
+    if (dto.territoireCommunes !== undefined) fieldsToUpdate.territoireCommunes = dto.territoireCommunes;
+    if (dto.classificationThematiques !== undefined)
+      fieldsToUpdate.classificationThematiques = dto.classificationThematiques;
+    if (dto.classificationSites !== undefined) fieldsToUpdate.classificationSites = dto.classificationSites;
+    if (dto.classificationInterventions !== undefined)
+      fieldsToUpdate.classificationInterventions = dto.classificationInterventions;
+    if (dto.crteId !== undefined) fieldsToUpdate.crteId = dto.crteId;
+    if (dto.crteAnneeInscription !== undefined) fieldsToUpdate.crteAnneeInscription = dto.crteAnneeInscription;
+    if (dto.crteOrientationStrategique !== undefined)
+      fieldsToUpdate.crteOrientationStrategique = dto.crteOrientationStrategique;
+    if (dto.sourceMec !== undefined) fieldsToUpdate.sourceMec = dto.sourceMec;
+    if (dto.pcaetOperationInscrite !== undefined) fieldsToUpdate.pcaetOperationInscrite = dto.pcaetOperationInscrite;
+    if (dto.fnvThematiques !== undefined) fieldsToUpdate.fnvThematiques = dto.fnvThematiques;
+    if (dto.motsCles !== undefined) fieldsToUpdate.motsCles = dto.motsCles;
+    if (dto.besoins !== undefined) fieldsToUpdate.besoins = dto.besoins;
+    if (dto.planRattachement !== undefined) fieldsToUpdate.planRattachement = dto.planRattachement;
+
+    if (Object.keys(fieldsToUpdate).length > 0) {
+      await db.update(mecProjetsOperationnels).set(fieldsToUpdate).where(eq(mecProjetsOperationnels.id, id));
+    }
+
+    return { id };
+  }
+
+  /**
+   * Resolve collectivite to SIREN + territory communes from our referential DB
+   * - Commune: code_insee → SIREN via refCommunes, territoireCommunes = [code_insee]
+   * - EPCI: code = SIREN, territoireCommunes from refPerimetres
+   */
+  private async resolveCollectivite(collectivite?: {
+    type: string;
+    code: string;
+  }): Promise<{ siren: string | null; territoireCommunes: string[] | null }> {
+    if (!collectivite) return { siren: null, territoireCommunes: null };
+
+    const db = this.dbService.database;
+
+    if (collectivite.type === "Commune") {
+      const [commune] = await db
+        .select({ siren: refCommunes.siren })
+        .from(refCommunes)
+        .where(eq(refCommunes.codeInsee, collectivite.code))
+        .limit(1);
+
+      return {
+        siren: commune?.siren ?? null,
+        territoireCommunes: [collectivite.code],
+      };
+    }
+
+    if (collectivite.type === "EPCI") {
+      const communes = await db
+        .select({ codeInsee: refPerimetres.codeInseeCommune })
+        .from(refPerimetres)
+        .where(eq(refPerimetres.sirenGroupement, collectivite.code));
+
+      return {
+        siren: collectivite.code,
+        territoireCommunes: communes.length > 0 ? communes.map((c) => c.codeInsee) : null,
+      };
+    }
+
+    return { siren: null, territoireCommunes: null };
+  }
+
+  private async upsertPlans(projetId: string, plans: MecPlanReference[], serviceType: string): Promise<void> {
+    const db = this.dbService.database;
+
+    // Remove existing plan links for this projet
+    await db.delete(mecProjetsToPlans).where(eq(mecProjetsToPlans.projetId, projetId));
+
+    for (const plan of plans) {
+      const [existingPlan] = await db
+        .select({ objetId: mecExternalIds.objetId })
+        .from(mecExternalIds)
+        .where(and(eq(mecExternalIds.serviceType, serviceType), eq(mecExternalIds.externalId, plan.externalId)))
+        .limit(1);
+
+      let planId: string;
+
+      if (existingPlan) {
+        planId = existingPlan.objetId;
+        await db
+          .update(mecPlansTransition)
+          .set({ nom: plan.nom ?? null, type: plan.type ?? null })
+          .where(eq(mecPlansTransition.id, planId));
+      } else {
+        const [inserted] = await db
+          .insert(mecPlansTransition)
+          .values({ nom: plan.nom ?? null, type: plan.type ?? null })
+          .returning();
+        planId = inserted.id;
+
+        await db.insert(mecExternalIds).values({ objetId: planId, serviceType, externalId: plan.externalId });
+      }
+
+      await db.insert(mecProjetsToPlans).values({ projetId, planTransitionId: planId }).onConflictDoNothing();
+    }
+  }
+
+  private async scheduleClassification(projetId: string): Promise<void> {
+    // TODO: The qualification worker currently reads/writes from public.projets directly.
+    // For now, schedule the classification job the same way — adjust the worker later to support data_mec.
+    this.logger.log(`Scheduling classification for MEC projet ${projetId}`);
+
+    await this.qualificationQueue.add(
+      PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+      { projetId, schema: "data_mec" },
+      { attempts: 3, backoff: { type: "exponential", delay: 5000 } },
+    );
+  }
+
+  private computeContentHash(nom: string, description: string | null | undefined): string {
+    const content = `${nom}|${description ?? ""}`;
+    return createHash("sha256").update(content).digest("hex");
+  }
+
+  private chunkArray<T>(array: T[], size: number): T[][] {
+    const chunks: T[][] = [];
+    for (let i = 0; i < array.length; i += size) {
+      chunks.push(array.slice(i, i + size));
+    }
+    return chunks;
+  }
+}


### PR DESCRIPTION
## Résumé

Nouveau module MEC avec ingestion dédiée, même pattern que TeT (`data_tet` → `data_mec`).

## Changements

**Schema Drizzle `data_mec`** (4 tables) :
- `projets_operationnels` — 23 champs v0.2.0 + classification LLM + CRTE first-class + MEC-spécifique
- `external_ids` — junction table générique (pattern TeT)
- `plans_transition` — plans liés (CRTE, PCAET...)
- `projets_to_plans` — junction N:N

**Module NestJS `/mec/v1/projets`** :
- `POST /` — upsert via externalId
- `POST /bulk` — bulk upsert (chunks de 500)
- `GET /:id` — projet + external IDs
- `PATCH /:id` — mise à jour partielle (backfill CRTE)
- `@UseGuards(ApiKeyGuard)`

## Contexte

Les projets MEC transitaient par le endpoint générique `/projets` (table `public.projets` partagée). Les champs CRTE n'étaient pas transmis, empêchant le dashboard de filtrer les vrais projets CRTE.

## Prochaines étapes (hors scope de cette PR)

1. Copie SQL `public.projets` → `data_mec.projets_operationnels`
2. Bascule MEC vers `/mec/v1/projets` (MR MEC : incubateur-territoires/startups/mon-espace-collectivite/mon-espace-collectivite!1498)
3. Backfill CRTE via PATCH
4. Switch pipeline schema_commun_v2

## Test plan

- [ ] L'API démarre sans erreur
- [ ] `POST /mec/v1/projets` crée un projet dans `data_mec.projets_operationnels`
- [ ] `GET /mec/v1/projets/:id` retourne le projet + external IDs
- [ ] `PATCH /mec/v1/projets/:id` met à jour les champs CRTE
- [ ] Le endpoint `/projets` existant continue de fonctionner (zéro impact)