### PR TITLE
feat(mec): auto-création plan CRTE + scripts migration data_mec

### DIFF
--- a/api/scripts/migrate-projets-to-data-mec-delta.sql
+++ b/api/scripts/migrate-projets-to-data-mec-delta.sql
@@ -1,0 +1,103 @@
+-- Delta migration: copy MEC projects added to public.projets AFTER the initial migration
+-- Safe to run multiple times (INSERT ... WHERE NOT EXISTS)
+--
+-- Usage:
+--   psql $DATABASE_URL -f scripts/migrate-projets-to-data-mec-delta.sql
+--
+-- Run this RIGHT AFTER MEC merges the /mec/v1/ MR to catch any projects
+-- that arrived between the initial migration and the endpoint switch.
+
+BEGIN;
+
+-- 1. Copy new projects not yet in data_mec
+INSERT INTO data_mec.projets_operationnels (
+  id, nom, description, budget_previsionnel, date_debut,
+  phase, phase_statut, collectivite_responsable_siren,
+  porteur_operationnel_siret, territoire_communes,
+  competences_m57, leviers_sgpe, programmes_rattachement,
+  classification_thematiques, classification_sites, classification_interventions,
+  classification_scores, probabilite_te, content_hash,
+  created_at, updated_at
+)
+SELECT
+  p.id, p.nom, p.description,
+  p.budget_previsionnel,
+  p.date_debut_previsionnelle,
+  p.phase::text, p."phaseStatut"::text,
+  (SELECT c.siren FROM public.projets_to_collectivites ptc
+   JOIN public.collectivites c ON c.id = ptc.collectivite_id
+   WHERE ptc.projet_id = p.id LIMIT 1),
+  p.code_siret,
+  (SELECT array_agg(c.code_insee) FROM public.projets_to_collectivites ptc
+   JOIN public.collectivites c ON c.id = ptc.collectivite_id
+   WHERE ptc.projet_id = p.id AND c.code_insee IS NOT NULL),
+  p.competences, p.leviers,
+  CASE WHEN p.programme IS NOT NULL AND p.programme != ''
+       THEN string_to_array(p.programme, ',') ELSE NULL END,
+  p.classification_thematiques, p.classification_sites, p.classification_interventions,
+  p.classification_scores,
+  CASE WHEN p.probabilite_te IS NOT NULL AND p.probabilite_te != ''
+       THEN p.probabilite_te::double precision ELSE NULL END,
+  p.content_hash, p.created_at, p.updated_at
+FROM public.projets p
+WHERE p.mec_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM data_mec.projets_operationnels d WHERE d.id = p.id
+  );
+
+-- 2. Copy missing external_ids
+INSERT INTO data_mec.external_ids (objet_id, service_type, external_id)
+SELECT p.id, 'MEC', p.mec_id
+FROM public.projets p
+WHERE p.mec_id IS NOT NULL
+  AND NOT EXISTS (
+    SELECT 1 FROM data_mec.external_ids e
+    WHERE e.objet_id = p.id AND e.service_type = 'MEC'
+  );
+
+-- 3. Also update existing projects that may have been modified
+-- (content_hash changed in public.projets since initial copy)
+UPDATE data_mec.projets_operationnels d
+SET
+  nom = p.nom,
+  description = p.description,
+  budget_previsionnel = p.budget_previsionnel,
+  phase = p.phase::text,
+  phase_statut = p."phaseStatut"::text,
+  classification_thematiques = p.classification_thematiques,
+  classification_sites = p.classification_sites,
+  classification_interventions = p.classification_interventions,
+  classification_scores = p.classification_scores,
+  probabilite_te = CASE WHEN p.probabilite_te IS NOT NULL AND p.probabilite_te != ''
+                        THEN p.probabilite_te::double precision ELSE d.probabilite_te END,
+  content_hash = p.content_hash,
+  updated_at = p.updated_at
+FROM public.projets p
+WHERE p.id = d.id
+  AND p.mec_id IS NOT NULL
+  AND p.content_hash != d.content_hash;
+
+-- 4. Report
+DO $$
+DECLARE
+  src_count INTEGER;
+  dst_count INTEGER;
+  ext_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO src_count FROM public.projets WHERE mec_id IS NOT NULL;
+  SELECT COUNT(*) INTO dst_count FROM data_mec.projets_operationnels;
+  SELECT COUNT(*) INTO ext_count FROM data_mec.external_ids WHERE service_type = 'MEC';
+
+  RAISE NOTICE '=== Delta migration complete ===';
+  RAISE NOTICE '  Source (public.projets MEC): % rows', src_count;
+  RAISE NOTICE '  data_mec.projets_operationnels: % rows', dst_count;
+  RAISE NOTICE '  data_mec.external_ids: % rows', ext_count;
+
+  IF src_count != dst_count OR src_count != ext_count THEN
+    RAISE WARNING '  ⚠ Count mismatch — check for orphaned records';
+  ELSE
+    RAISE NOTICE '  ✓ Counts match';
+  END IF;
+END $$;
+
+COMMIT;

