### PR TITLE
Feat/dashboard te filtres classification

### DIFF
--- a/api/src/dashboard-te/dashboard-te.controller.ts
+++ b/api/src/dashboard-te/dashboard-te.controller.ts
@@ -8,6 +8,35 @@ const toInt = (v: string | undefined, def: number) => {
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : def;
 };
 
+const toList = (v: string | string[] | undefined): string[] | undefined => {
+  if (v == null) return undefined;
+  const arr = (Array.isArray(v) ? v : v.split(",")).map((s) => s.trim()).filter(Boolean);
+  return arr.length > 0 ? arr : undefined;
+};
+
+const parseScoreMin = (v: string | undefined): number | undefined => {
+  if (v == null || v === "") return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+};
+
+// Parses `label` or `label:score` (score = optional per-entry threshold).
+// Split on the last `:` only, and only treat the suffix as a score if it parses as a finite number;
+// otherwise the entire token is kept as the label (robust to labels containing `:`).
+const toClassifList = (v: string | string[] | undefined): { label: string; scoreMin?: number }[] | undefined => {
+  const raw = toList(v);
+  if (!raw) return undefined;
+  return raw.map((item) => {
+    const idx = item.lastIndexOf(":");
+    if (idx < 0) return { label: item };
+    const labelPart = item.slice(0, idx).trim();
+    const scorePart = item.slice(idx + 1).trim();
+    const score = Number(scorePart);
+    if (!labelPart || !Number.isFinite(score)) return { label: item };
+    return { label: labelPart, scoreMin: score };
+  });
+};
+
 @ApiTags("Dashboard TE")
 @Controller("dashboard-te")
 @UseGuards(ApiKeyGuard)
