### PR TITLE
docs(aides): masquer les détails d'implémentation dans le Swagger

### DIFF
--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -76,7 +76,7 @@ export class AidesController {
   @ApiOperation({
     summary: "Lister les aides enrichies avec classification",
     description:
-      "Proxy enrichi de l'API Aides-Territoires. Retourne les aides avec classification thématiques/sites/interventions, filtrées par les territoires du projet (union des collectivités) et triées par score de matching.\n\n**Statuts de réponse** :\n- `200 ok` : aides matchées trouvées\n- `200 no_match` : aides présentes sur le périmètre mais aucune ne partage de label ≥ 0.8\n- `200 no_aides_on_perimeter` : aucune aide AT trouvée pour les codes INSEE du projet\n- `202 classification_pending` : projet pas encore classifié, job de classification (re)déclenché — réessayer après `retryAfter` secondes\n- `404` : projet inexistant",
+      "Retourne les aides pertinentes pour un projet : filtrées par son territoire, classifiées par thématiques/sites/interventions, et triées par pertinence.\n\n**Statuts de réponse** :\n- `200 ok` : aides pertinentes trouvées\n- `200 no_match` : des aides existent sur le périmètre mais aucune n'est jugée pertinente pour le projet\n- `200 no_aides_on_perimeter` : aucune aide trouvée sur le territoire du projet\n- `202 classification_pending` : le projet n'est pas encore classifié — réessayer après `retryAfter` secondes\n- `404` : projet inexistant",
   })
   @ApiQuery({
     name: "projetId",
@@ -95,8 +95,8 @@ export class AidesController {
     name: "textual",
     required: false,
     description:
-      "Force l'activation/désactivation du matching textuel (BM25) en complément du thématique. " +
-      "Sans ce param, suit le flag d'env AIDES_TEXTUAL_MATCHING_ENABLED.",
+      "Active une recherche de pertinence textuelle complémentaire (sur le contenu du projet et des aides). " +
+      "Optionnel — désactivé par défaut.",
     example: "true",
   })
   @ApiEndpointResponses({

--- a/api/src/aides/dto/aides.dto.ts
+++ b/api/src/aides/dto/aides.dto.ts
@@ -194,7 +194,7 @@ export class AideWithClassification extends Aide {
   @ApiProperty({
     required: false,
     type: Number,
-    description: "Score du matching thématique (labels de classification)",
+    description: "Score de pertinence thématique de l'aide pour le projet",
   })
   matchingScore?: number;
 
@@ -210,18 +210,22 @@ export class AideWithClassification extends Aide {
   @ApiProperty({
     required: false,
     type: Number,
-    description: "Score du matching lexical (BM25 texte projet ↔ texte aide), 0-1",
+    description: "Score de pertinence textuelle (0-1). Présent si la recherche textuelle complémentaire est activée.",
   })
   textualScore?: number;
 
   @ApiProperty({
     required: false,
     type: Number,
-    description: "Score combiné thématique + textuel — c'est le critère de tri",
+    description: "Score de pertinence global de l'aide — critère de tri des résultats",
   })
   combinedScore?: number;
 
-  @ApiProperty({ required: false, type: [String], description: "Termes du projet retrouvés dans le texte de l'aide" })
+  @ApiProperty({
+    required: false,
+    type: [String],
+    description: "Termes du projet retrouvés dans le contenu de l'aide",
+  })
   matchedTerms?: string[];
 }
 
@@ -231,7 +235,7 @@ export class AidesListResponse {
   @ApiProperty({
     enum: ["ok", "no_match", "no_aides_on_perimeter"],
     description:
-      "Statut du résultat — `ok` : aides matchées triées par pertinence ; `no_match` : aides présentes sur le périmètre mais aucune ne partage de label de classification ≥ 0.8 avec le projet ; `no_aides_on_perimeter` : aucune aide AT n'a été trouvée pour les codes INSEE du projet.",
+      "Statut du résultat — `ok` : aides pertinentes trouvées, triées par pertinence ; `no_match` : des aides existent sur le périmètre mais aucune n'est jugée pertinente pour le projet ; `no_aides_on_perimeter` : aucune aide n'a été trouvée sur le territoire du projet.",
   })
   status!: AidesListStatus;
 


### PR DESCRIPTION
## Contexte

La doc OpenAPI de `GET /aides` exposait des détails d'implémentation interne aux consommateurs de l'API :
- le nom de la variable d'env `AIDES_TEXTUAL_MATCHING_ENABLED` ;
- l'algorithme employé (`BM25`, « matching lexical ») ;
- un seuil de score (`label ≥ 0.8`).

Ces éléments sont susceptibles d'évoluer et ne devraient pas figurer dans le contrat public de l'API.

## Changements

Descriptions Swagger reformulées de façon **fonctionnelle** (aucun changement de comportement) :

| Endroit | Avant | Après |
|---|---|---|
| `@ApiQuery` `textual` | « matching textuel (BM25) … suit le flag d'env AIDES_TEXTUAL_MATCHING_ENABLED » | « recherche de pertinence textuelle complémentaire, optionnelle, désactivée par défaut » |
| `@ApiOperation` statuts | « aucune ne partage de label ≥ 0.8 » | « aucune aide jugée pertinente pour le projet » |
| DTO `textualScore` | « matching lexical (BM25 texte projet ↔ texte aide) » | « score de pertinence textuelle (0-1) » |
| DTO `matchingScore` / `combinedScore` | « matching thématique (labels…) » / « combiné thématique + textuel » | « score de pertinence thématique » / « score de pertinence global » |
| `AidesListResponse.status` | « ne partage de label de classification ≥ 0.8 » | « aucune n'est jugée pertinente » |

Les commentaires de code et les noms de tests conservent les termes techniques (BM25, variable d'env) — c'est leur place légitime.

## Test plan

- [x] `pnpm type-check` + `lint` + `format:check` OK
- [x] Aucun test ne porte sur les chaînes de description — comportement inchangé.

🤖 Generated with [Claude Code](https://claude.com/claude-code)