--- a/api/scripts/migrate-projets-to-data-mec.sql
+++ b/api/scripts/migrate-projets-to-data-mec.sql
@@ -1,0 +1,131 @@
+-- Migration: public.projets (MEC) → data_mec.projets_operationnels + external_ids
+--
+-- This is a one-time SQL migration script to copy MEC project data
+-- from the legacy shared table to the dedicated data_mec schema.
+-- Preserves UUIDs, classifications, and content hashes.
+--
+-- Prerequisites:
+--   - data_mec schema and tables must exist (migration 0038)
+--   - data_mec tables must be empty (or run the TRUNCATE below)
+--
+-- Usage:
+--   psql $DATABASE_URL -f scripts/migrate-projets-to-data-mec.sql
+--
+-- After running:
+--   1. Verify counts match
+--   2. MEC team runs backfill-communs-crte.ts to PATCH CRTE fields
+--   3. Switch pipeline schema_commun_v2 to read from data_mec
+
+BEGIN;
+
+-- Safety: clear data_mec tables if re-running
+TRUNCATE data_mec.projets_to_plans CASCADE;
+TRUNCATE data_mec.external_ids CASCADE;
+TRUNCATE data_mec.projets_operationnels CASCADE;
+TRUNCATE data_mec.plans_transition CASCADE;
+
+-- 1. Copy projects
+INSERT INTO data_mec.projets_operationnels (
+  id,
+  nom,
+  description,
+  budget_previsionnel,
+  date_debut,
+  phase,
+  phase_statut,
+  collectivite_responsable_siren,
+  porteur_operationnel_siret,
+  territoire_communes,
+  competences_m57,
+  leviers_sgpe,
+  programmes_rattachement,
+  classification_thematiques,
+  classification_sites,
+  classification_interventions,
+  classification_scores,
+  probabilite_te,
+  content_hash,
+  created_at,
+  updated_at
+)
+SELECT
+  p.id,
+  p.nom,
+  p.description,
+  p.budget_previsionnel,  -- bigint, keep as-is
+  p.date_debut_previsionnelle,
+  p.phase::text,
+  p."phaseStatut"::text,
+  -- Resolve collectivite SIREN (first collectivite linked)
+  (
+    SELECT c.siren
+    FROM public.projets_to_collectivites ptc
+    JOIN public.collectivites c ON c.id = ptc.collectivite_id
+    WHERE ptc.projet_id = p.id
+    LIMIT 1
+  ),
+  p.code_siret,
+  -- Resolve territoire communes (all linked collectivite code_insee)
+  (
+    SELECT array_agg(c.code_insee)
+    FROM public.projets_to_collectivites ptc
+    JOIN public.collectivites c ON c.id = ptc.collectivite_id
+    WHERE ptc.projet_id = p.id AND c.code_insee IS NOT NULL
+  ),
+  p.competences,
+  p.leviers,
+  -- programme is comma-separated text → split into array
+  CASE
+    WHEN p.programme IS NOT NULL AND p.programme != ''
+    THEN string_to_array(p.programme, ',')
+    ELSE NULL
+  END,
+  p.classification_thematiques,
+  p.classification_sites,
+  p.classification_interventions,
+  p.classification_scores,
+  CASE
+    WHEN p.probabilite_te IS NOT NULL AND p.probabilite_te != ''
+    THEN p.probabilite_te::double precision
+    ELSE NULL
+  END,
+  p.content_hash,
+  p.created_at,
+  p.updated_at
+FROM public.projets p
+WHERE p.mec_id IS NOT NULL;
+
+-- 2. Populate external_ids
+INSERT INTO data_mec.external_ids (objet_id, service_type, external_id)
+SELECT p.id, 'MEC', p.mec_id
+FROM public.projets p
+WHERE p.mec_id IS NOT NULL;
+
+-- 3. Verify counts
+DO $$
+DECLARE
+  src_count INTEGER;
+  dst_count INTEGER;
+  ext_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO src_count FROM public.projets WHERE mec_id IS NOT NULL;
+  SELECT COUNT(*) INTO dst_count FROM data_mec.projets_operationnels;
+  SELECT COUNT(*) INTO ext_count FROM data_mec.external_ids WHERE service_type = 'MEC';
+
+  RAISE NOTICE '=== Migration complete ===';
+  RAISE NOTICE '  Source (public.projets WHERE mec_id IS NOT NULL): % rows', src_count;
+  RAISE NOTICE '  Destination (data_mec.projets_operationnels): % rows', dst_count;
+  RAISE NOTICE '  External IDs (data_mec.external_ids): % rows', ext_count;
+
+  IF src_count != dst_count THEN
+    RAISE EXCEPTION 'Count mismatch! Source: %, Destination: %', src_count, dst_count;
+  END IF;
+
+  IF src_count != ext_count THEN
+    RAISE EXCEPTION 'External IDs count mismatch! Source: %, External IDs: %', src_count, ext_count;
+  END IF;
+
+  RAISE NOTICE '  ✓ Counts match';
+END $$;
+
+COMMIT;

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -8,7 +8,7 @@ import {
   refCommunes,
   refPerimetres,
 } from "@database/schema";
