### PR TITLE
fix(api): améliorer typing OpenAPI sur les endpoints /aides/feedback

### DIFF
--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -30,7 +30,7 @@ import { AidesMatchingService } from "./aides-matching.service";
 import { AidesCacheService } from "./aides-cache.service";
 import { AidesWarmupService } from "./aides-warmup.service";
 import { AidesFeedbackService } from "./aides-feedback.service";
-import { CreateAideFeedbackRequest, DeleteAideFeedbackRequest } from "./dto/aide-feedback.dto";
+import { AideFeedbackResponse, CreateAideFeedbackRequest, DeleteAideFeedbackRequest } from "./dto/aide-feedback.dto";
 import {
   Aide,
   AideMatchResult,
@@ -245,7 +245,8 @@ export class AidesController {
   @TrackApiUsage()
   @Post("feedback")
   @ApiOperation({ summary: "Signaler une aide non pertinente pour un projet" })
-  async createFeedback(@Body() dto: CreateAideFeedbackRequest) {
+  @ApiEndpointResponses({ successStatus: 201, response: AideFeedbackResponse })
+  async createFeedback(@Body() dto: CreateAideFeedbackRequest): Promise<AideFeedbackResponse> {
     return this.feedbackService.create(dto);
   }
 
@@ -258,7 +259,8 @@ export class AidesController {
     description: "ID du projet (UUID, communId)",
     example: "019df7ce-1234-7890-abcd-ef0123456789",
   })
-  async getFeedbacks(@Query("projetId", new ParseUUIDPipe()) projetId: string) {
+  @ApiEndpointResponses({ successStatus: 200, response: AideFeedbackResponse, isArray: true })
+  async getFeedbacks(@Query("projetId", new ParseUUIDPipe()) projetId: string): Promise<AideFeedbackResponse[]> {
     return this.feedbackService.findByProjet(projetId);
   }
 
@@ -266,7 +268,8 @@ export class AidesController {
   @Delete("feedback")
   @ApiOperation({ summary: "Annuler un feedback" })
   @HttpCode(204)
-  async deleteFeedback(@Body() dto: DeleteAideFeedbackRequest) {
+  @ApiEndpointResponses({ successStatus: 204 })
+  async deleteFeedback(@Body() dto: DeleteAideFeedbackRequest): Promise<void> {
     return this.feedbackService.delete(dto.projetId, dto.idAt);
   }
 

--- a/api/src/shared/decorator/api-response.decorator.ts
+++ b/api/src/shared/decorator/api-response.decorator.ts
@@ -4,7 +4,7 @@ import { ErrorResponse } from "../dto/error.response";
 
 export interface ApiResponseOptions {
   successStatus: number;
-  response: Type<unknown>;
+  response?: Type<unknown>;
   description?: string;
   isArray?: boolean;
 }


### PR DESCRIPTION
Ajout d'annotations Swagger sur les endpoints `/aides/feedback`, pour pouvoir côté client générer des types TS automatiquement