### PR TITLE
feat(classification): prompt system dédié aux aides

### DIFF
--- a/api/src/projet-qualification/classification/llm/classification-anthropic.service.spec.ts
+++ b/api/src/projet-qualification/classification/llm/classification-anthropic.service.spec.ts
@@ -1,6 +1,7 @@
 import { ClassificationAnthropicService } from "./classification-anthropic.service";
 import { ConfigService } from "@nestjs/config";
 import { CustomLogger } from "@logging/logger.service";
+import { SYSTEM_PROMPT_CLASSIFICATION, SYSTEM_PROMPT_CLASSIFICATION_AIDE } from "./prompts/classification-base.prompts";
 
 describe("ClassificationAnthropicService", () => {
   let service: ClassificationAnthropicService;
@@ -153,6 +154,30 @@ Correction - uniquement les modalités autorisées :
       };
       expect(result.json.projet).toBe("v2");
       expect(result.json.items[0].label).toBe("New");
+    });
+  });
+
+  describe("buildMessageParams — system prompt", () => {
+    const systemText = (params: ReturnType<ClassificationAnthropicService["buildMessageParams"]>): string => {
+      const system = params.system;
+      if (typeof system === "string") return system;
+      const block = system?.[0];
+      return block?.type === "text" ? block.text : "";
+    };
+
+    it("uses the aide-specific system prompt when type is 'aide'", () => {
+      const params = service.buildMessageParams("Aide test", "thematiques", "aide");
+      expect(systemText(params)).toBe(SYSTEM_PROMPT_CLASSIFICATION_AIDE);
+    });
+
+    it("uses the generic system prompt when type is 'projet'", () => {
+      const params = service.buildMessageParams("Projet test", "thematiques", "projet");
+      expect(systemText(params)).toBe(SYSTEM_PROMPT_CLASSIFICATION);
+    });
+
+    it("defaults to the generic (projet) system prompt", () => {
+      const params = service.buildMessageParams("Projet test", "sites");
+      expect(systemText(params)).toBe(SYSTEM_PROMPT_CLASSIFICATION);
     });
   });
 });

--- a/api/src/projet-qualification/classification/llm/classification-anthropic.service.ts
+++ b/api/src/projet-qualification/classification/llm/classification-anthropic.service.ts
@@ -3,7 +3,7 @@ import { ConfigService } from "@nestjs/config";
 import Anthropic from "@anthropic-ai/sdk";
 import { CustomLogger } from "@logging/logger.service";
 import { AnthropicModel, ClassificationAnalysisResult, ClassificationLLMResponse } from "./prompts/types";
-import { SYSTEM_PROMPT_CLASSIFICATION } from "./prompts/classification-base.prompts";
+import { SYSTEM_PROMPT_CLASSIFICATION, SYSTEM_PROMPT_CLASSIFICATION_AIDE } from "./prompts/classification-base.prompts";
 import { USER_PROMPT_THEMATIQUES, USER_PROMPT_THEMATIQUES_AIDE } from "./prompts/thematiques.prompts";
 import { USER_PROMPT_SITES, USER_PROMPT_SITES_AIDE } from "./prompts/sites.prompts";
 import { USER_PROMPT_INTERVENTIONS, USER_PROMPT_INTERVENTIONS_AIDE } from "./prompts/interventions.prompts";
@@ -74,7 +74,7 @@ export class ClassificationAnthropicService {
       system: [
         {
           type: "text",
-          text: SYSTEM_PROMPT_CLASSIFICATION,
+          text: type === "aide" ? SYSTEM_PROMPT_CLASSIFICATION_AIDE : SYSTEM_PROMPT_CLASSIFICATION,
           cache_control: { type: "ephemeral" },
         },
       ],

--- a/api/src/projet-qualification/classification/llm/prompts/classification-base.prompts.ts
+++ b/api/src/projet-qualification/classification/llm/prompts/classification-base.prompts.ts
@@ -1,5 +1,20 @@
 /**
- * Base system prompt shared across all classification axes
- * Matches the Python pipeline: single line, same for projects and aides
+ * System prompt for project classification — terse, as in the Python pipeline.
  */
 export const SYSTEM_PROMPT_CLASSIFICATION = `Tu es un expert en classification sémantique.`;
+
+/**
+ * System prompt for aide classification.
+ *
+ * Une aide se classifie INDIRECTEMENT : l'objet de la classification n'est pas
+ * l'aide mais le type de projet qu'elle finance. Sans ce cadrage, le LLM colle
+ * à l'aide ses propres caractéristiques — typiquement les labels de financement,
+ * une aide étant par nature un dispositif financier.
+ */
+export const SYSTEM_PROMPT_CLASSIFICATION_AIDE = `Tu es un expert en classification sémantique des aides publiques.
+
+Tu ne classifies pas l'aide elle-même, mais le type de projet qu'elle finance.
+Une aide étant par nature un dispositif financier, ne lui attribue pas les
+labels de financement (ex. « Structuration du financement ») pour cette seule
+raison : réserve-les aux cas où le projet soutenu porte lui-même sur le
+financement (ex. une aide à l'achat de vélos électriques).`;


### PR DESCRIPTION
## Contexte

La classification des aides réutilisait le prompt system des projets — `"Tu es un expert en classification sémantique."` — utilisé à l'identique pour les deux (aucun branchement sur `type` dans `buildMessageParams`).

Or **une aide se classifie indirectement** : ce qu'on qualifie n'est pas l'aide, mais le **type de projet qu'elle finance**. Sans ce cadrage, le LLM colle à l'aide ses propres caractéristiques — typiquement les labels de financement (« Structuration du financement »), une aide étant *par nature* un dispositif financier. Résultat : un faux positif quasi systématique sur l'axe modalités.

## Changements

- **Nouveau `SYSTEM_PROMPT_CLASSIFICATION_AIDE`** (`classification-base.prompts.ts`) :
  > Tu es un expert en classification sémantique des aides publiques.
  >
  > Tu ne classifies pas l'aide elle-même, mais le type de projet qu'elle finance. Une aide étant par nature un dispositif financier, ne lui attribue pas les labels de financement (ex. « Structuration du financement ») pour cette seule raison : réserve-les aux cas où le projet soutenu porte lui-même sur le financement (ex. une aide à l'achat de vélos électriques).
- **`buildMessageParams`** branche sur `type` : prompt aide vs prompt projet. Le prompt projet est **inchangé**.

## Point opérationnel

Changer le prompt **ne reclassifie pas l'existant** : le `contentHash` (`name + description`) ne couvre pas le prompt, donc `aide-classification.service.ts` ne repassera pas les aides déjà en base. Seules les aides nouvelles/modifiées passeront par le nouveau prompt.

Une **requalification complète** de `aide_classifications` (purge → reclassification au prochain sync) sera traitée séparément.

## Test plan

- [x] `pnpm type-check` + `lint` + `format:check` OK
- [x] `pnpm jest classification-anthropic.service.spec` → 15/15 (nouveau bloc `buildMessageParams` : prompt aide pour `type=aide`, prompt projet sinon / par défaut)
- [ ] Après requalification : vérifier sur quelques aides que l'axe modalités n'est plus saturé en « Structuration du financement ».

🤖 Generated with [Claude Code](https://claude.com/claude-code)