-import { eq, and } from "drizzle-orm";
+import { eq, and, sql } from "drizzle-orm";
 import { CustomLogger } from "@logging/logger.service";
 import { CreateMecProjetRequest, UpdateMecProjetRequest, MecPlanReference } from "./dto/create-mec-projet.dto";
 import { createHash } from "crypto";
@@ -108,6 +108,11 @@ export class MecService {
     // 5. Upsert plans and link them
     if (dto.plans?.length) {
       await this.upsertPlans(projetId, dto.plans, serviceType);
+    }
+
+    // 6. Auto-create CRTE plan if crteId is set
+    if (dto.crteId) {
+      await this.upsertCrtePlan(projetId, dto.crteId, serviceType);
     }
 
     return { id: projetId };
@@ -307,6 +312,43 @@ export class MecService {
 
       await db.insert(mecProjetsToPlans).values({ projetId, planTransitionId: planId }).onConflictDoNothing();
     }
+  }
+
+  /**
+   * Auto-create a CRTE plan from the crteId field and link it to the project.
+   * Resolves the CRTE name from snapshot_crte.contrats if available.
+   */
+  private async upsertCrtePlan(projetId: string, crteId: string, serviceType: string): Promise<void> {
+    const db = this.dbService.database;
+
+    // Check if plan already exists for this crteId
+    const [existingPlan] = await db
+      .select({ objetId: mecExternalIds.objetId })
+      .from(mecExternalIds)
+      .where(and(eq(mecExternalIds.serviceType, `${serviceType}_CRTE`), eq(mecExternalIds.externalId, crteId)))
+      .limit(1);
+
+    let planId: string;
+
+    if (existingPlan) {
+      planId = existingPlan.objetId;
+    } else {
+      // Resolve CRTE name from snapshot_crte.contrats
+      const crteResult = await db.execute(
+        sql`SELECT lib_crte FROM snapshot_crte.contrats WHERE id_crte = ${crteId} LIMIT 1`,
+      );
+      const crteName = (crteResult.rows[0] as { lib_crte?: string } | undefined)?.lib_crte ?? null;
+
+      const [inserted] = await db.insert(mecPlansTransition).values({ nom: crteName, type: "CRTE" }).returning();
+      planId = inserted.id;
+
+      await db
+        .insert(mecExternalIds)
+        .values({ objetId: planId, serviceType: `${serviceType}_CRTE`, externalId: crteId });
+    }
+
+    // Link project to CRTE plan
+    await db.insert(mecProjetsToPlans).values({ projetId, planTransitionId: planId }).onConflictDoNothing();
   }
 
   // FIXME: The qualification worker reads/writes from public.projets directly and does not

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -231,6 +231,11 @@ export class MecService {
       await db.update(mecProjetsOperationnels).set(fieldsToUpdate).where(eq(mecProjetsOperationnels.id, id));
     }
 
+    // Auto-create CRTE plan if crteId is provided in the update
+    if (dto.crteId) {
+      await this.upsertCrtePlan(id, dto.crteId, "MEC");
+    }
+
     return { id };
   }
 


### PR DESCRIPTION
## Résumé

1. **Auto-création plan CRTE** : quand un projet arrive avec `crteId`, le service crée automatiquement un plan de type CRTE dans `data_mec.plans_transition` et le lie au projet. Le nom du CRTE est résolu depuis `snapshot_crte.contrats`.

2. **Scripts de migration SQL** :
   - `migrate-projets-to-data-mec.sql` — migration initiale (déjà exécutée en prod, 78 589 projets)
   - `migrate-projets-to-data-mec-delta.sql` — rattrapage delta (à exécuter après merge MEC !1500)