### PR TITLE
fix: timestamp migration 0038 data_mec postérieur à 0037

### DIFF
--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -271,7 +271,7 @@
     {
       "idx": 38,
       "version": "7",
-      "when": 1745856000000,
+      "when": 1775347200000,
       "tag": "0038_data_mec_schema",
       "breakpoints": true
     }


### PR DESCRIPTION
Le when de la migration 0038 était antérieur à 0037, drizzle-kit la skippait silencieusement.