### PR TITLE
fix: fallback data_mec/data_tet sur endpoints legacy /projets

### DIFF
--- a/api/src/projets/services/extra-fields/extra-fields.service.ts
+++ b/api/src/projets/services/extra-fields/extra-fields.service.ts
@@ -1,13 +1,17 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { DatabaseService } from "@database/database.service";
-import { projets, serviceExtraFields } from "@database/schema";
+import { mecProjetsOperationnels, projets, serviceExtraFields, tetFichesAction } from "@database/schema";
 import { eq } from "drizzle-orm";
 import { CreateProjetExtraFieldRequest, ExtraField } from "@projets/dto/extra-fields.dto";
 import { IdType } from "@/shared/types";
+import { CustomLogger } from "@logging/logger.service";
 
 @Injectable()
 export class ExtraFieldsService {
-  constructor(private readonly dbService: DatabaseService) {}
+  constructor(
+    private readonly dbService: DatabaseService,
+    private readonly logger: CustomLogger,
+  ) {}
 
   async getExtraFieldsByProjetId(id: string, idType: IdType): Promise<ExtraField[]> {
     const projet = await this.findProjetByIdType(id, idType);
@@ -45,17 +49,41 @@ export class ExtraFieldsService {
     });
   }
 
-  private async findProjetByIdType(id: string, idType: IdType) {
+  private async findProjetByIdType(id: string, idType: IdType): Promise<{ id: string }> {
     const whereCondition = idType === "tetId" ? eq(projets.tetId, id) : eq(projets.id, id);
 
     const projet = await this.dbService.database.query.projets.findFirst({
       where: whereCondition,
     });
 
-    if (!projet) {
-      throw new NotFoundException(`Projet with ${idType} ${id} not found`);
+    if (projet) {
+      return projet;
     }
 
-    return projet;
+    if (idType === "communId") {
+      // Fallback to data_mec.projets_operationnels
+      this.logger.warn("Falling back to data_mec for extra-fields project lookup", { id });
+      const [mecProjet] = await this.dbService.database
+        .select({ id: mecProjetsOperationnels.id })
+        .from(mecProjetsOperationnels)
+        .where(eq(mecProjetsOperationnels.id, id));
+
+      if (mecProjet) {
+        return { id: mecProjet.id };
+      }
+
+      // Fallback to data_tet.fiches_action
+      this.logger.warn("Falling back to data_tet for extra-fields project lookup", { id });
+      const [tetFiche] = await this.dbService.database
+        .select({ id: tetFichesAction.id })
+        .from(tetFichesAction)
+        .where(eq(tetFichesAction.id, id));
+
+      if (tetFiche) {
+        return { id: tetFiche.id };
+      }
+    }
+
+    throw new NotFoundException(`Projet with ${idType} ${id} not found`);
   }
 }

--- a/api/src/projets/services/get-projets/get-projets.service.ts
+++ b/api/src/projets/services/get-projets/get-projets.service.ts
@@ -1,5 +1,5 @@
 import { DatabaseService } from "@database/database.service";
-import { collectivites, projets } from "@database/schema";
+import { collectivites, mecProjetsOperationnels, projets, tetFichesAction } from "@database/schema";
 import { CustomLogger } from "@logging/logger.service";
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { eq, InferSelectModel } from "drizzle-orm";
@@ -79,6 +79,18 @@ export class GetProjetsService {
       },
     });
 
+    if (!projet && idType === "communId") {
+      const fallback = await this.findFallbackProject(id);
+      if (fallback) {
+        const collectiviteList = await this.resolveCollectiviteFromSiren(fallback.siren);
+        return {
+          description: fallback.description,
+          phase: fallback.phase as ProjectPublicInfoResponse["phase"],
+          collectivites: collectiviteList,
+        };
+      }
+    }
+
     if (!projet) {
       this.logger.warn(`Projet not found by ${idType}`, { [idType]: id });
       throw new NotFoundException(`Projet with ${idType} ${id} not found`);
@@ -118,5 +130,65 @@ export class GetProjetsService {
       leviers: projet.leviers ? (projet.leviers as Leviers) : null,
       collectivites: projet.collectivites.map((c) => c.collectivite),
     };
+  }
+
+  /**
+   * Search data_mec then data_tet for a project not found in public.projets.
+   */
+  private async findFallbackProject(
+    id: string,
+  ): Promise<{ description: string | null; phase: string | null; siren: string | null } | null> {
+    this.logger.warn("Falling back to data_mec for project lookup", { id });
+    const [mecProjet] = await this.dbService.database
+      .select({
+        description: mecProjetsOperationnels.description,
+        phase: mecProjetsOperationnels.phase,
+        siren: mecProjetsOperationnels.collectiviteResponsableSiren,
+      })
+      .from(mecProjetsOperationnels)
+      .where(eq(mecProjetsOperationnels.id, id));
+
+    if (mecProjet) return mecProjet;
+
+    this.logger.warn("Falling back to data_tet for project lookup", { id });
+    const [tetFiche] = await this.dbService.database
+      .select({
+        description: tetFichesAction.description,
+        siren: tetFichesAction.collectiviteResponsableSiren,
+      })
+      .from(tetFichesAction)
+      .where(eq(tetFichesAction.id, id));
+
+    if (tetFiche) return { ...tetFiche, phase: null };
+
+    return null;
+  }
+
+  /**
+   * Resolve a SIREN to a collectivite object. Checks public.collectivites first,
+   * returns a minimal stub if not found.
+   */
+  private async resolveCollectiviteFromSiren(siren: string | null): Promise<Collectivite[]> {
+    if (!siren) return [];
+
+    const [existing] = await this.dbService.database.select().from(collectivites).where(eq(collectivites.siren, siren));
+
+    if (existing) return [existing];
+
+    // Minimal stub — SIREN exists but not in our collectivites table
+    return [
+      {
+        id: siren,
+        nom: "",
+        type: "Commune",
+        codeInsee: null,
+        codeEpci: null,
+        codeDepartements: null,
+        codeRegions: null,
+        siren,
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      } as Collectivite,
+    ];
   }
 }

