### PR TITLE
fix(mec): accepter collectivites sur PATCH (même contrat que POST)

### DIFF
--- a/api/src/mec/dto/create-mec-projet.dto.ts
+++ b/api/src/mec/dto/create-mec-projet.dto.ts
@@ -187,6 +187,16 @@ export class BulkCreateMecProjetsRequest {
 }
 
 export class UpdateMecProjetRequest {
+  @ApiPropertyOptional({
+    type: [CollectiviteReference],
+    description: "Collectivités concernées (résout SIREN + territoire)",
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => CollectiviteReference)
+  collectivites?: CollectiviteReference[];
+
   @ApiPropertyOptional({ type: String })
   @IsOptional()
   @IsString()

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -199,6 +199,14 @@ export class MecService {
     }
 
     const fieldsToUpdate: Record<string, unknown> = {};
+
+    // Resolve collectivites → SIREN + territoireCommunes (same as createOrUpdate)
+    if (dto.collectivites?.length) {
+      const { siren, territoireCommunes } = await this.resolveCollectivite(dto.collectivites[0]);
+      fieldsToUpdate.collectiviteResponsableSiren = siren;
+      if (territoireCommunes) fieldsToUpdate.territoireCommunes = territoireCommunes;
+    }
+
     if (dto.nom !== undefined) fieldsToUpdate.nom = dto.nom;
     if (dto.description !== undefined) fieldsToUpdate.description = dto.description;
     if (dto.budgetPrevisionnel !== undefined) fieldsToUpdate.budgetPrevisionnel = dto.budgetPrevisionnel;


### PR DESCRIPTION
## Problème

Le POST `/mec/v1/projets` accepte `collectivites` (avec résolution SIREN + territoire), mais le PATCH `/mec/v1/projets/:id` n'acceptait que `territoireCommunes`. MEC devait mapper `collectivites → territoireCommunes` côté client avant d'envoyer le PATCH.

## Fix

Le PATCH accepte maintenant `collectivites` (optionnel) en plus de `territoireCommunes`. Si `collectivites` est fourni, le service résout le SIREN et le territoire via le référentiel (même logique que le POST). `territoireCommunes` reste accepté pour la rétro-compatibilité.

Contrat POST et PATCH alignés — MEC peut envoyer le même body aux deux.