### PR TITLE
feat(dashboard-te,mec): page dispositifs sur data_mec + classification LLM

### DIFF
--- a/api/src/batch-classification/batch-classification.controller.ts
+++ b/api/src/batch-classification/batch-classification.controller.ts
@@ -22,21 +22,33 @@ export class BatchClassificationController {
   @ApiQuery({
     name: "source",
     required: false,
-    description: "Filtrer par source: MEC, TeT, Recoco, etc. (défaut: tous)",
+    description: "Filtrer par source: MEC, TeT, Recoco, etc. (défaut: tous, ignoré si schema=data_mec)",
   })
-  async triggerBatchClassification(@Query("limit") limit?: string, @Query("source") source?: string) {
+  @ApiQuery({
+    name: "schema",
+    required: false,
+    description: "Schéma cible: public (défaut) ou data_mec",
+  })
+  async triggerBatchClassification(
+    @Query("limit") limit?: string,
+    @Query("source") source?: string,
+    @Query("schema") schema?: string,
+  ) {
     const maxProjects = limit ? parseInt(limit, 10) : undefined;
+    const targetSchema = schema === "data_mec" ? "data_mec" : "public";
 
     await this.batchQueue.add(BATCH_SUBMIT_JOB, {
       triggeredBy: "management-endpoint",
       maxProjects,
-      source,
+      source: targetSchema === "data_mec" ? undefined : source,
+      schema: targetSchema,
     });
 
     const parts = [
       "Batch classification scheduled",
+      `schema: ${targetSchema}`,
       maxProjects ? `limit: ${maxProjects}` : null,
-      source ? `source: ${source}` : null,
+      source && targetSchema !== "data_mec" ? `source: ${source}` : null,
     ].filter(Boolean);
 
     return {

--- a/api/src/batch-classification/batch-classification.processor.ts
+++ b/api/src/batch-classification/batch-classification.processor.ts
@@ -3,7 +3,7 @@ import { Job, Queue } from "bullmq";
 import { isNull, isNotNull, eq, and, inArray } from "drizzle-orm";
 import { CustomLogger } from "@logging/logger.service";
 import { DatabaseService } from "@database/database.service";
-import { projets } from "@database/schema";
+import { projets, mecProjetsOperationnels } from "@database/schema";
 import { ClassificationAnthropicService } from "@/projet-qualification/classification/llm/classification-anthropic.service";
 import { ClassificationValidationService } from "@/projet-qualification/classification/validation/classification-validation.service";
 import { EnrichmentService } from "@/projet-qualification/classification/post-processing/enrichment.service";
@@ -22,6 +22,8 @@ import {
   CLASSIFICATION_AXES,
   ClassificationAxis,
 } from "./batch-classification.const";
+
+export type ClassificationSchema = "public" | "data_mec";
 
 /** Page size for paginated SELECT of unclassified projects */
 const SELECT_PAGE_SIZE = 5000;
@@ -52,6 +54,7 @@ export class BatchClassificationProcessor extends WorkerHost {
       projectCount?: number;
       maxProjects?: number;
       source?: string;
+      schema?: ClassificationSchema;
       projectIds?: string[];
       batchIds?: string[];
       totalProjects?: number;
@@ -62,9 +65,11 @@ export class BatchClassificationProcessor extends WorkerHost {
       case BATCH_SUBMIT_JOB:
         return this.handleSubmit(job);
       case BATCH_POLL_JOB:
-        return this.handlePoll(job as Job<{ batchIds: string[]; totalProjects: number }>);
+        return this.handlePoll(
+          job as Job<{ batchIds: string[]; totalProjects: number; schema?: ClassificationSchema }>,
+        );
       case BATCH_PROCESS_JOB:
-        return this.handleProcess(job as Job<{ batchId: string }>);
+        return this.handleProcess(job as Job<{ batchId: string; schema?: ClassificationSchema }>);
       default:
         throw new Error(`Unknown job type: ${job.name}`);
     }
@@ -80,19 +85,21 @@ export class BatchClassificationProcessor extends WorkerHost {
       projectCount?: number;
       maxProjects?: number;
       source?: string;
+      schema?: ClassificationSchema;
       projectIds?: string[];
     }>,
   ) {
-    const { maxProjects, projectIds, source } = job.data;
+    const { maxProjects, projectIds, source, schema } = job.data;
+    const targetSchema = schema ?? "public";
     this.logger.log(
-      `Batch classification submit triggered (${job.data.triggeredBy ?? "unknown"}, ~${job.data.projectCount ?? "?"} projects${maxProjects ? `, limit: ${maxProjects}` : ""}${source ? `, source: ${source}` : ""})`,
+      `Batch classification submit triggered (${job.data.triggeredBy ?? "unknown"}, schema: ${targetSchema}, ~${job.data.projectCount ?? "?"} projects${maxProjects ? `, limit: ${maxProjects}` : ""}${source ? `, source: ${source}` : ""})`,
     );
 
     try {
       // Collect projects to classify: either specific IDs or all unclassified
       const allUnclassified = projectIds
-        ? await this.fetchProjectsByIds(projectIds)
-        : await this.fetchUnclassifiedProjects(source);
+        ? await this.fetchProjectsByIds(projectIds, targetSchema)
+        : await this.fetchUnclassifiedProjects(source, targetSchema);
 
       const limit = maxProjects ?? MAX_PROJECTS_PER_SUBMIT;
       const unclassified = allUnclassified.slice(0, limit);
@@ -104,6 +111,7 @@ export class BatchClassificationProcessor extends WorkerHost {
           triggeredBy: "continuation",
           projectCount: remainingIds.length,
           projectIds: remainingIds,
+          schema: targetSchema,
         });
         this.logger.log(`${remainingIds.length} remaining projects scheduled in follow-up job`);
       }
@@ -140,7 +148,7 @@ export class BatchClassificationProcessor extends WorkerHost {
       // Enqueue poll job
       await this.batchQueue.add(
         BATCH_POLL_JOB,
-        { batchIds, totalProjects: unclassified.length },
+        { batchIds, totalProjects: unclassified.length, schema: targetSchema },
         {
           delay: POLL_DELAY_MS,
           attempts: MAX_POLL_ATTEMPTS,
@@ -163,8 +171,8 @@ export class BatchClassificationProcessor extends WorkerHost {
   /**
    * Step 2: Poll Anthropic batch status. Throws if not done (BullMQ retries with backoff).
    */
-  private async handlePoll(job: Job<{ batchIds: string[]; totalProjects: number }>) {
-    const { batchIds } = job.data;
+  private async handlePoll(job: Job<{ batchIds: string[]; totalProjects: number; schema?: ClassificationSchema }>) {
+    const { batchIds, schema } = job.data;
     const client = this.anthropicService.getClient();
 
     let allEnded = true;
@@ -188,7 +196,7 @@ export class BatchClassificationProcessor extends WorkerHost {
 
     // All batches ended — enqueue process jobs (one per batch)
     for (const batchId of batchIds) {
-      await this.batchQueue.add(BATCH_PROCESS_JOB, { batchId });
+      await this.batchQueue.add(BATCH_PROCESS_JOB, { batchId, schema });
     }
 
     this.logger.log(`All ${batchIds.length} batches ended, processing jobs enqueued`);
@@ -199,8 +207,9 @@ export class BatchClassificationProcessor extends WorkerHost {
   /**
    * Step 3: Stream results from a completed batch, apply post-processing, write to DB.
    */
-  private async handleProcess(job: Job<{ batchId: string }>) {
-    const { batchId } = job.data;
+  private async handleProcess(job: Job<{ batchId: string; schema?: ClassificationSchema }>) {
+    const { batchId, schema } = job.data;
+    const targetSchema = schema ?? "public";
     const client = this.anthropicService.getClient();
 
     this.logger.log(`Processing results for batch ${batchId}`);
@@ -317,16 +326,29 @@ export class BatchClassificationProcessor extends WorkerHost {
 
         // Write to DB sequentially to avoid saturating the connection pool
         for (const u of updates) {
-          await this.dbService.database
-            .update(projets)
-            .set({
-              classificationScores: u.classificationScores,
-              classificationThematiques: u.classificationThematiques,
-              classificationSites: u.classificationSites,
-              classificationInterventions: u.classificationInterventions,
-              probabiliteTE: u.probabiliteTE,
-            })
-            .where(eq(projets.id, u.projectId));
+          if (targetSchema === "data_mec") {
+            await this.dbService.database
+              .update(mecProjetsOperationnels)
+              .set({
+                classificationScores: u.classificationScores,
+                classificationThematiques: u.classificationThematiques,
+                classificationSites: u.classificationSites,
+                classificationInterventions: u.classificationInterventions,
+                probabiliteTe: u.probabiliteTE !== null ? Number(u.probabiliteTE) : null,
+              })
+              .where(eq(mecProjetsOperationnels.id, u.projectId));
+          } else {
+            await this.dbService.database
+              .update(projets)
+              .set({
+                classificationScores: u.classificationScores,
+                classificationThematiques: u.classificationThematiques,
+                classificationSites: u.classificationSites,
+                classificationInterventions: u.classificationInterventions,
+                probabiliteTE: u.probabiliteTE,
+              })
+              .where(eq(projets.id, u.projectId));
+          }
         }
 
         written += updates.length;
@@ -348,38 +370,55 @@ export class BatchClassificationProcessor extends WorkerHost {
   /**
    * Fetch unclassified projects with pagination to avoid loading everything in RAM.
    */
-  private async fetchUnclassifiedProjects(source?: string): Promise<ProjectForClassification[]> {
-    const sourceColumns = {
-      MEC: projets.mecId,
-      TeT: projets.tetId,
-      Recoco: projets.recocoId,
-      UrbanVitaliz: projets.urbanVitalizId,
-      SosPonts: projets.sosPontsId,
-      FondVert: projets.fondVertId,
-    } as const;
-
+  private async fetchUnclassifiedProjects(
+    source?: string,
+    schema: ClassificationSchema = "public",
+  ): Promise<ProjectForClassification[]> {
     const allProjects: ProjectForClassification[] = [];
     let offset = 0;
 
     while (true) {
-      let query = this.dbService.database
-        .select({ id: projets.id, nom: projets.nom, description: projets.description })
-        .from(projets)
-        .where(isNull(projets.classificationScores))
-        .limit(SELECT_PAGE_SIZE)
-        .offset(offset);
+      let page: ProjectForClassification[];
 
-      if (source && source in sourceColumns) {
-        const column = sourceColumns[source as keyof typeof sourceColumns];
-        query = this.dbService.database
-          .select({ id: projets.id, nom: projets.nom, description: projets.description })
-          .from(projets)
-          .where(and(isNull(projets.classificationScores), isNotNull(column)))
+      if (schema === "data_mec") {
+        page = await this.dbService.database
+          .select({
+            id: mecProjetsOperationnels.id,
+            nom: mecProjetsOperationnels.nom,
+            description: mecProjetsOperationnels.description,
+          })
+          .from(mecProjetsOperationnels)
+          .where(isNull(mecProjetsOperationnels.classificationScores))
           .limit(SELECT_PAGE_SIZE)
           .offset(offset);
+      } else {
+        const sourceColumns = {
+          MEC: projets.mecId,
+          TeT: projets.tetId,
+          Recoco: projets.recocoId,
+          UrbanVitaliz: projets.urbanVitalizId,
+          SosPonts: projets.sosPontsId,
+          FondVert: projets.fondVertId,
+        } as const;
+
+        if (source && source in sourceColumns) {
+          const column = sourceColumns[source as keyof typeof sourceColumns];
+          page = await this.dbService.database
+            .select({ id: projets.id, nom: projets.nom, description: projets.description })
+            .from(projets)
+            .where(and(isNull(projets.classificationScores), isNotNull(column)))
+            .limit(SELECT_PAGE_SIZE)
+            .offset(offset);
+        } else {
+          page = await this.dbService.database
+            .select({ id: projets.id, nom: projets.nom, description: projets.description })
+            .from(projets)
+            .where(isNull(projets.classificationScores))
+            .limit(SELECT_PAGE_SIZE)
+            .offset(offset);
+        }
       }
 
-      const page = await query;
       allProjects.push(...page);
 
       if (page.length < SELECT_PAGE_SIZE) break;
@@ -394,15 +433,20 @@ export class BatchClassificationProcessor extends WorkerHost {
   /**
    * Fetch specific projects by IDs (for bulk-triggered jobs that pass their own IDs).
    */
-  private async fetchProjectsByIds(ids: string[]): Promise<ProjectForClassification[]> {
+  private async fetchProjectsByIds(
+    ids: string[],
+    schema: ClassificationSchema = "public",
+  ): Promise<ProjectForClassification[]> {
     const allProjects: ProjectForClassification[] = [];
     const chunks = this.chunkArray(ids, SELECT_PAGE_SIZE);
 
+    const table = schema === "data_mec" ? mecProjetsOperationnels : projets;
+
     for (const chunk of chunks) {
       const page = await this.dbService.database
-        .select({ id: projets.id, nom: projets.nom, description: projets.description })
-        .from(projets)
-        .where(inArray(projets.id, chunk));
+        .select({ id: table.id, nom: table.nom, description: table.description })
+        .from(table)
+        .where(inArray(table.id, chunk));
 
       allProjects.push(...page);
     }

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -741,13 +741,13 @@ export class DashboardTeService {
         parStatut[s] = (parStatut[s] ?? 0) + 1;
       }
 
-      const [counts] = await this.query<{ nb_mec: string; nb_all: string }>(sql`
+      // Count from data_mec with CRTE breakdown
+      const [counts] = await this.query<{ nb_crte: string; nb_all: string }>(sql`
         SELECT
-          COUNT(*) FILTER (WHERE p.source_origine = 'MEC') AS nb_mec,
-          COUNT(*) AS nb_all
-        FROM schema_commun_v2.projets_operationnels p
-        JOIN schema_commun_v2.liens_projets_communes lpc ON lpc.projet_id = p.id
-        JOIN api_referentiel.communes c ON c.code_insee = lpc.insee_com
+          COUNT(DISTINCT p.id) FILTER (WHERE p.crte_id IS NOT NULL) AS nb_crte,
+          COUNT(DISTINCT p.id) AS nb_all
+        FROM data_mec.projets_operationnels p
+        JOIN api_referentiel.communes c ON c.code_insee = ANY(p.territoire_communes)
         WHERE c.code_epci = ANY(${sql`ARRAY[${sql.join(
           epciSirens.map((s) => sql`${s}`),
           sql`, `,
@@ -756,8 +756,8 @@ export class DashboardTeService {
 
       stats[type] = {
         totalEpci: items.length,
-        nbProjetsMec: Number(counts?.nb_mec ?? 0),
-        nbProjetsToutesSources: Number(counts?.nb_all ?? 0),
+        nbProjetsCrte: Number(counts?.nb_crte ?? 0),
+        nbProjetsMec: Number(counts?.nb_all ?? 0),
         parStatut,
       };
     }
@@ -767,18 +767,16 @@ export class DashboardTeService {
 
   async dispositifsProjets(filters: { type?: string; statut?: string; source?: string; page: number; limit: number }) {
     const typeFilter = filters.type ?? "COT";
-    const conditions: SQL[] = [sql`dt.dispositif = ${typeFilter}`];
+    const conditions: SQL[] = [sql`p.crte_id IS NOT NULL`, sql`dt.dispositif = ${typeFilter}`];
     if (filters.statut) conditions.push(sql`dt.statut = ${filters.statut}`);
-    if (filters.source) conditions.push(sql`p.source_origine = ${filters.source}`);
+    // source filter ignored — data_mec is MEC-only
     const where = sql`WHERE ${sql.join(conditions, sql` AND `)}`;
 
     const [countRow] = await this.query<{ total: string }>(sql`
       SELECT COUNT(DISTINCT p.id)::text AS total
-      FROM schema_commun_v2.projets_operationnels p
-      JOIN schema_commun_v2.liens_projets_communes lpc ON lpc.projet_id = p.id
-      JOIN api_referentiel.communes c ON c.code_insee = lpc.insee_com
+      FROM data_mec.projets_operationnels p
+      JOIN api_referentiel.communes c ON c.code_insee = ANY(p.territoire_communes)
       JOIN schema_commun_v2.dispositifs_territoriaux dt ON dt.epci_siren = c.code_epci
-      LEFT JOIN snapshot_crte.contrats crte ON crte.id_crte = dt.crte_code
       ${where}
     `);
 
@@ -787,31 +785,31 @@ export class DashboardTeService {
         p.id,
         p.nom,
         p.description,
-        p.source_origine AS "sourceOrigine",
+        'MEC' AS "sourceOrigine",
         p.phase,
-        p."phaseStatut",
-        p."budgetPrevisionnel",
-        p."collectiviteResponsableSiren" AS "collectiviteSiren",
-        p."dateDebut",
-        p."dateFin",
-        p.llm_thematiques AS "llmThematiques",
-        p.llm_sites AS "llmSites",
-        p.llm_interventions AS "llmInterventions",
-        p.llm_probabilite_te AS "llmProbabiliteTe",
-        p."competencesM57",
-        p."leviersSgpe",
+        p.phase_statut AS "phaseStatut",
+        p.budget_previsionnel AS "budgetPrevisionnel",
+        p.collectivite_responsable_siren AS "collectiviteSiren",
+        p.date_debut AS "dateDebut",
+        p.date_fin AS "dateFin",
+        p.classification_scores->'thematiques' AS "llmThematiques",
+        p.classification_scores->'sites' AS "llmSites",
+        p.classification_scores->'interventions' AS "llmInterventions",
+        p.probabilite_te AS "llmProbabiliteTe",
+        p.competences_m57 AS "competencesM57",
+        p.leviers_sgpe AS "leviersSgpe",
         p.mots_cles AS "motsCles",
+        p.crte_id AS "crteId",
+        p.crte_annee_inscription AS "crteAnneeInscription",
+        p.crte_orientation_strategique AS "crteOrientationStrategique",
         c.code_epci AS "epciSiren",
         dt.crte_code AS "crteCode",
         dt.metadata->>'crte_nom' AS "crteNom",
         dt.statut AS "cotStatut",
-        dt.date_signature AS "cotDateSignature",
-        crte.date_signature AS "crteDateSignature"
-      FROM schema_commun_v2.projets_operationnels p
-      JOIN schema_commun_v2.liens_projets_communes lpc ON lpc.projet_id = p.id
-      JOIN api_referentiel.communes c ON c.code_insee = lpc.insee_com
+        dt.date_signature AS "cotDateSignature"
+      FROM data_mec.projets_operationnels p
+      JOIN api_referentiel.communes c ON c.code_insee = ANY(p.territoire_communes)
       JOIN schema_commun_v2.dispositifs_territoriaux dt ON dt.epci_siren = c.code_epci
-      LEFT JOIN snapshot_crte.contrats crte ON crte.id_crte = dt.crte_code
       ${where}
       ORDER BY p.id
       OFFSET ${filters.page * filters.limit}

--- a/api/src/mec/mec.module.ts
+++ b/api/src/mec/mec.module.ts
@@ -1,10 +1,11 @@
 import { Module } from "@nestjs/common";
+import { BullModule } from "@nestjs/bullmq";
 import { MecController } from "./mec.controller";
 import { MecService } from "./mec.service";
+import { PROJECT_QUALIFICATION_QUEUE_NAME } from "@/projet-qualification/const";
 
-// FIXME: Re-add BullModule.registerQueue({ name: PROJECT_QUALIFICATION_QUEUE_NAME })
-// when the classification worker is adapted to support data_mec.
 @Module({
+  imports: [BullModule.registerQueue({ name: PROJECT_QUALIFICATION_QUEUE_NAME })],
   controllers: [MecController],
   providers: [MecService],
 })

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -1,4 +1,6 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
+import { InjectQueue } from "@nestjs/bullmq";
+import { Queue } from "bullmq";
 import { DatabaseService } from "@database/database.service";
 import {
   mecProjetsOperationnels,
@@ -13,12 +15,17 @@ import { CustomLogger } from "@logging/logger.service";
 import { CreateMecProjetRequest, UpdateMecProjetRequest, MecPlanReference } from "./dto/create-mec-projet.dto";
 import { createHash } from "crypto";
 import { uuidv7 } from "uuidv7";
+import {
+  PROJECT_QUALIFICATION_QUEUE_NAME,
+  PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+} from "@/projet-qualification/const";
 
 @Injectable()
 export class MecService {
   constructor(
     private readonly dbService: DatabaseService,
     private readonly logger: CustomLogger,
+    @InjectQueue(PROJECT_QUALIFICATION_QUEUE_NAME) private readonly qualificationQueue: Queue,
   ) {}
 
   async createOrUpdate(dto: CreateMecProjetRequest, serviceType = "MEC"): Promise<{ id: string }> {
@@ -364,13 +371,15 @@ export class MecService {
     await db.insert(mecProjetsToPlans).values({ projetId, planTransitionId: planId }).onConflictDoNothing();
   }
 
-  // FIXME: The qualification worker reads/writes from public.projets directly and does not
-  // support data_mec yet. Scheduling a job with schema:"data_mec" would silently fail
-  // (projet not found in public.projets). Classification is disabled until the worker
-  // is adapted to support data_mec. Existing projects keep their classifications from
-  // the SQL migration; only NEW projects added after migration will be unclassified.
   private scheduleClassification(projetId: string): void {
-    this.logger.warn(`Classification skipped for MEC projet ${projetId} — worker does not support data_mec yet`);
+    this.qualificationQueue
+      .add(PROJECT_QUALIFICATION_CLASSIFICATION_JOB, { projetId, schema: "data_mec" })
+      .then(() => this.logger.log(`Classification scheduled for MEC projet ${projetId}`))
+      .catch((err) =>
+        this.logger.error(
+          `Failed to schedule classification for MEC projet ${projetId}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
   }
 
   private computeContentHash(nom: string, description: string | null | undefined): string {

--- a/api/src/projet-qualification/projet-qualification.service.ts
+++ b/api/src/projet-qualification/projet-qualification.service.ts
@@ -12,7 +12,7 @@ import {
 } from "@/projet-qualification/const";
 import { ClassificationService } from "@/projet-qualification/classification/classification.service";
 import { DatabaseService } from "@database/database.service";
-import { tetFichesAction } from "@database/schema";
+import { tetFichesAction, mecProjetsOperationnels } from "@database/schema";
 import { eq } from "drizzle-orm";
 import { UpdateProjetsService } from "@projets/services/update-projets/update-projets.service";
 import { ServiceType } from "@/shared/types";
@@ -40,11 +40,11 @@ export class ProjetQualificationService extends WorkerHost {
     super();
   }
 
-  async process(job: Job<{ projetId?: string; ficheActionId?: string }>) {
-    const { projetId, ficheActionId } = job.data;
+  async process(job: Job<{ projetId?: string; ficheActionId?: string; schema?: string }>) {
+    const { projetId, ficheActionId, schema } = job.data;
     const entityId = projetId ?? ficheActionId;
     this.logger.log(
-      `Processing qualification job for ${projetId ? "project" : "fiche"} ${entityId} for job ${job.name}`,
+      `Processing qualification job for ${projetId ? "project" : "fiche"} ${entityId} for job ${job.name}${schema ? ` (schema: ${schema})` : ""}`,
     );
     try {
       // Handle fiche action classification (from data_tet)
@@ -55,6 +55,12 @@ export class ProjetQualificationService extends WorkerHost {
 
       if (!projetId) {
         throw new Error("projetId is required for non-fiche jobs");
+      }
+
+      // Handle data_mec classification directly (bypass public.projets read/write)
+      if (schema === "data_mec" && job.name === PROJECT_QUALIFICATION_CLASSIFICATION_JOB) {
+        await this.classifyMecProjet(projetId);
+        return;
       }
 
       const projet = await this.projetGetService.findOne(projetId);
@@ -179,6 +185,47 @@ export class ProjetQualificationService extends WorkerHost {
     this.logger.log(
       `Successfully classified project ${projetId} with ${classificationThematiques.length} thématiques, ${classificationSites.length} sites, ${classificationInterventions.length} interventions (TE: ${probabiliteTE})`,
     );
+  }
+
+  private async classifyMecProjet(projetId: string): Promise<void> {
+    const [projet] = await this.dbService.database
+      .select({
+        id: mecProjetsOperationnels.id,
+        nom: mecProjetsOperationnels.nom,
+        description: mecProjetsOperationnels.description,
+      })
+      .from(mecProjetsOperationnels)
+      .where(eq(mecProjetsOperationnels.id, projetId))
+      .limit(1);
+
+    if (!projet || (!projet.nom && !projet.description)) {
+      this.logger.log(`MEC projet ${projetId} not found or empty, skipping classification`);
+      return;
+    }
+
+    const context = `${projet.nom}\n${projet.description ?? ""}`;
+    this.logger.log(`Classifying MEC projet ${projetId}: ${projet.nom.slice(0, 60)}`);
+
+    const allScores = await this.classificationService.classify(context, "projet", 0);
+
+    const classificationScores = {
+      thematiques: allScores.thematiques,
+      sites: allScores.sites,
+      interventions: allScores.interventions,
+    };
+
+    await this.dbService.database
+      .update(mecProjetsOperationnels)
+      .set({
+        classificationThematiques: allScores.thematiques.filter((t) => t.score >= 0.8).map((t) => t.label),
+        classificationSites: allScores.sites.filter((s) => s.score >= 0.8).map((s) => s.label),
+        classificationInterventions: allScores.interventions.filter((i) => i.score >= 0.8).map((i) => i.label),
+        probabiliteTe: allScores.probabiliteTE !== null ? Number(allScores.probabiliteTE) : null,
+        classificationScores,
+      })
+      .where(eq(mecProjetsOperationnels.id, projetId));
+
+    this.logger.log(`Successfully classified MEC projet ${projetId}`);
   }
 
   private async classifyFicheAction(ficheActionId: string): Promise<void> {


### PR DESCRIPTION
## Résumé

- **Page Dispositifs** : requête `data_mec.projets_operationnels` au lieu de `schema_commun_v2`, filtre `crte_id IS NOT NULL` — seuls les vrais projets CRTE sont affichés
- **Classification LLM data_mec** : le batch processor et le worker individuel supportent le schema `data_mec`, classification auto réactivée sur ingestion MEC
- Nouvelles colonnes exposées : `crteId`, `crteAnneeInscription`, `crteOrientationStrategique`

## Détail des changements

### Endpoints dispositifs (`dashboard-te.service.ts`)
- `dispositifsAll()` : stats depuis `data_mec` avec breakdown `nbProjetsCrte` vs `nbProjetsMec`
- `dispositifsProjets()` : lecture `data_mec.projets_operationnels` avec `WHERE crte_id IS NOT NULL`, JOINs via `territoire_communes`

### Classification LLM
- `BatchClassificationProcessor` : nouveau paramètre `schema` propagé dans toute la chaîne submit → poll → process
- `ProjetQualificationService` : nouveau handler `classifyMecProjet()` pour read/write `data_mec`
- `MecService.scheduleClassification()` réactivé avec `schema: "data_mec"`
- `MecModule` : BullModule réinjecté
- `POST /management/batch-classify?schema=data_mec` pour lancer la classification batch

## Test plan

- [ ] Vérifier `GET /dashboard-te/dispositifs/all` retourne `nbProjetsCrte` et `nbProjetsMec`
- [ ] Vérifier `GET /dashboard-te/dispositifs/projets` ne retourne que les projets avec `crte_id IS NOT NULL`
- [ ] Vérifier les nouvelles colonnes `crteAnneeInscription`, `crteOrientationStrategique` dans la réponse
- [ ] Tester `POST /management/batch-classify?schema=data_mec&limit=5` — vérifie que la classification fonctionne sur data_mec
- [ ] Vérifier qu'un `POST /mec/v1/projets` avec contenu nouveau déclenche un job de classification