### PR TITLE
feat(aides): endpoint feedback — signaler une aide non pertinente

### DIFF
--- a/api/drizzle/0039_aide_feedbacks.sql
+++ b/api/drizzle/0039_aide_feedbacks.sql
@@ -1,0 +1,14 @@
+CREATE TABLE "aide_feedbacks" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "projet_id" uuid NOT NULL,
+  "id_at" text NOT NULL,
+  "feedback" text NOT NULL DEFAULT 'not_relevant',
+  "reason" text,
+  "source" text DEFAULT 'MEC',
+  "created_at" timestamp DEFAULT now() NOT NULL,
+  "updated_at" timestamp DEFAULT now() NOT NULL
+);
+
+CREATE UNIQUE INDEX "aide_feedbacks_projet_aide_idx" ON "aide_feedbacks" ("projet_id", "id_at");
+CREATE INDEX "aide_feedbacks_projet_idx" ON "aide_feedbacks" ("projet_id");
+CREATE INDEX "aide_feedbacks_id_at_idx" ON "aide_feedbacks" ("id_at");

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1775347200000,
       "tag": "0038_data_mec_schema",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1746449700000,
+      "tag": "0039_aide_feedbacks",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/aides/aides-feedback.service.ts
+++ b/api/src/aides/aides-feedback.service.ts
@@ -1,0 +1,42 @@
+import { Injectable } from "@nestjs/common";
+import { eq, and } from "drizzle-orm";
+import { DatabaseService } from "@database/database.service";
+import { aideFeedbacks } from "@database/schema";
+import { CreateAideFeedbackRequest, AideFeedbackResponse } from "./dto/aide-feedback.dto";
+
+@Injectable()
+export class AidesFeedbackService {
+  constructor(private readonly dbService: DatabaseService) {}
+
+  async create(dto: CreateAideFeedbackRequest): Promise<AideFeedbackResponse> {
+    const [result] = await this.dbService.database
+      .insert(aideFeedbacks)
+      .values({
+        projetId: dto.projetId,
+        idAt: dto.idAt,
+        feedback: dto.feedback ?? "not_relevant",
+        reason: dto.reason ?? null,
+        source: dto.source ?? "MEC",
+      })
+      .onConflictDoUpdate({
+        target: [aideFeedbacks.projetId, aideFeedbacks.idAt],
+        set: {
+          feedback: dto.feedback ?? "not_relevant",
+          reason: dto.reason ?? null,
+          source: dto.source ?? "MEC",
+        },
+      })
+      .returning();
+    return result;
+  }
+
+  async findByProjet(projetId: string): Promise<AideFeedbackResponse[]> {
+    return this.dbService.database.select().from(aideFeedbacks).where(eq(aideFeedbacks.projetId, projetId));
+  }
+
+  async delete(projetId: string, idAt: string): Promise<void> {
+    await this.dbService.database
+      .delete(aideFeedbacks)
+      .where(and(eq(aideFeedbacks.projetId, projetId), eq(aideFeedbacks.idAt, idAt)));
+  }
+}

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -7,6 +7,7 @@ import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
 import { AidesCacheService, CacheResult } from "./aides-cache.service";
 import { AidesWarmupService } from "./aides-warmup.service";
+import { AidesFeedbackService } from "./aides-feedback.service";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { CustomLogger } from "@logging/logger.service";
 import { Aide, AidesListResponse, ClassificationPendingResponse } from "./dto/aides.dto";