@@ -22,6 +51,24 @@ export class DashboardTeController {
   @Get("stats/departement/:code")
   statsDepartement(@Param("code") code: string) {
     return this.svc.statsDepartement(code);
+  }
+
+  @Get("stats/sites")
+  async statsSites(@Query("scoreMin") scoreMin?: string) {
+    const items = await this.svc.statsClassif("llm_sites", parseScoreMin(scoreMin));
+    return { items };
+  }
+
+  @Get("stats/thematiques")
+  async statsThematiques(@Query("scoreMin") scoreMin?: string) {
+    const items = await this.svc.statsClassif("llm_thematiques", parseScoreMin(scoreMin));
+    return { items };
+  }
+
+  @Get("stats/interventions")
+  async statsInterventions(@Query("scoreMin") scoreMin?: string) {
+    const items = await this.svc.statsClassif("llm_interventions", parseScoreMin(scoreMin));
+    return { items };
   }
 
   @Get("collectivites")
@@ -50,6 +97,10 @@ export class DashboardTeController {
     @Query("siren") siren?: string,
     @Query("levier") levier?: string,
     @Query("competence") competence?: string,
+    @Query("site") site?: string | string[],
+    @Query("intervention") intervention?: string | string[],
+    @Query("thematique") thematique?: string | string[],
+    @Query("scoreMin") scoreMin?: string,
     @Query("source") source?: string,
     @Query("phase") phase?: string,
     @Query("q") q?: string,
@@ -58,12 +109,17 @@ export class DashboardTeController {
   ) {
     const p = toInt(page, 0);
     const l = Math.min(toInt(limit, 50), 200);
+    const scoreMinNum = scoreMin != null && scoreMin !== "" ? Number(scoreMin) : undefined;
     const result = await this.svc.projets({
       commune,
       departement,
       siren,
       levier,
       competence,
+      site: toClassifList(site),
+      intervention: toClassifList(intervention),
+      thematique: toClassifList(thematique),
+      scoreMin: Number.isFinite(scoreMinNum) ? scoreMinNum : undefined,
       source,
       phase,
       q,

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -259,6 +259,39 @@ export class DashboardTeService {
     };
   }
 
+  /**
+   * Distribution of a JSONB classification column (first element's label) across all projects,
+   * keeping only entries whose score >= scoreMin (default 0.8). Used to feed front-end dropdowns
+   * with values actually present in the data.
+   */
+  async statsClassif(
+    column: "llm_sites" | "llm_thematiques" | "llm_interventions",
+    scoreMin?: number,
+  ): Promise<{ value: string; count: number }[]> {
+    const threshold = scoreMin ?? 0.8;
+    const col = (() => {
+      switch (column) {
+        case "llm_sites":
+          return sql`p.llm_sites`;
+        case "llm_thematiques":
+          return sql`p.llm_thematiques`;
+        case "llm_interventions":
+          return sql`p.llm_interventions`;
+      }
+    })();
+    const rows = await this.query<{ value: string; count: string }>(sql`
+      SELECT
+        ${col}->0->>'label' AS value,
+        count(*)::text AS count
+      FROM schema_commun_v2.projets_operationnels p
+      WHERE ${col}->0->>'label' IS NOT NULL
+        AND COALESCE((${col}->0->>'score')::numeric, 0) >= ${threshold}
+      GROUP BY 1
+      ORDER BY count(*) DESC, value
+    `);
+    return rows.map((r) => ({ value: r.value, count: Number(r.count) }));
+  }
+
   async collectivites(params: { region?: string; departement?: string; q?: string; page: number; limit: number }) {
     const { region, departement, q, page, limit } = params;
     const pattern = q ? `%${q}%` : null;
@@ -321,16 +354,45 @@ export class DashboardTeService {
     siren?: string;
     levier?: string;
     competence?: string;
+    site?: { label: string; scoreMin?: number }[];
+    intervention?: { label: string; scoreMin?: number }[];
+    thematique?: { label: string; scoreMin?: number }[];
+    scoreMin?: number;
     source?: string;
     phase?: string;
     q?: string;
     page: number;
     limit: number;
   }) {
-    const { commune, departement, siren, levier, competence, source, phase, q, page, limit } = params;
+    const {
+      commune,
+      departement,
+      siren,
+      levier,
+      competence,
+      site,
+      intervention,
+      thematique,
+      source,
+      phase,
+      q,
+      page,
+      limit,
+    } = params;
+    const scoreMin = params.scoreMin ?? 0.8;
     const pattern = q ? `%${q}%` : null;
     const leviersPattern = levier ? `%${levier}%` : null;
     const competencesPattern = competence ? `%${competence}%` : null;
+
+    // Builds `(label=X1 AND score>=S1) OR (label=X2 AND score>=S2) ...`
+    // where Sn falls back to the request-level scoreMin if not set per-entry.
+    const classifClause = (col: SQL, entries: { label: string; scoreMin?: number }[]): SQL => {
+      const parts = entries.map(
+        (e) =>
+          sql`(${col}->0->>'label' = ${e.label} AND COALESCE((${col}->0->>'score')::numeric, 0) >= ${e.scoreMin ?? scoreMin})`,
+      );
+      return sql`(${sql.join(parts, sql` OR `)})`;
+    };
 
     const conditions: SQL[] = [];
     if (commune) conditions.push(sql`lpc.insee_com = ${commune}`);
@@ -341,6 +403,9 @@ export class DashboardTeService {
     if (pattern) conditions.push(sql`p.nom ILIKE ${pattern}`);
     if (leviersPattern) conditions.push(sql`p."leviersSgpe" ILIKE ${leviersPattern}`);
     if (competencesPattern) conditions.push(sql`p."competencesM57" ILIKE ${competencesPattern}`);
+    if (site && site.length > 0) conditions.push(classifClause(sql`p.llm_sites`, site));
+    if (intervention && intervention.length > 0) conditions.push(classifClause(sql`p.llm_interventions`, intervention));
+    if (thematique && thematique.length > 0) conditions.push(classifClause(sql`p.llm_thematiques`, thematique));
 
     const needsCommuneJoin = Boolean(commune ?? departement);
 

--- a/api/src/referentiel/referentiel-doc.setup.ts
+++ b/api/src/referentiel/referentiel-doc.setup.ts
@@ -14,6 +14,10 @@ export function setupReferentielDoc(app: INestApplication) {
     .addTag("Référentiel - Groupements", "EPCI, syndicats, PETR (9 345 entités)")
     .addTag("Référentiel - Compétences", "123 compétences Banatic en 10 catégories")
     .addTag("Référentiel - Recherche", "Recherche transversale par nom")
+    .addTag(
+      "Référentiel - Taxonomies",
+      "Listes fermées sites, thématiques, interventions et leviers utilisées par la classification",
+    )
     .build();
 
   const documentFactory = () =>

--- a/api/src/referentiel/referentiel.module.ts
+++ b/api/src/referentiel/referentiel.module.ts
@@ -7,9 +7,16 @@ import { CompetencesController } from "./competences/competences.controller";
 import { CompetencesService } from "./competences/competences.service";
 import { RechercheController } from "./recherche/recherche.controller";
 import { RechercheService } from "./recherche/recherche.service";
+import { TaxonomiesController } from "./taxonomies/taxonomies.controller";
 
 @Module({
-  controllers: [CommunesController, GroupementsController, CompetencesController, RechercheController],
+  controllers: [
+    CommunesController,
+    GroupementsController,
+    CompetencesController,
+    RechercheController,
+    TaxonomiesController,
+  ],
   providers: [CommunesService, GroupementsService, CompetencesService, RechercheService],
 })
 export class ReferentielModule {}

--- a/api/src/referentiel/taxonomies/taxonomies.controller.ts
+++ b/api/src/referentiel/taxonomies/taxonomies.controller.ts
@@ -1,0 +1,34 @@
+import { Controller, Get } from "@nestjs/common";
+import { ApiOperation, ApiTags } from "@nestjs/swagger";
+import { sites } from "@/projet-qualification/classification/const/sites";
+import { thematiques } from "@/projet-qualification/classification/const/thematiques";
+import { interventions } from "@/projet-qualification/classification/const/interventions";
+import { leviers } from "@/shared/const/leviers";
+
+@Controller("referentiel/v1")
+@ApiTags("Référentiel - Taxonomies")
+export class TaxonomiesController {
+  @Get("sites")
+  @ApiOperation({ summary: "Lister les sites de la taxonomie de classification" })
+  getSites(): { items: readonly string[] } {
+    return { items: sites };
+  }
+
+  @Get("thematiques")
+  @ApiOperation({ summary: "Lister les thématiques de la taxonomie de classification" })
+  getThematiques(): { items: readonly string[] } {
+    return { items: thematiques };
+  }
+
+  @Get("interventions")
+  @ApiOperation({ summary: "Lister les interventions de la taxonomie de classification" })
+  getInterventions(): { items: readonly string[] } {
+    return { items: interventions };
+  }
+
+  @Get("leviers")
+  @ApiOperation({ summary: "Lister les leviers SGPE" })
+  getLeviers(): { items: readonly string[] } {
+    return { items: leviers };
+  }
+}


### PR DESCRIPTION
## Changements

  ### `/dashboard-te/projets` — nouveaux query params
  - `site`, `intervention`, `thematique` : multi-valeurs (CSV ou répétés), syntaxe `label:score` optionnelle pour seuil par entrée
  - `scoreMin` : seuil global (défaut **0.8**)

  ### `/dashboard-te/stats/*` — nouveaux endpoints
  - `GET /stats/sites|thematiques|interventions` → `{ items: [{ value, count }] }` avec filtre `scoreMin` (défaut 0.8)

  ### `/referentiel/v1/*` — nouveaux endpoints (public, pas d'auth)
  - `GET /sites|thematiques|interventions|leviers` → `{ items: string[] }` exposant les constantes TS de classification

  ## Notes d'implémentation
  - Schéma DB : `llm_sites`/`llm_interventions`/`llm_thematiques` sont des JSONB arrays — match sur `->0->>'label'` (premier élément, cohérent avec ce que la liste 
  retourne déjà).
  - Le filtre `thematique` passe de `"classificationThematiques"` (CSV sans score) à `llm_thematiques` (JSONB scoré) pour permettre le `scoreMin` cohérent sur les 3 
  axes.
  - Les filtres existants `levier`/`competence` restent en ILIKE substring (hors scope).
