### PR TITLE
fix(aides): valider projetId sur GET /aides/feedback (400 explicite)

### DIFF
--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -68,6 +68,7 @@ describe("AidesController", () => {
   let mockWarmupService: jest.Mocked<AidesWarmupService>;
   let mockClassificationService: jest.Mocked<AideClassificationService>;
   let mockMatchingService: jest.Mocked<AidesMatchingService>;
+  let mockFeedbackService: jest.Mocked<AidesFeedbackService>;
   let mockProjetsService: jest.Mocked<GetProjetsService>;
   let mockQualificationQueue: jest.Mocked<Queue>;
   const mockLogger = {
@@ -116,7 +117,7 @@ describe("AidesController", () => {
       add: jest.fn().mockResolvedValue({ id: "auto-classify:test-id" }),
     } as unknown as jest.Mocked<Queue>;
 
-    const mockFeedbackService = {
+    mockFeedbackService = {
       create: jest.fn(),
       findByProjet: jest.fn(),
       delete: jest.fn(),
@@ -322,6 +323,57 @@ describe("AidesController", () => {
       expect(result.warmupStarted).toBe(true);
       // warmup is fire-and-forget, not awaited
       expect(result).not.toHaveProperty("warmup");
+    });
+  });
+
+  describe("feedback endpoints", () => {
+    const projetId = "019df7ce-1234-7890-abcd-ef0123456789";
+
+    it("createFeedback should delegate to feedbackService.create", async () => {
+      const dto = { projetId, idAt: "12345", reason: "wrong_territory" };
+      const created = {
+        id: "00000000-0000-0000-0000-000000000001",
+        projetId,
+        idAt: "12345",
+        feedback: "not_relevant",
+        reason: "wrong_territory",
+        source: "MEC",
+        createdAt: new Date(),
+      };
+      mockFeedbackService.create.mockResolvedValue(created);
+
+      const result = await controller.createFeedback(dto);
+
+      expect(mockFeedbackService.create).toHaveBeenCalledWith(dto);
+      expect(result).toEqual(created);
+    });
+
+    it("getFeedbacks should delegate to feedbackService.findByProjet", async () => {
+      const feedbacks = [
+        {
+          id: "00000000-0000-0000-0000-000000000001",
+          projetId,
+          idAt: "12345",
+          feedback: "not_relevant",
+          reason: null,
+          source: "MEC",
+          createdAt: new Date(),
+        },
+      ];
+      mockFeedbackService.findByProjet.mockResolvedValue(feedbacks);
+
+      const result = await controller.getFeedbacks(projetId);
+
+      expect(mockFeedbackService.findByProjet).toHaveBeenCalledWith(projetId);
+      expect(result).toEqual(feedbacks);
+    });
+
+    it("deleteFeedback should delegate to feedbackService.delete", async () => {
+      mockFeedbackService.delete.mockResolvedValue(undefined);
+
+      await controller.deleteFeedback({ projetId, idAt: "12345" });
+
+      expect(mockFeedbackService.delete).toHaveBeenCalledWith(projetId, "12345");
     });
   });
 });

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -4,6 +4,7 @@ import {
   Delete,
   Get,
   HttpCode,
+  ParseUUIDPipe,
   Post,
   Query,
   Res,
@@ -237,7 +238,13 @@ export class AidesController {
   @TrackApiUsage()
   @Get("feedback")
   @ApiOperation({ summary: "Liste des feedbacks pour un projet" })
-  async getFeedbacks(@Query("projetId") projetId: string) {
+  @ApiQuery({
+    name: "projetId",
+    required: true,
+    description: "ID du projet (UUID, communId)",
+    example: "019df7ce-1234-7890-abcd-ef0123456789",
+  })
+  async getFeedbacks(@Query("projetId", new ParseUUIDPipe()) projetId: string) {
     return this.feedbackService.findByProjet(projetId);
   }
 


### PR DESCRIPTION
## Contexte

Sylvain (MEC) a remonté que `POST /aides/feedback` fonctionne, mais que `GET /aides/feedback` ne renvoie rien :

> J'arrive à créer des feedbacks via l'endpoint POST, mais l'endpoint GET ne me liste rien en retour. J'ai testé avec le projet \`019db955-d3e9-71b2-b8f0-4c19ae99c193\` sur l'env staging.

Reproduction confirmée contre staging :
- `?projetId=019db955-...` → renvoie bien les 3 feedbacks créés
- `?projet_id=019db955-...` → renvoie `[]` silencieusement (Sylvain a probablement utilisé snake_case par cohérence avec `GET /aides?projet_id=...`)

## Cause

`@Query("projetId")` sans validation — si le param est absent ou mal nommé, on appelle `findByProjet(undefined)` qui matche zéro ligne et renvoie `[]` sans erreur.

## Convention retenue

`camelCase` pour les query params multi-mots, cohérent avec le reste du repo (`idType`, `planId`, `codeInsee`, etc.). `GET /aides?projet_id=...` reste l'exception historique — sera traité dans une PR séparée avec dépréciation graceful.

## Changements

- `ParseUUIDPipe` sur `@Query("projetId")` → `400 BadRequest` explicite si absent ou pas un UUID
- `@ApiQuery` Swagger avec `required: true` + exemple
- 3 tests unit pour les endpoints feedback (create, get, delete) — il n'y en avait aucun

## À communiquer à Sylvain

Une fois mergé/déployé staging :
- Utiliser `?projetId=...` (camelCase), pas `?projet_id=...`
- Toute erreur de nommage renvoie maintenant un 400 explicite

## Test plan

- [ ] CI verte
- [ ] Après déploiement staging, vérifier `GET /aides/feedback?projetId=019db955-d3e9-71b2-b8f0-4c19ae99c193` renvoie les 3 feedbacks
- [ ] Vérifier que `?projet_id=...` renvoie maintenant `400 BadRequest` (au lieu de `[]`)