@@ -115,12 +116,19 @@ describe("AidesController", () => {
       add: jest.fn().mockResolvedValue({ id: "auto-classify:test-id" }),
     } as unknown as jest.Mocked<Queue>;
 
+    const mockFeedbackService = {
+      create: jest.fn(),
+      findByProjet: jest.fn(),
+      delete: jest.fn(),
+    } as unknown as jest.Mocked<AidesFeedbackService>;
+
     controller = new AidesController(
       mockAtService,
       mockClassificationService,
       mockMatchingService,
       mockCacheService,
       mockWarmupService,
+      mockFeedbackService,
       mockProjetsService,
       mockQualificationQueue,
       mockLogger,

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -1,4 +1,15 @@
-import { Controller, Get, Query, Res, UseGuards, BadRequestException } from "@nestjs/common";
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpCode,
+  Post,
+  Query,
+  Res,
+  UseGuards,
+  BadRequestException,
+} from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { Response } from "express";
 import { InjectQueue } from "@nestjs/bullmq";
@@ -17,6 +28,8 @@ import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
 import { AidesCacheService } from "./aides-cache.service";
 import { AidesWarmupService } from "./aides-warmup.service";
+import { AidesFeedbackService } from "./aides-feedback.service";
+import { CreateAideFeedbackRequest, DeleteAideFeedbackRequest } from "./dto/aide-feedback.dto";
 import {
   Aide,
   AideMatchResult,
@@ -41,6 +54,7 @@ export class AidesController {
     private readonly matchingService: AidesMatchingService,
     private readonly cacheService: AidesCacheService,
     private readonly warmupService: AidesWarmupService,
+    private readonly feedbackService: AidesFeedbackService,
     private readonly projetsService: GetProjetsService,
     @InjectQueue(PROJECT_QUALIFICATION_QUEUE_NAME) private readonly qualificationQueue: Queue,
     private readonly logger: CustomLogger,
@@ -211,6 +225,28 @@ export class AidesController {
     );
 
     return { ...result, total: aides.length, warmupStarted: true };
+  }
+
+  @TrackApiUsage()
+  @Post("feedback")
+  @ApiOperation({ summary: "Signaler une aide non pertinente pour un projet" })
+  async createFeedback(@Body() dto: CreateAideFeedbackRequest) {
+    return this.feedbackService.create(dto);
+  }
+
+  @TrackApiUsage()
+  @Get("feedback")
+  @ApiOperation({ summary: "Liste des feedbacks pour un projet" })
+  async getFeedbacks(@Query("projetId") projetId: string) {
+    return this.feedbackService.findByProjet(projetId);
+  }
+
+  @TrackApiUsage()
+  @Delete("feedback")
+  @ApiOperation({ summary: "Annuler un feedback" })
+  @HttpCode(204)
+  async deleteFeedback(@Body() dto: DeleteAideFeedbackRequest) {
+    return this.feedbackService.delete(dto.projetId, dto.idAt);
   }
 
   /**

--- a/api/src/aides/aides.module.ts
+++ b/api/src/aides/aides.module.ts
@@ -15,6 +15,7 @@ import { AidesMatchingService } from "./aides-matching.service";
 import { AidesCacheService } from "./aides-cache.service";
 import { AidesSyncProcessor, AIDES_SYNC_QUEUE_NAME, AIDES_SYNC_JOB_NAME } from "./aides-sync.processor";
 import { AidesWarmupService } from "./aides-warmup.service";
+import { AidesFeedbackService } from "./aides-feedback.service";
 
 @Module({
   imports: [
@@ -39,6 +40,7 @@ import { AidesWarmupService } from "./aides-warmup.service";
     AidesMatchingService,
     AidesCacheService,
     AidesWarmupService,
+    AidesFeedbackService,
     AidesSyncProcessor,
   ],
   exports: [AideClassificationService],

--- a/api/src/aides/dto/aide-feedback.dto.ts
+++ b/api/src/aides/dto/aide-feedback.dto.ts
@@ -1,0 +1,64 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsNotEmpty, IsOptional, IsString, IsUUID } from "class-validator";
+
+export class CreateAideFeedbackRequest {
+  @ApiProperty({ description: "ID du projet (communId)" })
+  @IsUUID()
+  @IsNotEmpty()
+  projetId!: string;
+
+  @ApiProperty({ description: "ID Aides Territoires de l'aide" })
+  @IsString()
+  @IsNotEmpty()
+  idAt!: string;
+
+  @ApiPropertyOptional({ description: "Type de feedback", default: "not_relevant" })
+  @IsOptional()
+  @IsString()
+  feedback?: string;
+
+  @ApiPropertyOptional({ description: "Raison du feedback (expired, wrong_territory, wrong_theme, other)" })
+  @IsOptional()
+  @IsString()
+  reason?: string;
+
+  @ApiPropertyOptional({ description: "Source du feedback (MEC, etc.)", default: "MEC" })
+  @IsOptional()
+  @IsString()
+  source?: string;
+}
+
+export class DeleteAideFeedbackRequest {
+  @ApiProperty({ description: "ID du projet" })
+  @IsUUID()
+  @IsNotEmpty()
+  projetId!: string;
+
+  @ApiProperty({ description: "ID Aides Territoires de l'aide" })
+  @IsString()
+  @IsNotEmpty()
+  idAt!: string;
+}
+
+export class AideFeedbackResponse {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  projetId!: string;
+
+  @ApiProperty()
+  idAt!: string;
+
+  @ApiProperty()
+  feedback!: string;
+
+  @ApiPropertyOptional()
+  reason?: string | null;
+
+  @ApiPropertyOptional()
+  source?: string | null;
+
+  @ApiProperty()
+  createdAt!: Date;
+}

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -244,6 +244,28 @@ export const serviceExtraFieldsRelations = relations(serviceExtraFields, ({ one 
   }),
 }));
 
+export const aideFeedbacks = pgTable(
+  "aide_feedbacks",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    projetId: uuid("projet_id").notNull(),
+    idAt: text("id_at").notNull(),
+    feedback: text("feedback").notNull().default("not_relevant"),
+    reason: text("reason"),
+    source: text("source").default("MEC"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at")
+      .notNull()
+      .defaultNow()
+      .$onUpdate(() => new Date()),
+  },
+  (t) => [
+    uniqueIndex("aide_feedbacks_projet_aide_idx").on(t.projetId, t.idAt),
+    index("aide_feedbacks_projet_idx").on(t.projetId),
+    index("aide_feedbacks_id_at_idx").on(t.idAt),
+  ],
+);
+
 // Re-export sub-schemas so DatabaseService picks up all tables
 export * from "./referentiel-schema";
 export * from "./plans-fiches-schema";


### PR DESCRIPTION
## Résumé

Nouvel endpoint pour permettre aux utilisateurs MEC de signaler qu'une aide suggérée n'est pas pertinente pour leur projet. Signal binaire pour itérer sur l'algo de matching.

## Endpoints

- `POST /aides/feedback` — signaler une aide non pertinente (upsert sur projet+aide)
- `GET /aides/feedback?projetId=xxx` — liste des feedbacks pour un projet
- `DELETE /aides/feedback` — annuler un feedback

## Payload POST

```json
{
  "projetId": "uuid",
  "idAt": "12345",
  "feedback": "not_relevant",
  "reason": "wrong_territory",
  "source": "MEC"
}
```

## Technique

- Table `public.aide_feedbacks` avec contrainte unique (projet_id, id_at)
- Migration Drizzle 0039
- Upsert (onConflictDoUpdate) — idempotent
- Auth ApiKeyGuard (même que les autres endpoints aides)

## Contexte

Maquette Figma : https://www.figma.com/design/EuKgkWiXjRQEAw3zYaKkWl/MEC---Fiche-projet---aides---services?node-id=59-5451

## Test plan

- [ ] POST crée un feedback
- [ ] POST sur la même paire (projetId, idAt) met à jour (upsert)
- [ ] GET retourne la liste des feedbacks d'un projet
- [ ] DELETE supprime un feedback
- [ ] Sans API key → 401