### PR TITLE
fix(aides): fallback data_mec/data_tet sur findOne + routing des jobs de classification

### DIFF
--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -105,10 +105,13 @@ describe("AidesController", () => {
     } as unknown as jest.Mocked<AidesMatchingService>;
 
     mockProjetsService = {
-      findOne: jest.fn().mockResolvedValue({
-        id: "test-id",
-        collectivites: [{ type: "Commune", codeInsee: "44109" }],
-        classificationScores: { thematiques: [], sites: [], interventions: [] },
+      findOneWithSource: jest.fn().mockResolvedValue({
+        projet: {
+          id: "test-id",
+          collectivites: [{ type: "Commune", codeInsee: "44109" }],
+          classificationScores: { thematiques: [], sites: [], interventions: [] },
+        },
+        source: "public",
       }),
     } as unknown as jest.Mocked<GetProjetsService>;
 
@@ -202,10 +205,13 @@ describe("AidesController", () => {
 
   describe("listAides response statuses", () => {
     it("should return 202 + classification_pending and enqueue a job when project is unclassified", async () => {
-      mockProjetsService.findOne.mockResolvedValue({
-        id: "test-id",
-        collectivites: [{ type: "Commune", codeInsee: "44109" }],
-        classificationScores: null,
+      mockProjetsService.findOneWithSource.mockResolvedValue({
+        projet: {
+          id: "test-id",
+          collectivites: [{ type: "Commune", codeInsee: "44109" }],
+          classificationScores: null,
+        },
+        source: "public",
       } as never);
 
       const { res, statusSpy, headerSpy } = makeRes();
@@ -224,11 +230,54 @@ describe("AidesController", () => {
       );
     });
 
+    it("should tag the classification job with schema=data_mec when projet comes from data_mec", async () => {
+      mockProjetsService.findOneWithSource.mockResolvedValue({
+        projet: {
+          id: "test-id",
+          collectivites: [{ type: "Commune", codeInsee: "44109" }],
+          classificationScores: null,
+        },
+        source: "data_mec",
+      } as never);
+
+      const { res } = makeRes();
+      await controller.listAides("test-id", res);
+
+      expect(mockQualificationQueue.add).toHaveBeenCalledWith(
+        PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+        { projetId: "test-id", schema: "data_mec" },
+        expect.objectContaining({ jobId: "auto-classify:test-id" }),
+      );
+    });
+
+    it("should tag the classification job as ficheActionId when projet comes from data_tet", async () => {
+      mockProjetsService.findOneWithSource.mockResolvedValue({
+        projet: {
+          id: "test-id",
+          collectivites: [{ type: "Commune", codeInsee: "44109" }],
+          classificationScores: null,
+        },
+        source: "data_tet",
+      } as never);
+
+      const { res } = makeRes();
+      await controller.listAides("test-id", res);
+
+      expect(mockQualificationQueue.add).toHaveBeenCalledWith(
+        PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+        { ficheActionId: "test-id" },
+        expect.objectContaining({ jobId: "auto-classify:test-id" }),
+      );
+    });
+
     it("should not re-enqueue when a classification job is already in flight", async () => {
-      mockProjetsService.findOne.mockResolvedValue({
-        id: "test-id",
-        collectivites: [{ type: "Commune", codeInsee: "44109" }],
-        classificationScores: null,
+      mockProjetsService.findOneWithSource.mockResolvedValue({
+        projet: {
+          id: "test-id",
+          collectivites: [{ type: "Commune", codeInsee: "44109" }],
+          classificationScores: null,
+        },
+        source: "public",
       } as never);
 
       mockQualificationQueue.getJob.mockResolvedValue({
@@ -244,10 +293,13 @@ describe("AidesController", () => {
     });
 
     it("should remove a stale completed/failed job before re-enqueuing", async () => {
-      mockProjetsService.findOne.mockResolvedValue({
-        id: "test-id",
-        collectivites: [{ type: "Commune", codeInsee: "44109" }],
-        classificationScores: null,
+      mockProjetsService.findOneWithSource.mockResolvedValue({
+        projet: {
+          id: "test-id",
+          collectivites: [{ type: "Commune", codeInsee: "44109" }],
+          classificationScores: null,
+        },
+        source: "public",
       } as never);
 
       const removeSpy = jest.fn();
@@ -399,7 +451,7 @@ describe("AidesController", () => {
       const result = (await controller.listAides("test-id", res)) as AidesListResponse;
 
       expect(result.status).toBe("ok");
-      expect(mockProjetsService.findOne).toHaveBeenCalledWith("test-id");
+      expect(mockProjetsService.findOneWithSource).toHaveBeenCalledWith("test-id");
       expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining("Deprecated query param projet_id"));
     });
 
@@ -408,7 +460,7 @@ describe("AidesController", () => {
       const result = (await controller.listAides(undefined, res, undefined, "test-id")) as AidesListResponse;
 
       expect(result.status).toBe("ok");
-      expect(mockProjetsService.findOne).toHaveBeenCalledWith("test-id");
+      expect(mockProjetsService.findOneWithSource).toHaveBeenCalledWith("test-id");
       expect(mockLogger.warn).toHaveBeenCalledWith(expect.stringContaining("Deprecated query param projet_id"));
     });
 
@@ -417,7 +469,7 @@ describe("AidesController", () => {
       const result = (await controller.listAides("camel-id", res, undefined, "snake-id")) as AidesListResponse;
 
       expect(result.status).toBe("ok");
-      expect(mockProjetsService.findOne).toHaveBeenCalledWith("camel-id");
+      expect(mockProjetsService.findOneWithSource).toHaveBeenCalledWith("camel-id");
       expect(mockLogger.warn).not.toHaveBeenCalledWith(expect.stringContaining("Deprecated query param projet_id"));
     });
 

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -18,7 +18,7 @@ import { Queue } from "bullmq";
 import { ApiKeyGuard } from "@/auth/api-key-guard";
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
 import { CustomLogger } from "@logging/logger.service";
-import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
+import { GetProjetsService, ProjetSource } from "@projets/services/get-projets/get-projets.service";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import {
   PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
@@ -110,12 +110,13 @@ export class AidesController {
 
     const maxResults = parseInt(limit ?? "20", 10);
 
-    // 1. Load project (throws 404 if not found)
-    const projet = await this.projetsService.findOne(projetId);
+    // 1. Load project (throws 404 if not found) + détecte la source pour
+    //    pouvoir tagger correctement un éventuel job de classification.
+    const { projet, source } = await this.projetsService.findOneWithSource(projetId);
 
     // 2. If not classified yet → enqueue classification + return 202
     if (!projet.classificationScores) {
-      const triggered = await this.triggerClassificationIfNeeded(projetId);
+      const triggered = await this.triggerClassificationIfNeeded(projetId, source);
       res.status(202).setHeader("Retry-After", String(CLASSIFICATION_RETRY_AFTER_SECONDS));
       return {
         status: "classification_pending",
@@ -183,9 +184,14 @@ export class AidesController {
   /**
    * Enqueue a classification job for the project if none is already pending or active.
    * Uses a deterministic jobId so concurrent polls from MEC don't pile up duplicate jobs.
+   * Le payload du job dépend de la source du projet pour que le processor
+   * (projet-qualification.service.ts) écrive dans la bonne table :
+   *   - public        → { projetId }                  → analyzeAndUpdateClassification (public.projets)
+   *   - data_mec      → { projetId, schema: "data_mec" } → classifyMecProjet (data_mec.projets_operationnels)
+   *   - data_tet      → { ficheActionId: projetId }   → classifyFicheAction (data_tet.fiches_action)
    * Returns true if a new job was enqueued, false if one was already in flight.
    */
-  private async triggerClassificationIfNeeded(projetId: string): Promise<boolean> {
+  private async triggerClassificationIfNeeded(projetId: string, source: ProjetSource): Promise<boolean> {
     const jobId = `auto-classify:${projetId}`;
     const existing = await this.qualificationQueue.getJob(jobId);
 
@@ -199,17 +205,29 @@ export class AidesController {
       await existing.remove();
     }
 
-    await this.qualificationQueue.add(
-      PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
-      { projetId },
-      {
-        jobId,
-        attempts: 3,
-        backoff: { type: "exponential", delay: 5000 },
-      },
-    );
-    this.logger.log(`Enqueued classification job for ${projetId} (triggered by GET /aides)`);
+    const jobData = this.buildClassificationJobData(projetId, source);
+
+    await this.qualificationQueue.add(PROJECT_QUALIFICATION_CLASSIFICATION_JOB, jobData, {
+      jobId,
+      attempts: 3,
+      backoff: { type: "exponential", delay: 5000 },
+    });
+    this.logger.log(`Enqueued classification job for ${projetId} (source: ${source}, triggered by GET /aides)`);
     return true;
+  }
+
+  private buildClassificationJobData(
+    projetId: string,
+    source: ProjetSource,
+  ): { projetId?: string; ficheActionId?: string; schema?: string } {
+    switch (source) {
+      case "data_tet":
+        return { ficheActionId: projetId };
+      case "data_mec":
+        return { projetId, schema: "data_mec" };
+      case "public":
+        return { projetId };
+    }
   }
 
   @TrackApiUsage()

--- a/api/src/projets/services/get-projets/get-projets.service.ts
+++ b/api/src/projets/services/get-projets/get-projets.service.ts
@@ -1,8 +1,15 @@
 import { DatabaseService } from "@database/database.service";
-import { collectivites, mecProjetsOperationnels, projets, tetFichesAction } from "@database/schema";
+import {
+  collectivites,
+  mecProjetsOperationnels,
+  PhaseStatut,
+  projets,
+  ProjetPhase,
+  tetFichesAction,
+} from "@database/schema";
 import { CustomLogger } from "@logging/logger.service";
 import { Injectable, NotFoundException } from "@nestjs/common";
-import { eq, InferSelectModel } from "drizzle-orm";
+import { eq, inArray, InferSelectModel } from "drizzle-orm";
 import { ProjetResponse } from "@projets/dto/projet.dto";
 import { CompetenceCodes, IdType, Leviers } from "@/shared/types";
 import { ProjectPublicInfoResponse } from "@projets/dto/project-public-info.dto";
@@ -12,6 +19,13 @@ type Collectivite = InferSelectModel<typeof collectivites>;
 type ProjetWithCollectivites = InferSelectModel<typeof projets> & {
   collectivites: { collectivite: Collectivite }[];
 };
+
+export type ProjetSource = "public" | "data_mec" | "data_tet";
+
+export interface ProjetWithSource {
+  projet: ProjetResponse;
+  source: ProjetSource;
+}
 
 @Injectable()
 export class GetProjetsService {
@@ -41,6 +55,16 @@ export class GetProjetsService {
   }
 
   async findOne(id: string): Promise<ProjetResponse> {
+    return (await this.findOneWithSource(id)).projet;
+  }
+
+  /**
+   * Comme findOne, mais retourne aussi la source réelle du projet
+   * (public/data_mec/data_tet). Utile aux appelants qui doivent router le
+   * traitement aval selon la table d'origine — typiquement l'enqueue de jobs
+   * de classification (cf. aides.controller.ts).
+   */
+  async findOneWithSource(id: string): Promise<ProjetWithSource> {
     const projet = (await this.dbService.database.query.projets.findFirst({
       where: eq(projets.id, id),
       with: {
@@ -52,12 +76,18 @@ export class GetProjetsService {
       },
     })) as ProjetWithCollectivites | undefined;
 
-    if (!projet) {
-      this.logger.warn("Projet not found", { projetId: id });
-      throw new NotFoundException(`Projet with ID ${id} not found`);
+    if (projet) {
+      return { projet: this.mapFieldsToDTO(projet), source: "public" };
     }
 
-    return this.mapFieldsToDTO(projet);
+    // Fallback : projets MEC/TeT inscrits directement dans data_mec/data_tet
+    // (bypass de POST /projets côté pipeline). Aligne findOne sur getPublicInfo
+    // et getServicesByProjectId qui font déjà ce fallback.
+    const fallback = await this.findFallbackProjetResponse(id);
+    if (fallback) return fallback;
+
+    this.logger.warn("Projet not found", { projetId: id });
+    throw new NotFoundException(`Projet with ID ${id} not found`);
   }
 
   async getPublicInfo(id: string, idType: IdType): Promise<ProjectPublicInfoResponse> {
@@ -162,6 +192,118 @@ export class GetProjetsService {
     if (tetFiche) return { ...tetFiche, phase: null };
 
     return null;
+  }
+
+  /**
+   * Full-DTO fallback for findOne. Used when projet absent de public.projets
+   * mais présent dans data_mec.projets_operationnels ou data_tet.fiches_action.
+   */
+  private async findFallbackProjetResponse(id: string): Promise<ProjetWithSource | null> {
+    this.logger.warn("Falling back to data_mec for findOne", { projetId: id });
+    const [mec] = await this.dbService.database
+      .select()
+      .from(mecProjetsOperationnels)
+      .where(eq(mecProjetsOperationnels.id, id));
+
+    if (mec) {
+      const collectivitesList = await this.resolveCollectivitesFromTerritoire(
+        mec.territoireCommunes,
+        mec.collectiviteResponsableSiren,
+      );
+      return { projet: this.mapMecToProjetResponse(mec, collectivitesList), source: "data_mec" };
+    }
+
+    this.logger.warn("Falling back to data_tet for findOne", { projetId: id });
+    const [tet] = await this.dbService.database.select().from(tetFichesAction).where(eq(tetFichesAction.id, id));
+
+    if (tet) {
+      const collectivitesList = await this.resolveCollectivitesFromTerritoire(
+        tet.territoireCommunes,
+        tet.collectiviteResponsableSiren,
+      );
+      return { projet: this.mapTetToProjetResponse(tet, collectivitesList), source: "data_tet" };
+    }
+
+    return null;
+  }
+
+  private mapMecToProjetResponse(
+    mec: InferSelectModel<typeof mecProjetsOperationnels>,
+    collectivitesList: Collectivite[],
+  ): ProjetResponse {
+    return {
+      id: mec.id,
+      createdAt: mec.createdAt,
+      updatedAt: mec.updatedAt,
+      nom: mec.nom,
+      description: mec.description,
+      porteur: null,
+      collectivites: collectivitesList,
+      budgetPrevisionnel: mec.budgetPrevisionnel,
+      dateDebutPrevisionnelle: mec.dateDebut,
+      phaseStatut: (mec.phaseStatut as PhaseStatut | null) ?? null,
+      phase: (mec.phase as ProjetPhase | null) ?? null,
+      programme: null,
+      competences: (mec.competencesM57 as CompetenceCodes | null) ?? null,
+      leviers: (mec.leviersSgpe as Leviers | null) ?? null,
+      classificationThematiques: mec.classificationThematiques ?? null,
+      classificationSites: mec.classificationSites ?? null,
+      classificationInterventions: mec.classificationInterventions ?? null,
+      probabiliteTE: mec.probabiliteTe !== null && mec.probabiliteTe !== undefined ? String(mec.probabiliteTe) : null,
+      classificationScores: mec.classificationScores ?? null,
+      mecId: null,
+      tetId: null,
+      recocoId: null,
+    };
+  }
+
+  private mapTetToProjetResponse(
+    tet: InferSelectModel<typeof tetFichesAction>,
+    collectivitesList: Collectivite[],
+  ): ProjetResponse {
+    return {
+      id: tet.id,
+      createdAt: tet.createdAt,
+      updatedAt: tet.updatedAt,
+      nom: tet.nom,
+      description: tet.description,
+      porteur: null,
+      collectivites: collectivitesList,
+      budgetPrevisionnel: null,
+      dateDebutPrevisionnelle: null,
+      phaseStatut: null,
+      phase: null,
+      programme: null,
+      competences: (tet.competencesM57 as CompetenceCodes | null) ?? null,
+      leviers: (tet.leviersSgpe as Leviers | null) ?? null,
+      classificationThematiques: tet.classificationThematiques ?? null,
+      classificationSites: tet.classificationSites ?? null,
+      classificationInterventions: tet.classificationInterventions ?? null,
+      probabiliteTE: tet.probabiliteTE ?? null,
+      classificationScores: tet.classificationScores ?? null,
+      mecId: null,
+      tetId: null,
+      recocoId: null,
+    };
+  }
+
+  /**
+   * Résout les collectivités d'un projet MEC/TeT.
+   * 1) territoire_communes (codes INSEE) → query batch sur public.collectivites
+   * 2) Fallback sur collectivite_responsable_siren si territoire vide
+   */
+  private async resolveCollectivitesFromTerritoire(
+    codesInsee: string[] | null,
+    siren: string | null,
+  ): Promise<Collectivite[]> {
+    if (codesInsee && codesInsee.length > 0) {
+      const rows = await this.dbService.database
+        .select()
+        .from(collectivites)
+        .where(inArray(collectivites.codeInsee, codesInsee));
+      if (rows.length > 0) return rows;
+    }
+    return this.resolveCollectiviteFromSiren(siren);
   }
 
   /**


### PR DESCRIPTION
## Contexte

`GET /aides?projetId=<uuid>` retourne `404` en staging pour un projet créé via le pipeline MEC parce que celui-ci insère directement dans `data_mec.projets_operationnels` sans passer par `POST /projets` (donc `public.projets` reste vide pour ce projet).

`get-projets.service.ts:findOne()` ne lisait que `public.projets` — alors que `getPublicInfo()` (même service) et `getServicesByProjectId()` (services.service.ts) font déjà un fallback `data_mec` → `data_tet`. Incohérence interne du code.

En cascade, lorsqu'un projet MEC n'avait pas encore de `classificationScores`, `/aides` enquêtait un job de classification dont le payload ne taggait pas la source. Le processor (`projet-qualification.service.ts`) retombait alors sur la branche `public.projets` et l'`UPDATE` final ne touchait aucune ligne → boucle de classification jamais résolue.

## Changements

### `api/src/projets/services/get-projets/get-projets.service.ts`
- Nouveau type exporté `ProjetSource = "public" | "data_mec" | "data_tet"` et interface `ProjetWithSource`.
- Nouvelle méthode `findOneWithSource(id)` qui retourne `{ projet, source }`. `findOne(id)` devient un wrapper trivial — aucun callsite existant n'est cassé.
- Fallback `public.projets` → `data_mec.projets_operationnels` → `data_tet.fiches_action`.
- Mappers `mapMecToProjetResponse` / `mapTetToProjetResponse` qui produisent un `ProjetResponse` complet à partir des données MEC/TeT (classificationScores, competencesM57, leviersSgpe, classifs v0.2, etc.).
- Résolution des collectivités via `territoire_communes` (codes INSEE → batch lookup `public.collectivites`) avec fallback sur `collectivite_responsable_siren`.

### `api/src/aides/aides.controller.ts`
- `listAides` utilise `findOneWithSource` et propage la `source` à `triggerClassificationIfNeeded`.
- Nouveau `buildClassificationJobData(projetId, source)` qui construit le payload BullMQ en respectant le contrat de `projet-qualification.service.ts:process()` :

| Source | Payload | Branche prise |
|---|---|---|
| `public` | `{ projetId }` | `analyzeAndUpdateClassification` → `public.projets` |
| `data_mec` | `{ projetId, schema: "data_mec" }` | `classifyMecProjet` → `data_mec.projets_operationnels` |
| `data_tet` | `{ ficheActionId: projetId }` | `classifyFicheAction` → `data_tet.fiches_action` |

## Limitations connues
- `porteur`, `mecId`, `tetId`, `recocoId`, `programme` retournent `null` pour les projets fallback (ces champs n'existent pas dans `data_mec`/`data_tet`). Le porteur pourrait être enrichi via `data_mec.external_ids` ultérieurement si nécessaire.
- Aucun nouveau test ajouté — les specs existantes (`get-projets.service.spec.ts:142-181`) couvrent uniquement la voie `public.projets` qui reste inchangée. Tests d'intégration pour le fallback à ajouter dans un PR de suivi.