### PR TITLE
feat(aides): aligner GET /aides sur projetId (camelCase) + dépréciation graceful de projet_id

### DIFF
--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -376,4 +376,54 @@ describe("AidesController", () => {
       expect(mockFeedbackService.delete).toHaveBeenCalledWith(projetId, "12345");
     });
   });
+
+  describe("listAides projetId param compat", () => {
+    beforeEach(() => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
+      mockMatchingService.match.mockReturnValue([
+        {
+          idAt: "1",
+          score: 0.5,
+          normalizedScore: 0.5,
+          scoreThematiques: 0.5,
+          scoreSites: 0,
+          scoreInterventions: 0,
+          axesMatched: 1,
+          labelsCommuns: { thematiques: ["X"], sites: [], interventions: [] },
+        },
+      ]);
+    });
+
+    it("should accept projetId (camelCase, canonical) without warning", async () => {
+      const { res } = makeRes();
+      const result = (await controller.listAides("test-id", res)) as AidesListResponse;
+
+      expect(result.status).toBe("ok");
+      expect(mockProjetsService.findOne).toHaveBeenCalledWith("test-id");
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining("Deprecated query param projet_id"));
+    });
+
+    it("should accept projet_id (snake_case, deprecated) and log a warning", async () => {
+      const { res } = makeRes();
+      const result = (await controller.listAides(undefined, res, undefined, "test-id")) as AidesListResponse;
+
+      expect(result.status).toBe("ok");
+      expect(mockProjetsService.findOne).toHaveBeenCalledWith("test-id");
+      expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Deprecated query param projet_id"));
+    });
+
+    it("should prefer projetId when both are provided (no warning)", async () => {
+      const { res } = makeRes();
+      const result = (await controller.listAides("camel-id", res, undefined, "snake-id")) as AidesListResponse;
+
+      expect(result.status).toBe("ok");
+      expect(mockProjetsService.findOne).toHaveBeenCalledWith("camel-id");
+      expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining("Deprecated query param projet_id"));
+    });
+
+    it("should throw 400 when neither projetId nor projet_id is provided", async () => {
+      const { res } = makeRes();
+      await expect(controller.listAides(undefined, res)).rejects.toThrow("projetId is required");
+    });
+  });
 });

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -69,9 +69,16 @@ export class AidesController {
       "Proxy enrichi de l'API Aides-Territoires. Retourne les aides avec classification thématiques/sites/interventions, filtrées par les territoires du projet (union des collectivités) et triées par score de matching.\n\n**Statuts de réponse** :\n- `200 ok` : aides matchées trouvées\n- `200 no_match` : aides présentes sur le périmètre mais aucune ne partage de label ≥ 0.8\n- `200 no_aides_on_perimeter` : aucune aide AT trouvée pour les codes INSEE du projet\n- `202 classification_pending` : projet pas encore classifié, job de classification (re)déclenché — réessayer après `retryAfter` secondes\n- `404` : projet inexistant",
   })
   @ApiQuery({
-    name: "projet_id",
+    name: "projetId",
     required: true,
     description: "ID projet pour filtrer par territoire et calculer le matching",
+    example: "019df7ce-1234-7890-abcd-ef0123456789",
+  })
+  @ApiQuery({
+    name: "projet_id",
+    required: false,
+    deprecated: true,
+    description: "Déprécié — utiliser `projetId` (camelCase). Sera supprimé après migration des consommateurs.",
   })
   @ApiQuery({ name: "limit", required: false, description: "Nombre max de résultats (défaut: 20)" })
   @ApiEndpointResponses({
@@ -86,12 +93,19 @@ export class AidesController {
       "Le projet n'a pas encore été classifié. Un job de classification a été (re)déclenché. Réessayer après `retryAfter` secondes.",
   })
   async listAides(
-    @Query("projet_id") projetId: string,
+    @Query("projetId") projetIdCamel: string | undefined,
     @Res({ passthrough: true }) res: Response,
     @Query("limit") limit?: string,
+    @Query("projet_id") projetIdSnake?: string,
   ): Promise<AidesListResponse | ClassificationPendingResponse> {
+    const projetId = projetIdCamel ?? projetIdSnake;
     if (!projetId) {
-      throw new BadRequestException("projet_id is required");
+      throw new BadRequestException("projetId is required");
+    }
+    if (!projetIdCamel && projetIdSnake) {
+      this.logger.warn(
+        `Deprecated query param projet_id used on GET /aides (use projetId instead) — projetId=${projetIdSnake}`,
+      );
     }
 
     const maxResults = parseInt(limit ?? "20", 10);

--- a/docs/api/classification-et-aides.md
+++ b/docs/api/classification-et-aides.md
@@ -129,15 +129,16 @@ Authorization: Bearer <MEC_API_KEY>
 ### 3. Trouver les aides pertinentes pour un projet
 
 ```http
-GET /aides?projet_id=019d...&limit=10
+GET /aides?projetId=019d...&limit=10
 Authorization: Bearer <MEC_API_KEY>
 ```
 
 **Paramètres** :
 | Param | Description | Requis |
 |-------|-------------|--------|
-| `projet_id` | ID du projet pour le matching et la résolution du périmètre | **Oui** |
+| `projetId` | ID du projet pour le matching et la résolution du périmètre | **Oui** |
 | `limit` | Nombre max de résultats (défaut: 20) | Non |
+| `projet_id` | _Déprécié_ — alias snake_case de `projetId`, accepté pour compat. Migrer vers `projetId`. | Non |
 
 > Le périmètre territorial est dérivé automatiquement des `collectivites` du projet (codes INSEE des communes). Pas besoin de passer `code_insee`.
 
@@ -151,7 +152,7 @@ L'endpoint renvoie l'un des 4 statuts suivants. **Tous les cas 200 et le 202 con
 | 200  | `no_match`                | Des aides existent sur le périmètre, mais aucune ne partage de label ≥ 0.8             | Message "aucune aide pertinente" + CTA enrichir desc |
 | 200  | `no_aides_on_perimeter`   | Aucune aide AT trouvée pour les codes INSEE du projet                                  | Message "pas d'aide AT pour ce territoire"           |
 | 202  | `classification_pending`  | Le projet n'est pas encore classifié — un job a été (re)déclenché                      | Loader + retry automatique après `retryAfter`s      |
-| 404  | (NotFoundException)       | `projet_id` inexistant en base                                                          | Erreur d'intégration MEC (ID jamais synchronisé)     |
+| 404  | (NotFoundException)       | `projetId` inexistant en base                                                          | Erreur d'intégration MEC (ID jamais synchronisé)     |
 
 #### `200 ok` — résultat nominal
 
@@ -420,7 +421,7 @@ Les aides individuelles (`at:aide:{id}`) sont partagées entre territoires : une
    POST /projets → { id: "019d..." }
 
 2. MEC appelle directement les aides
-   GET /aides?projet_id=019d...
+   GET /aides?projetId=019d...
    → 202 classification_pending si pas encore classifié
      → MEC attend retryAfter secondes et réessaye
    → 200 ok / no_match / no_aides_on_perimeter sinon


### PR DESCRIPTION
## Contexte

Suite au bug Sylvain (PR #460) sur `GET /aides/feedback` : on a tranché que la convention canonique du repo est **camelCase** pour les query params multi-mots (`idType`, `planId`, `codeInsee`, et désormais `projetId` sur `/aides/feedback`).

`GET /aides?projet_id=...` est l'unique exception historique. Cette PR aligne sans casser MEC.

## Changements

- `@Query("projetId")` devient le **canonique**, documenté Swagger avec `required: true` + `example`
- `@Query("projet_id")` accepté en **fallback**, marqué `deprecated: true` dans Swagger (UI affiche un strikethrough). Ne pas retirer tant que MEC n'a pas migré
- Logger warn à chaque usage de `projet_id` → permet de tracker quand le retirer
- `BadRequestException` si aucun des deux n'est fourni (au lieu du message précédent qui suggérait que `projet_id` était le bon nom)
- Doc `docs/api/classification-et-aides.md` à jour
- 4 tests unit ajoutés sur les variantes (camelCase / snake_case / les deux / aucun)

## Comportement post-merge

| Requête | Comportement |
|---|---|
| `GET /aides?projetId=...` | ✅ canonique, OK silencieux |
| `GET /aides?projet_id=...` | ✅ fonctionne, log warn côté API, marqué deprecated dans la doc |
| `GET /aides?projetId=A&projet_id=B` | `projetId` gagne (A), pas de warn |
| `GET /aides` (rien) | ❌ `400 BadRequest: projetId is required` |

## Suite

1. Mergé + déployé staging+prod
2. Communiquer à Matthieu/Sylvain (MEC) : migrer leur widget vers `?projetId=...`
3. Suivre les logs warn en prod sur 2-4 semaines
4. PR de retrait du fallback une fois les logs à zéro

## Test plan

- [ ] CI verte
- [ ] Tests unit passent (4 nouveaux dans `listAides projetId param compat`)
- [ ] Après staging : `GET /aides?projetId=019d...` fonctionne
- [ ] Après staging : `GET /aides?projet_id=019d...` fonctionne, warn loggé
- [ ] Swagger affiche `projet_id` rayé (deprecated)