### PR TITLE
chore(aides): rééquilibrer le matching combiné vers le thématique

### DIFF
--- a/api/scripts/aides-labels-stats.ts
+++ b/api/scripts/aides-labels-stats.ts
@@ -69,7 +69,7 @@ const DEFAULT_THRESHOLD = 0.8;
 const TERRITORY_PREFIX = "at:territory:";
 const AIDE_PREFIX = "at:aide:";
 // Plancher de rescue textuel — aligné sur aides.controller.ts.
-const MIN_TEXTUAL_RESCUE = 0.2;
+const MIN_TEXTUAL_RESCUE = 0.35;
 
 // ─── DB config (parse manuel pour ignorer sslmode de l'URL) ──────────────────
 

--- a/api/scripts/diagnose-aides-geo.ts
+++ b/api/scripts/diagnose-aides-geo.ts
@@ -45,9 +45,9 @@ const SCORE_THRESHOLD = 0.8;
 const SCORE_OFFSET = 0.1;
 
 // Combinaison thématique/textuel — alignée sur aides.controller.ts.
-const W_THEMATIC = 0.7;
-const W_TEXTUAL = 0.3;
-const MIN_TEXTUAL_RESCUE = 0.2;
+const W_THEMATIC = 0.85;
+const W_TEXTUAL = 0.15;
+const MIN_TEXTUAL_RESCUE = 0.35;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -405,8 +405,8 @@ describe("AidesController", () => {
       mockMatchingService.match.mockReturnValue([]); // aucun match thématique
       mockTextualMatchingService.score.mockReturnValue(
         new Map([
-          ["1", { score: 0.5, matchedTerms: ["renovation"] }], // ≥ 0.2 → rescue
-          ["2", { score: 0.05, matchedTerms: [] }], // < 0.2 → écartée
+          ["1", { score: 0.5, matchedTerms: ["renovation"] }], // ≥ 0.35 → rescue
+          ["2", { score: 0.05, matchedTerms: [] }], // < 0.35 → écartée
         ]),
       );
 
@@ -443,7 +443,7 @@ describe("AidesController", () => {
 
       const result = (await controller.listAides("test-id", makeRes().res)) as AidesListResponse;
 
-      // combiné : aide2 = 0.7*0.9 + 0.3*0.1 = 0.66 ; aide1 = 0.7*0 + 0.3*0.9 = 0.27
+      // combiné : aide2 = 0.85*0.9 + 0.15*0.1 = 0.78 ; aide1 = 0.85*0 + 0.15*0.9 = 0.135
       expect(result.aides.map((a) => a.id)).toEqual([2, 1]);
     });
 

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -46,9 +46,11 @@ const CLASSIFICATION_RETRY_AFTER_SECONDS = 15;
 
 // Matching textuel — pondération de la combinaison thématique / textuel et
 // plancher de "rescue" pour qu'une aide non matchée thématiquement remonte.
-const W_THEMATIC = 0.7;
-const W_TEXTUAL = 0.3;
-const MIN_TEXTUAL_RESCUE = 0.2;
+// Le thématique (labels de classification) est plus fiable que le lexical :
+// il domine nettement le score combiné, le textuel reste un bonus + rescue.
+const W_THEMATIC = 0.85;
+const W_TEXTUAL = 0.15;
+const MIN_TEXTUAL_RESCUE = 0.35;
 
 @ApiBearerAuth()
 @ApiTags("Aides")


### PR DESCRIPTION
## Contexte

Suite à la mise en service du matching textuel lexical (#468), le signal **textuel ressortait surpondéré** par rapport au thématique. Le thématique (labels de classification LLM) est plus fiable ; or des aides à fort recouvrement de mots mais faible pertinence thématique remontaient au-dessus d'aides thématiquement valides.

## Changements

Ajustement des constantes de réglage (aucune logique modifiée) :

| Constante | Avant | Après | Effet |
|---|---|---|---|
| `W_THEMATIC` | 0.7 | **0.85** | le thématique domine le score combiné |
| `W_TEXTUAL` | 0.3 | **0.15** | un textuel parfait (1.0) ne pèse plus que 0.15 → ne dépasse qu'une aide à score thématique normalisé < 0.21 |
| `MIN_TEXTUAL_RESCUE` | 0.2 | **0.35** | une aide sans match thématique doit un score textuel ≥ 0.35 pour remonter → moins de bruit lexical |

Constantes mises à jour aux **3 endroits** qui les dupliquent : `aides.controller.ts` (l'endpoint) + les deux scripts de diagnostic (`diagnose-aides-geo.ts`, `aides-labels-stats.ts`), pour que la simulation reste fidèle à l'endpoint.

## Test plan

- [x] `pnpm type-check` + `lint` + `format:check` OK
- [x] `pnpm jest src/aides/aides.controller.spec.ts` → 26/26 (commentaires de calcul mis à jour ; les seuils des tests rescue restent valides : 0.5 ≥ 0.35, 0.05 < 0.35)
- [ ] Staging : re-vérifier sur un projet que le classement privilégie bien les aides thématiquement matchées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)