### PR TITLE
Exposer Swagger dashboard-te sur le hub public /api

### DIFF
--- a/api/src/dashboard-te/dashboard-te-doc.setup.ts
+++ b/api/src/dashboard-te/dashboard-te-doc.setup.ts
@@ -1,0 +1,32 @@
+import { INestApplication } from "@nestjs/common";
+import { DocumentBuilder, SwaggerModule } from "@nestjs/swagger";
+import { DashboardTeModule } from "./dashboard-te.module";
+
+export function setupDashboardTeDoc(app: INestApplication) {
+  const config = new DocumentBuilder()
+    .setTitle("API Dashboard TE")
+    .setDescription(
+      "API interne du Dashboard Transition Écologique. " +
+        "Lit le schéma unifié `schema_commun_v2` (projets, fiches action, plans, clusters) " +
+        "issu de l'agrégation MEC + Fonds Vert + PVD + ACV + TeT + CRTE. " +
+        "Auth requise (clé `DashboardTE`) — proxifiée par le Worker Cloudflare via Turnstile + JWT.",
+    )
+    .setVersion("1.0")
+    .addBearerAuth()
+    .addTag("Dashboard TE", "Endpoints consommés par le SPA Dashboard TE V3")
+    .build();
+
+  const documentFactory = () =>
+    SwaggerModule.createDocument(app, config, {
+      include: [DashboardTeModule],
+    });
+
+  SwaggerModule.setup("api/dashboard-te", app, documentFactory, {
+    jsonDocumentUrl: "/api/dashboard-te/openapi.json",
+    customSiteTitle: "API Dashboard TE - Documentation",
+    swaggerOptions: {
+      tagsSorter: "alpha",
+      persistAuthorization: true,
+    },
+  });
+}

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -8,6 +8,7 @@ import { serveStatisticsDashboard } from "@/serve-statistics-dashboard";
 import { serveRessources } from "@/serve-ressources";
 import { setupReferentielDoc } from "@/referentiel/referentiel-doc.setup";
 import { setupOpendataDoc } from "@/plans-fiches/opendata-doc.setup";
+import { setupDashboardTeDoc } from "@/dashboard-te/dashboard-te-doc.setup";
 import { setupSwaggerHub } from "@/swagger-hub";
 import { serveLandingPages } from "@/landing/landing-pages";
 
@@ -25,6 +26,7 @@ async function bootstrap() {
   setupApp(app);
   setupReferentielDoc(app);
   setupOpendataDoc(app);
+  setupDashboardTeDoc(app);
   setupSwaggerHub(app);
   serveDemoWidget(app);
   serveStatisticsDashboard(app);

--- a/api/src/swagger-hub.ts
+++ b/api/src/swagger-hub.ts
@@ -11,6 +11,7 @@ export function setupSwaggerHub(app: INestApplication) {
         { name: "API Référentiel Collectivités", url: "/api/referentiel/openapi.json" },
         { name: "API Opendata — PCAET", url: "/api/opendata/openapi.json" },
         { name: "API Projets (legacy)", url: "/api/projets/openapi.json" },
+        { name: "API Dashboard TE", url: "/api/dashboard-te/openapi.json" },
       ],
     },
   });


### PR DESCRIPTION
## Contexte

Thomas part en absence prolongée à partir du 2026-05-09. Pour transmettre la doc des endpoints du Dashboard TE à l'associé qui prend le relais, on expose la doc OpenAPI du module `dashboard-te` sur le hub Swagger public `/api`.

## Contenu

- Nouveau `api/src/dashboard-te/dashboard-te-doc.setup.ts` — pattern identique à `referentiel-doc.setup.ts` et `opendata-doc.setup.ts`
- `api/src/main.ts` — import + appel `setupDashboardTeDoc(app)`
- `api/src/swagger-hub.ts` — 4e entrée du dropdown ("API Dashboard TE")

## Résultat

| URL | Contenu |
|---|---|
| `/api` | Swagger UI hub avec dropdown 4 APIs (Référentiel, Opendata PCAET, Projets legacy, **Dashboard TE**) |
| `/api/dashboard-te/openapi.json` | Spec OpenAPI 3.0 des 19 endpoints du module dashboard-te |

⚠️ **L'auth API elle-même reste protégée** : `ApiKeyGuard` avec clé `DASHBOARD_TE_API_KEY` (proxifiée par le Worker Cloudflare via Turnstile + JWT côté SPA). Seule la doc des endpoints est listée publiquement, ce qui est cohérent avec les 3 autres APIs du hub.

## Hors scope

Le controller `dashboard-te.controller.ts` n'est **pas** enrichi avec `@ApiOperation`/`@ApiQuery`/`@ApiResponse`. La doc affiche les méthodes HTTP, paths et params via les décorateurs existants (`@Get`/`@Param`/`@Query`) mais sans descriptions ni schémas de réponse. Cet enrichissement est consigné comme TODO T3 dans le runbook handover côté `dashboard-te`.

## Test plan

- [ ] Vérifier que `pnpm validate` passe (déjà OK localement)
- [ ] Après merge + déploiement, vérifier `https://api.collectivites.beta.gouv.fr/api/dashboard-te/openapi.json` (HTTP 200, JSON OpenAPI)
- [ ] Vérifier le dropdown sur `https://api.collectivites.beta.gouv.fr/api`
- [ ] Confirmer que les routes `/dashboard-te/*` répondent toujours en bearer (pas de régression auth)

## PR liée

dashboard-te : pipeline répétable + runbook handover.