--- a/api/src/services/services.service.ts
+++ b/api/src/services/services.service.ts
@@ -3,7 +3,14 @@ import { CreateServiceRequest, CreateServiceResponse } from "./dto/create-servic
 import { eq } from "drizzle-orm";
 import { DatabaseService } from "@database/database.service";
 import { CustomLogger } from "@logging/logger.service";
-import { projets, collectivites, services } from "@database/schema";
+import {
+  collectivites,
+  mecProjetsOperationnels,
+  projets,
+  ProjetPhase,
+  services,
+  tetFichesAction,
+} from "@database/schema";
 import { ServicesByProjectIdResponse } from "./dto/service.dto";
 import { ServicesContextService } from "./services-context.service";
 import { CompetenceCodes, IdType, Leviers } from "@/shared/types";
@@ -68,6 +75,18 @@ export class ServicesService {
       },
     });
 
+    if (!project && idType === "communId") {
+      const fallback = await this.findFallbackForServices(id);
+      if (fallback) {
+        return this.serviceContextService.findMatchingServicesContext(
+          fallback.competences,
+          fallback.leviers,
+          fallback.phase,
+          fallback.codeRegions,
+        );
+      }
+    }
+
     if (!project) {
       throw new NotFoundException(`Projet with ${idType} ${id} not found`);
     }
@@ -89,5 +108,69 @@ export class ServicesService {
       project.phase,
       codeRegionsFromProject,
     );
+  }
+
+  /**
+   * Search data_mec then data_tet for a project and resolve its region codes.
+   */
+  private async findFallbackForServices(id: string): Promise<{
+    competences: CompetenceCodes | null;
+    leviers: Leviers | null;
+    phase: ProjetPhase | null;
+    codeRegions: RegionCode[];
+  } | null> {
+    // data_mec
+    this.logger.warn("Falling back to data_mec for services project lookup", { id });
+    const [mecProjet] = await this.dbService.database
+      .select({
+        competencesM57: mecProjetsOperationnels.competencesM57,
+        leviersSgpe: mecProjetsOperationnels.leviersSgpe,
+        phase: mecProjetsOperationnels.phase,
+        siren: mecProjetsOperationnels.collectiviteResponsableSiren,
+      })
+      .from(mecProjetsOperationnels)
+      .where(eq(mecProjetsOperationnels.id, id));
+
+    if (mecProjet) {
+      const codeRegions = await this.resolveRegionsFromSiren(mecProjet.siren);
+      return {
+        competences: (mecProjet.competencesM57 as CompetenceCodes) ?? null,
+        leviers: (mecProjet.leviersSgpe as Leviers) ?? null,
+        phase: mecProjet.phase as ProjetPhase | null,
+        codeRegions,
+      };
+    }
+
+    // data_tet
+    this.logger.warn("Falling back to data_tet for services project lookup", { id });
+    const [tetFiche] = await this.dbService.database
+      .select({
+        competencesM57: tetFichesAction.competencesM57,
+        leviersSgpe: tetFichesAction.leviersSgpe,
+        siren: tetFichesAction.collectiviteResponsableSiren,
+      })
+      .from(tetFichesAction)
+      .where(eq(tetFichesAction.id, id));
+
+    if (tetFiche) {
+      const codeRegions = await this.resolveRegionsFromSiren(tetFiche.siren);
+      return {
+        competences: (tetFiche.competencesM57 as CompetenceCodes) ?? null,
+        leviers: (tetFiche.leviersSgpe as Leviers) ?? null,
+        phase: null,
+        codeRegions,
+      };
+    }
+
+    return null;
+  }
+
+  private async resolveRegionsFromSiren(siren: string | null): Promise<RegionCode[]> {
+    if (!siren) return [];
+    const [collectivite] = await this.dbService.database
+      .select({ codeRegions: collectivites.codeRegions })
+      .from(collectivites)
+      .where(eq(collectivites.siren, siren));
+    return (collectivite?.codeRegions as RegionCode[]) ?? [];
   }
 }


### PR DESCRIPTION
## Problème

Les endpoints legacy `/projets/{id}/public-info`, `/projets/{id}/extra-fields` et `/services/project/{id}` ne cherchent que dans `public.projets`. Les projets créés via `/mec/v1/` sont dans `data_mec.projets_operationnels` → 404.

Le widget ServicesWidget intégré dans MEC est cassé pour les nouveaux projets.

## Fix

Fallback dans les 3 services : si le projet n'est pas trouvé dans `public.projets` et que `idType === "communId"`, chercher dans `data_mec.projets_operationnels` puis `data_tet.fiches_action`.

- `get-projets.service.ts` → `getPublicInfo()` : fallback data_mec puis data_tet
- `extra-fields.service.ts` → `findProjetByIdType()` : fallback data_mec (retourne [] pour extra-fields)
- `services.service.ts` → `getServicesByProjectId()` : fallback data_mec avec résolution collectivité

## Test plan

- [ ] `GET /projets/{id}/public-info?idType=communId` avec un ID data_mec retourne 200
- [ ] `GET /projets/{id}/extra-fields?idType=communId` avec un ID data_mec retourne 200 (tableau vide)
- [ ] `GET /services/project/{id}?idType=communId` avec un ID data_mec retourne 200
- [ ] Les endpoints fonctionnent toujours pour les projets dans `public.projets`