### PR TITLE
feat(aides): améliorations matching — requalif, poids, doc, seuils

### DIFF
--- a/api/scripts/aides-labels-stats.ts
+++ b/api/scripts/aides-labels-stats.ts
@@ -69,7 +69,7 @@ const DEFAULT_THRESHOLD = 0.8;
 const TERRITORY_PREFIX = "at:territory:";
 const AIDE_PREFIX = "at:aide:";
 // Plancher de rescue textuel — aligné sur aides.controller.ts.
-const MIN_TEXTUAL_RESCUE = 0.2;
+const MIN_TEXTUAL_RESCUE = 0.35;
 
 // ─── DB config (parse manuel pour ignorer sslmode de l'URL) ──────────────────
 

--- a/api/scripts/diagnose-aides-geo.ts
+++ b/api/scripts/diagnose-aides-geo.ts
@@ -45,9 +45,9 @@ const SCORE_THRESHOLD = 0.8;
 const SCORE_OFFSET = 0.1;
 
 // Combinaison thématique/textuel — alignée sur aides.controller.ts.
-const W_THEMATIC = 0.7;
-const W_TEXTUAL = 0.3;
-const MIN_TEXTUAL_RESCUE = 0.2;
+const W_THEMATIC = 0.85;
+const W_TEXTUAL = 0.15;
+const MIN_TEXTUAL_RESCUE = 0.35;
 
 // ─── Types ───────────────────────────────────────────────────────────────────
 

--- a/api/scripts/requalify-aides.ts
+++ b/api/scripts/requalify-aides.ts
@@ -1,0 +1,209 @@
+/**
+ * Requalification du catalogue d'aides — invalide les classifications
+ * existantes pour forcer leur recalcul par le LLM (ex. après un changement
+ * de prompt).
+ *
+ * Méthode "douce" : on ne TRUNCATE pas la table — on réécrit content_hash
+ * avec un sentinel. Les classification_scores actuels restent servis par
+ * GET /aides jusqu'à ce que chaque aide soit individuellement reclassifiée.
+ * Aucune fenêtre no_match : remplacement progressif, pas de coupure.
+ *
+ * Le déclenchement passe par un job BullMQ (queue aides-sync) — le processor
+ * tourne en arrière-plan, sans timeout HTTP (contrairement à GET /aides/sync
+ * qui est synchrone et couperait sur un run complet de plusieurs heures).
+ *
+ * Modes :
+ *   (défaut)       dry-run : compte les lignes, n'écrit rien
+ *   --apply        invalide les content_hash + enqueue le job de sync
+ *   --apply --no-trigger   invalide seulement (sync laissé au cron 3h UTC)
+ *   --watch        suit la progression de la reclassification (lecture seule)
+ *
+ * Usage :
+ *   DATABASE_URL=... npx tsx scripts/requalify-aides.ts
+ *   DATABASE_URL=... REDIS_URL=... npx tsx scripts/requalify-aides.ts --apply
+ *   DATABASE_URL=... npx tsx scripts/requalify-aides.ts --watch
+ *
+ * Coût : --apply déclenche un run LLM complet (~ nb_aides × 3 appels Claude,
+ * séquentiel, plusieurs heures). À lancer en heures creuses.
+ */
+
+import { Pool, type PoolConfig } from "pg";
+import Redis from "ioredis";
+import { Queue } from "bullmq";
+
+// Sentinel écrit dans content_hash — ne peut pas entrer en collision avec un
+// vrai hash (SHA256 = 64 caractères hexadécimaux).
+const STALE_SENTINEL = "requalify-pending";
+
+// cf. api/src/aides/aides-sync.processor.ts
+const AIDES_SYNC_QUEUE_NAME = "aides-sync";
+const AIDES_SYNC_JOB_NAME = "aides-sync-classification";
+
+const WATCH_INTERVAL_MS = 30_000;
+const WATCH_STALL_LIMIT = 10; // arrêt si aucune progression sur N tours
+
+// ─── Config ──────────────────────────────────────────────────────────────────
+
+function buildDbConfig(): PoolConfig {
+  const url = process.env.DATABASE_URL;
+  if (!url) {
+    console.error("❌ DATABASE_URL manquant");
+    process.exit(1);
+  }
+  const u = new URL(url);
+  return {
+    host: u.hostname,
+    port: u.port ? Number(u.port) : 5432,
+    database: decodeURIComponent(u.pathname.replace(/^\//, "")),
+    user: decodeURIComponent(u.username),
+    password: decodeURIComponent(u.password),
+    ssl: { rejectUnauthorized: false },
+  };
+}
+
+function buildRedis(): Redis {
+  const url = process.env.REDIS_URL;
+  if (!url) {
+    console.error("❌ REDIS_URL manquant (requis pour --apply sans --no-trigger)");
+    process.exit(1);
+  }
+  return new Redis(url, {
+    maxRetriesPerRequest: null, // requis par BullMQ
+    ...(url.startsWith("rediss://") ? { tls: { rejectUnauthorized: false } } : {}),
+  });
+}
+
+// ─── Progression ─────────────────────────────────────────────────────────────
+
+interface Progress {
+  total: number;
+  done: number;
+  pending: number;
+}
+
+async function readProgress(pool: Pool): Promise<Progress> {
+  const { rows } = await pool.query<{ total: string; done: string; pending: string }>(
+    `SELECT
+       count(*)::text                                       AS total,
+       count(*) FILTER (WHERE content_hash <> $1)::text     AS done,
+       count(*) FILTER (WHERE content_hash =  $1)::text     AS pending
+     FROM public.aide_classifications`,
+    [STALE_SENTINEL],
+  );
+  return {
+    total: Number(rows[0].total),
+    done: Number(rows[0].done),
+    pending: Number(rows[0].pending),
+  };
+}
+
+function pct(p: Progress): string {
+  return p.total === 0 ? "0%" : `${Math.round((p.done / p.total) * 100)}%`;
+}
+
+// ─── Main ────────────────────────────────────────────────────────────────────
+
+async function main() {
+  const argv = process.argv.slice(2);
+  const apply = argv.includes("--apply");
+  const watch = argv.includes("--watch");
+  const noTrigger = argv.includes("--no-trigger");
+
+  const pool = new Pool(buildDbConfig());
+
+  console.log(`\n=== Requalification des aides ===\n`);
+
+  // ── Mode --watch seul ──────────────────────────────────────────────────────
+  if (watch && !apply) {
+    await watchProgress(pool);
+    await pool.end();
+    return;
+  }
+
+  const before = await readProgress(pool);
+  console.log(`Table public.aide_classifications : ${before.total} aides classifiées`);
+  console.log(`  déjà invalidées (sentinel)       : ${before.pending}`);
+  console.log(`  avec un hash valide              : ${before.done}\n`);
+
+  if (!apply) {
+    // ── Dry-run ──────────────────────────────────────────────────────────────
+    console.log(`Mode DRY-RUN — aucune écriture.\n`);
+    console.log(`Avec --apply, le script :`);
+    console.log(`  1. réécrit content_hash = "${STALE_SENTINEL}" sur les ${before.total} lignes`);
+    console.log(`     (classification_scores INCHANGÉS — toujours servis par GET /aides)`);
+    console.log(`  2. enqueue un job "${AIDES_SYNC_JOB_NAME}" sur la queue "${AIDES_SYNC_QUEUE_NAME}"`);
+    console.log(`     → le worker reclassifie chaque aide au LLM, en arrière-plan`);
+    console.log(`\n⚠️  Coût : ~${before.total} aides × 3 appels Claude, séquentiel, plusieurs heures.`);
+    console.log(`   À lancer en heures creuses. Suivre ensuite avec --watch.\n`);
+    await pool.end();
+    return;
+  }
+
+  // ── --apply : invalidation ─────────────────────────────────────────────────
+  console.log(`Invalidation des content_hash…`);
+  const res = await pool.query(`UPDATE public.aide_classifications SET content_hash = $1`, [STALE_SENTINEL]);
+  console.log(`  ✓ ${res.rowCount} ligne(s) invalidée(s) — classification_scores conservés.\n`);
+
+  // ── --apply : déclenchement ────────────────────────────────────────────────
+  if (noTrigger) {
+    console.log(`--no-trigger : job de sync NON enqueué.`);
+    console.log(`La reclassification se fera au prochain cron (3h UTC).\n`);
+  } else {
+    const redis = buildRedis();
+    const queue = new Queue(AIDES_SYNC_QUEUE_NAME, { connection: redis });
+    const job = await queue.add(
+      AIDES_SYNC_JOB_NAME,
+      {},
+      { attempts: 3, backoff: { type: "exponential", delay: 60_000 } },
+    );
+    console.log(`✓ Job de sync enqueué (id=${job.id}) sur la queue "${AIDES_SYNC_QUEUE_NAME}".`);
+    console.log(`  Le worker va reclassifier les aides en arrière-plan.\n`);
+    await queue.close();
+    redis.disconnect();
+  }
+
+  console.log(`Suivre la progression :`);
+  console.log(`  DATABASE_URL=... npx tsx scripts/requalify-aides.ts --watch\n`);
+
+  if (watch) {
+    await watchProgress(pool);
+  }
+  await pool.end();
+}
+
+/** Boucle de suivi : affiche done/total jusqu'à la fin (ou un plateau). */
+async function watchProgress(pool: Pool): Promise<void> {
+  console.log(`Suivi de la reclassification (Ctrl-C pour arrêter)\n`);
+  let lastDone = -1;
+  let stall = 0;
+
+  for (;;) {
+    const p = await readProgress(pool);
+    const ts = new Date().toISOString().slice(11, 19);
+    console.log(`  [${ts}] ${p.done}/${p.total} reclassifiées (${pct(p)}) — ${p.pending} en attente`);
+
+    if (p.pending === 0) {
+      console.log(`\n✅ Reclassification terminée — toutes les aides ont un hash valide.\n`);
+      return;
+    }
+
+    stall = p.done === lastDone ? stall + 1 : 0;
+    lastDone = p.done;
+    if (stall >= WATCH_STALL_LIMIT) {
+      console.log(
+        `\n⚠️  Aucune progression depuis ${(WATCH_STALL_LIMIT * WATCH_INTERVAL_MS) / 60_000} min.\n` +
+          `   Les ${p.pending} aide(s) restantes sont probablement des orphelines\n` +
+          `   (retirées du catalogue Aides-Territoires, donc jamais revues par le sync).\n` +
+          `   Le job de sync est peut-être aussi terminé/échoué — vérifier Bull Board.\n`,
+      );
+      return;
+    }
+
+    await new Promise((r) => setTimeout(r, WATCH_INTERVAL_MS));
+  }
+}
+
+main().catch((err) => {
+  console.error("Requalify failed:", err instanceof Error ? err.stack : err);
+  process.exit(1);
+});

--- a/api/src/aides/aides-matching.service.spec.ts
+++ b/api/src/aides/aides-matching.service.spec.ts
@@ -142,4 +142,41 @@ describe("AidesMatchingService", () => {
       expect(service.match(makeScores(), new Map())).toEqual([]);
     });
   });
+
+  describe("match — custom thresholds", () => {
+    it("includes a project label below 0.8 when projetThreshold is lowered", () => {
+      const projet = makeScores([{ label: "Energies renouvelables", score: 0.65 }]);
+      const aides = new Map([["aide-1", makeScores([{ label: "Energies renouvelables", score: 0.9 }])]]);
+
+      // Default (0.8) : le label projet à 0.65 est filtré → aucun match.
+      expect(service.match(projet, aides)).toHaveLength(0);
+
+      // projetThreshold abaissé à 0.6 : le label passe → match.
+      const results = service.match(projet, aides, 10, { projet: 0.6 });
+      expect(results).toHaveLength(1);
+      expect(results[0].idAt).toBe("aide-1");
+    });
+
+    it("includes an aide label below 0.8 when aideThreshold is lowered", () => {
+      const projet = makeScores([{ label: "Sobriété énergétique", score: 0.9 }]);
+      const aides = new Map([["aide-1", makeScores([{ label: "Sobriété énergétique", score: 0.55 }])]]);
+
+      expect(service.match(projet, aides)).toHaveLength(0);
+
+      const results = service.match(projet, aides, 10, { aide: 0.5 });
+      expect(results).toHaveLength(1);
+      expect(results[0].idAt).toBe("aide-1");
+    });
+
+    it("keeps thresholds independent for the project and aide sides", () => {
+      // Label projet à 0.9 (OK au défaut), label aide à 0.6 (sous le défaut).
+      const projet = makeScores([{ label: "Test", score: 0.9 }]);
+      const aides = new Map([["aide-1", makeScores([{ label: "Test", score: 0.6 }])]]);
+
+      // Abaisser seulement le seuil projet ne suffit pas — le label aide reste filtré.
+      expect(service.match(projet, aides, 10, { projet: 0.5 })).toHaveLength(0);
+      // Abaisser le seuil aide débloque le match.
+      expect(service.match(projet, aides, 10, { aide: 0.5 })).toHaveLength(1);
+    });
+  });
 });

--- a/api/src/aides/aides-matching.service.ts
+++ b/api/src/aides/aides-matching.service.ts
@@ -7,40 +7,35 @@
  * interventions), each label having a confidence score between 0 and 1.
  *
  * For each axis:
- *   1. Keep only labels with score ≥ 0.8 (high confidence)
+ *   1. Keep only labels with score ≥ threshold (high confidence). The threshold
+ *      defaults to 0.8 but can be set independently for the project side and
+ *      the aide side (see `match` thresholds option).
  *   2. Find common labels between the project and the aide
  *   3. For each common label, compute:
- *        term = (score_project - 0.7) × (score_aide - 0.7)
- *      The -0.7 offset means:
- *        - A label at 0.8 (just above threshold) contributes 0.1 × ... (low weight)
- *        - A label at 1.0 (very confident) contributes 0.3 × ... (high weight)
+ *        term = (score_project - projetThreshold + offset)
+ *             × (score_aide   - aideThreshold   + offset)
+ *      The offset (0.1) means a label just above its threshold contributes a
+ *      small weight, a label at 1.0 contributes a large one.
  *   4. Axis score = sum(terms) / number of project labels on this axis
  *      Division normalizes so projects with fewer labels aren't penalized
  *
  * Total score = score_thématiques + score_sites + score_interventions
- *
- * Example:
- *   Project: "Isolation thermique" (0.95), "Rénovation énergétique" (0.85)
- *   Aide:    "Rénovation énergétique" (0.92)
- *   Common label: "Rénovation énergétique"
- *   Score = (0.85 - 0.7) × (0.92 - 0.7) / 2 = 0.15 × 0.22 / 2 = 0.0165
  */
 
 import { Injectable } from "@nestjs/common";
 import { CustomLogger } from "@logging/logger.service";
 import { AideClassification, AideMatchResult } from "./dto/aides.dto";
 
-/**
- * Matching engine for projects and aides
- * Algorithm aligned with Gaëtan's match_projets_aides.py
- *
- * For each axis, score = Σ((score_projet - 0.7) × (score_aide - 0.7)) / nb_labels_projet
- * Total score = sum of 3 axis scores
- */
+/** Per-call confidence thresholds. Absent values fall back to DEFAULT_THRESHOLD. */
+export interface MatchThresholds {
+  projet?: number;
+  aide?: number;
+}
+
 @Injectable()
 export class AidesMatchingService {
-  // Threshold and offset matching Gaëtan's script (THRESHOLD=80, OFFSET=10 on 0-100 scale)
-  private readonly SCORE_THRESHOLD = 0.8;
+  /** Default confidence threshold (Gaëtan's script: THRESHOLD=80 on the 0-100 scale). */
+  static readonly DEFAULT_THRESHOLD = 0.8;
   private readonly SCORE_OFFSET = 0.1;
 
   constructor(private readonly logger: CustomLogger) {}
@@ -50,18 +45,27 @@ export class AidesMatchingService {
    * @param projetScores Classification scores of the project
    * @param aidesScores Map of aide id_at -> classification scores
    * @param limit Max number of results
+   * @param thresholds Optional per-side confidence thresholds (default 0.8 each)
    * @returns Sorted list of matching aides with scores
    */
-  match(projetScores: AideClassification, aidesScores: Map<string, AideClassification>, limit = 10): AideMatchResult[] {
-    // Filter project labels by threshold
-    const pThematiques = this.filterByThreshold(projetScores.thematiques);
-    const pSites = this.filterByThreshold(projetScores.sites);
-    const pInterventions = this.filterByThreshold(projetScores.interventions);
+  match(
+    projetScores: AideClassification,
+    aidesScores: Map<string, AideClassification>,
+    limit = 10,
+    thresholds?: MatchThresholds,
+  ): AideMatchResult[] {
+    const projetThreshold = thresholds?.projet ?? AidesMatchingService.DEFAULT_THRESHOLD;
+    const aideThreshold = thresholds?.aide ?? AidesMatchingService.DEFAULT_THRESHOLD;
 
-    const projectMax = this.computeProjectMax(pThematiques, pSites, pInterventions);
+    // Filter project labels by the project threshold
+    const pThematiques = this.filterByThreshold(projetScores.thematiques, projetThreshold);
+    const pSites = this.filterByThreshold(projetScores.sites, projetThreshold);
+    const pInterventions = this.filterByThreshold(projetScores.interventions, projetThreshold);
+
+    const projectMax = this.computeProjectMax(pThematiques, pSites, pInterventions, projetThreshold, aideThreshold);
 
     // Build inverted index for fast candidate lookup
-    const candidates = this.findCandidates(pThematiques, pSites, pInterventions, aidesScores);
+    const candidates = this.findCandidates(pThematiques, pSites, pInterventions, aidesScores, aideThreshold);
 
     // Score each candidate
     const results: AideMatchResult[] = [];
@@ -69,13 +73,13 @@ export class AidesMatchingService {
     for (const idAt of candidates) {
       const aideScores = aidesScores.get(idAt)!;
 
-      const aThematiques = this.filterByThreshold(aideScores.thematiques);
-      const aSites = this.filterByThreshold(aideScores.sites);
-      const aInterventions = this.filterByThreshold(aideScores.interventions);
+      const aThematiques = this.filterByThreshold(aideScores.thematiques, aideThreshold);
+      const aSites = this.filterByThreshold(aideScores.sites, aideThreshold);
+      const aInterventions = this.filterByThreshold(aideScores.interventions, aideThreshold);
 
-      const thResult = this.scoreAxis(pThematiques, aThematiques);
-      const siResult = this.scoreAxis(pSites, aSites);
-      const inResult = this.scoreAxis(pInterventions, aInterventions);
+      const thResult = this.scoreAxis(pThematiques, aThematiques, projetThreshold, aideThreshold);
+      const siResult = this.scoreAxis(pSites, aSites, projetThreshold, aideThreshold);
+      const inResult = this.scoreAxis(pInterventions, aInterventions, projetThreshold, aideThreshold);
 
       const totalScore = thResult.score + siResult.score + inResult.score;
 
@@ -115,27 +119,31 @@ export class AidesMatchingService {
     pThematiques: Map<string, number>,
     pSites: Map<string, number>,
     pInterventions: Map<string, number>,
+    projetThreshold: number,
+    aideThreshold: number,
   ): number {
-    return this.axisMax(pThematiques) + this.axisMax(pSites) + this.axisMax(pInterventions);
+    return (
+      this.axisMax(pThematiques, projetThreshold, aideThreshold) +
+      this.axisMax(pSites, projetThreshold, aideThreshold) +
+      this.axisMax(pInterventions, projetThreshold, aideThreshold)
+    );
   }
 
-  private axisMax(projectLabels: Map<string, number>): number {
+  private axisMax(projectLabels: Map<string, number>, projetThreshold: number, aideThreshold: number): number {
     if (projectLabels.size === 0) return 0;
-    const maxAideContribution = 1.0 - this.SCORE_THRESHOLD + this.SCORE_OFFSET; // 0.3
+    const maxAideContribution = 1.0 - aideThreshold + this.SCORE_OFFSET;
     let sum = 0;
     for (const pScore of projectLabels.values()) {
-      sum += (pScore - this.SCORE_THRESHOLD + this.SCORE_OFFSET) * maxAideContribution;
+      sum += (pScore - projetThreshold + this.SCORE_OFFSET) * maxAideContribution;
     }
     return sum / projectLabels.size;
   }
 
-  /**
-   * Filter labels above the threshold (matching Gaëtan's THRESHOLD=80 on 0-100 scale)
-   */
-  private filterByThreshold(items: { label: string; score: number }[]): Map<string, number> {
+  /** Filter labels at or above the given confidence threshold. */
+  private filterByThreshold(items: { label: string; score: number }[], threshold: number): Map<string, number> {
     const map = new Map<string, number>();
     for (const item of items) {
-      if (item.score >= this.SCORE_THRESHOLD) {
+      if (item.score >= threshold) {
         map.set(item.label, item.score);
       }
     }
@@ -150,15 +158,16 @@ export class AidesMatchingService {
     pSi: Map<string, number>,
     pIn: Map<string, number>,
     aidesScores: Map<string, AideClassification>,
+    aideThreshold: number,
   ): Set<string> {
     const candidates = new Set<string>();
     const projectLabels = new Set([...pTh.keys(), ...pSi.keys(), ...pIn.keys()]);
 
     for (const [idAt, scores] of aidesScores) {
       const aideLabels = [
-        ...scores.thematiques.filter((t) => t.score >= this.SCORE_THRESHOLD).map((t) => t.label),
-        ...scores.sites.filter((s) => s.score >= this.SCORE_THRESHOLD).map((s) => s.label),
-        ...scores.interventions.filter((i) => i.score >= this.SCORE_THRESHOLD).map((i) => i.label),
+        ...scores.thematiques.filter((t) => t.score >= aideThreshold).map((t) => t.label),
+        ...scores.sites.filter((s) => s.score >= aideThreshold).map((s) => s.label),
+        ...scores.interventions.filter((i) => i.score >= aideThreshold).map((i) => i.label),
       ];
 
       for (const label of aideLabels) {
@@ -175,11 +184,13 @@ export class AidesMatchingService {
 
   /**
    * Score one axis between a project and an aide
-   * Formula: Σ((Sp - threshold + offset) × (Sa - threshold + offset)) / Pt
+   * Formula: Σ((Sp - projetThreshold + offset) × (Sa - aideThreshold + offset)) / nbLabelsProjet
    */
   private scoreAxis(
     projectItems: Map<string, number>,
     aideItems: Map<string, number>,
+    projetThreshold: number,
+    aideThreshold: number,
   ): { score: number; commonLabels: string[] } {
     if (projectItems.size === 0) {
       return { score: 0, commonLabels: [] };
@@ -191,8 +202,7 @@ export class AidesMatchingService {
     for (const [label, pScore] of projectItems) {
       const aScore = aideItems.get(label);
       if (aScore !== undefined) {
-        const term =
-          (pScore - this.SCORE_THRESHOLD + this.SCORE_OFFSET) * (aScore - this.SCORE_THRESHOLD + this.SCORE_OFFSET);
+        const term = (pScore - projetThreshold + this.SCORE_OFFSET) * (aScore - aideThreshold + this.SCORE_OFFSET);
         totalScore += term;
         commonLabels.push(label);
       }

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -466,6 +466,77 @@ describe("AidesController", () => {
     });
   });
 
+  describe("listAides cutoff & thresholds", () => {
+    const matchResult = (idAt: string, score: number, normalizedScore: number) => ({
+      idAt,
+      score,
+      normalizedScore,
+      scoreThematiques: score,
+      scoreSites: 0,
+      scoreInterventions: 0,
+      axesMatched: 1,
+      labelsCommuns: { thematiques: ["X"], sites: [], interventions: [] },
+    });
+
+    it("filters out aides whose normalized score is below the cutoff", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1), makeAide(2)], status: "fresh" });
+      mockMatchingService.match.mockReturnValue([
+        matchResult("1", 0.5, 0.5), // ≥ 0.1 → gardée
+        matchResult("2", 0.05, 0.05), // < 0.1 → écartée
+      ]);
+
+      // cutoff = 6e argument
+      const result = (await controller.listAides(
+        "test-id",
+        makeRes().res,
+        undefined,
+        undefined,
+        undefined,
+        "0.1",
+      )) as AidesListResponse;
+
+      expect(result.status).toBe("ok");
+      expect(result.aides.map((a) => a.id)).toEqual([1]);
+    });
+
+    it("keeps every matched aide when no cutoff is provided", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1), makeAide(2)], status: "fresh" });
+      mockMatchingService.match.mockReturnValue([matchResult("1", 0.5, 0.5), matchResult("2", 0.05, 0.05)]);
+
+      const result = (await controller.listAides("test-id", makeRes().res)) as AidesListResponse;
+
+      expect(result.aides.map((a) => a.id)).toEqual([1, 2]);
+    });
+
+    it("passes aideThreshold and projetThreshold to the matching service", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
+
+      await controller.listAides("test-id", makeRes().res, undefined, undefined, undefined, undefined, "0.7", "0.6");
+
+      expect(mockMatchingService.match).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.any(Number), {
+        projet: 0.6,
+        aide: 0.7,
+      });
+    });
+
+    it("leaves thresholds undefined when the params are absent (matcher applies its default)", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
+
+      await controller.listAides("test-id", makeRes().res);
+
+      expect(mockMatchingService.match).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.any(Number), {
+        projet: undefined,
+        aide: undefined,
+      });
+    });
+
+    it("rejects an out-of-range score parameter with 400", async () => {
+      await expect(
+        controller.listAides("test-id", makeRes().res, undefined, undefined, undefined, "1.5"),
+      ).rejects.toThrow();
+    });
+  });
+
   describe("syncClassifications", () => {
     it("should invalidate territories and trigger warmup in background", async () => {
       const result = await controller.syncClassifications();

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -405,8 +405,8 @@ describe("AidesController", () => {
       mockMatchingService.match.mockReturnValue([]); // aucun match thématique
       mockTextualMatchingService.score.mockReturnValue(
         new Map([
-          ["1", { score: 0.5, matchedTerms: ["renovation"] }], // ≥ 0.2 → rescue
-          ["2", { score: 0.05, matchedTerms: [] }], // < 0.2 → écartée
+          ["1", { score: 0.5, matchedTerms: ["renovation"] }], // ≥ 0.35 → rescue
+          ["2", { score: 0.05, matchedTerms: [] }], // < 0.35 → écartée
         ]),
       );
 
@@ -443,7 +443,7 @@ describe("AidesController", () => {
 
       const result = (await controller.listAides("test-id", makeRes().res)) as AidesListResponse;
 
-      // combiné : aide2 = 0.7*0.9 + 0.3*0.1 = 0.66 ; aide1 = 0.7*0 + 0.3*0.9 = 0.27
+      // combiné : aide2 = 0.85*0.9 + 0.15*0.1 = 0.78 ; aide1 = 0.85*0 + 0.15*0.9 = 0.135
       expect(result.aides.map((a) => a.id)).toEqual([2, 1]);
     });
 

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -101,6 +101,27 @@ export class AidesController {
       "Optionnel — désactivé par défaut.",
     example: "true",
   })
+  @ApiQuery({
+    name: "cutoff",
+    required: false,
+    description:
+      "Score de pertinence minimal (0-1) sous lequel une aide est écartée du résultat. Optionnel — aucun seuil par défaut.",
+    example: "0.1",
+  })
+  @ApiQuery({
+    name: "aideThreshold",
+    required: false,
+    description:
+      "Seuil de confiance (0-1) des labels de classification d'une aide pris en compte dans le matching. Défaut : 0.8.",
+    example: "0.8",
+  })
+  @ApiQuery({
+    name: "projetThreshold",
+    required: false,
+    description:
+      "Seuil de confiance (0-1) des labels de classification du projet pris en compte dans le matching. Défaut : 0.8.",
+    example: "0.8",
+  })
   @ApiEndpointResponses({
     successStatus: 200,
     response: AidesListResponse,
@@ -118,6 +139,9 @@ export class AidesController {
     @Query("limit") limit?: string,
     @Query("projet_id") projetIdSnake?: string,
     @Query("textual") textualOverride?: string,
+    @Query("cutoff") cutoffRaw?: string,
+    @Query("aideThreshold") aideThresholdRaw?: string,
+    @Query("projetThreshold") projetThresholdRaw?: string,
   ): Promise<AidesListResponse | ClassificationPendingResponse> {
     const projetId = projetIdCamel ?? projetIdSnake;
     if (!projetId) {
@@ -130,6 +154,11 @@ export class AidesController {
     }
 
     const maxResults = parseInt(limit ?? "20", 10);
+    // Score de pertinence minimal — 0 si non fourni (= aucun filtrage par score).
+    const cutoff = this.parseUnitInterval("cutoff", cutoffRaw) ?? 0;
+    // Seuils de confiance des labels — undefined laisse le matcher appliquer son défaut (0.8).
+    const aideThreshold = this.parseUnitInterval("aideThreshold", aideThresholdRaw);
+    const projetThreshold = this.parseUnitInterval("projetThreshold", projetThresholdRaw);
 
     // 1. Load project (throws 404 if not found) + détecte la source pour
     //    pouvoir tagger correctement un éventuel job de classification.
@@ -170,7 +199,10 @@ export class AidesController {
     // 6. Thematic matching — pass allAides.length so nothing is pre-sliced
     //    before the (optional) textual combination below.
     const matchResults = new Map<string, AideMatchResult>();
-    const results = this.matchingService.match(projet.classificationScores, classifications, allAides.length);
+    const results = this.matchingService.match(projet.classificationScores, classifications, allAides.length, {
+      projet: projetThreshold,
+      aide: aideThreshold,
+    });
     for (const r of results) {
       matchResults.set(r.idAt, r);
     }
@@ -213,14 +245,20 @@ export class AidesController {
     if (textualEnabled) {
       // Rescue + booster : on garde tout match thématique, plus toute aide
       // dont le score textuel dépasse le plancher de rescue. Tri par score combiné.
+      // Le cutoff écarte les aides sous le score de pertinence minimal demandé.
       enriched = enriched
-        .filter((a) => a.matchingScore !== undefined || (a.textualScore ?? 0) >= MIN_TEXTUAL_RESCUE)
+        .filter(
+          (a) =>
+            (a.matchingScore !== undefined || (a.textualScore ?? 0) >= MIN_TEXTUAL_RESCUE) &&
+            (a.combinedScore ?? 0) >= cutoff,
+        )
         .sort((a, b) => (b.combinedScore ?? 0) - (a.combinedScore ?? 0))
         .slice(0, maxResults);
     } else {
       // Comportement historique : matching thématique seul.
+      // Le cutoff filtre sur le score de pertinence normalisé (0-1).
       enriched = enriched
-        .filter((a) => a.matchingScore !== undefined)
+        .filter((a) => a.matchingScore !== undefined && (a.normalizedScore ?? 0) >= cutoff)
         .sort((a, b) => (b.matchingScore ?? 0) - (a.matchingScore ?? 0))
         .slice(0, maxResults);
     }
@@ -240,6 +278,19 @@ export class AidesController {
     if (override === "true") return true;
     if (override === "false") return false;
     return this.configService.get<string>("AIDES_TEXTUAL_MATCHING_ENABLED") === "true";
+  }
+
+  /**
+   * Parse un paramètre de score dans [0, 1]. Renvoie undefined si absent,
+   * lève une 400 explicite si la valeur est invalide.
+   */
+  private parseUnitInterval(name: string, raw: string | undefined): number | undefined {
+    if (raw === undefined || raw === "") return undefined;
+    const value = Number(raw);
+    if (Number.isNaN(value) || value < 0 || value > 1) {
+      throw new BadRequestException(`Paramètre "${name}" invalide : attendu un nombre entre 0 et 1, reçu "${raw}"`);
+    }
+    return value;
   }
 
   /**

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -46,9 +46,11 @@ const CLASSIFICATION_RETRY_AFTER_SECONDS = 15;
 
 // Matching textuel — pondération de la combinaison thématique / textuel et
 // plancher de "rescue" pour qu'une aide non matchée thématiquement remonte.
-const W_THEMATIC = 0.7;
-const W_TEXTUAL = 0.3;
-const MIN_TEXTUAL_RESCUE = 0.2;
+// Le thématique (labels de classification) est plus fiable que le lexical :
+// il domine nettement le score combiné, le textuel reste un bonus + rescue.
+const W_THEMATIC = 0.85;
+const W_TEXTUAL = 0.15;
+const MIN_TEXTUAL_RESCUE = 0.35;
 
 @ApiBearerAuth()
 @ApiTags("Aides")

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -78,7 +78,7 @@ export class AidesController {
   @ApiOperation({
     summary: "Lister les aides enrichies avec classification",
     description:
-      "Proxy enrichi de l'API Aides-Territoires. Retourne les aides avec classification thématiques/sites/interventions, filtrées par les territoires du projet (union des collectivités) et triées par score de matching.\n\n**Statuts de réponse** :\n- `200 ok` : aides matchées trouvées\n- `200 no_match` : aides présentes sur le périmètre mais aucune ne partage de label ≥ 0.8\n- `200 no_aides_on_perimeter` : aucune aide AT trouvée pour les codes INSEE du projet\n- `202 classification_pending` : projet pas encore classifié, job de classification (re)déclenché — réessayer après `retryAfter` secondes\n- `404` : projet inexistant",
+      "Retourne les aides pertinentes pour un projet : filtrées par son territoire, classifiées par thématiques/sites/interventions, et triées par pertinence.\n\n**Statuts de réponse** :\n- `200 ok` : aides pertinentes trouvées\n- `200 no_match` : des aides existent sur le périmètre mais aucune n'est jugée pertinente pour le projet\n- `200 no_aides_on_perimeter` : aucune aide trouvée sur le territoire du projet\n- `202 classification_pending` : le projet n'est pas encore classifié — réessayer après `retryAfter` secondes\n- `404` : projet inexistant",
   })
   @ApiQuery({
     name: "projetId",
@@ -97,8 +97,8 @@ export class AidesController {
     name: "textual",
     required: false,
     description:
-      "Force l'activation/désactivation du matching textuel (BM25) en complément du thématique. " +
-      "Sans ce param, suit le flag d'env AIDES_TEXTUAL_MATCHING_ENABLED.",
+      "Active une recherche de pertinence textuelle complémentaire (sur le contenu du projet et des aides). " +
+      "Optionnel — désactivé par défaut.",
     example: "true",
   })
   @ApiEndpointResponses({

--- a/api/src/aides/dto/aides.dto.ts
+++ b/api/src/aides/dto/aides.dto.ts
@@ -194,7 +194,7 @@ export class AideWithClassification extends Aide {
   @ApiProperty({
     required: false,
     type: Number,
-    description: "Score du matching thématique (labels de classification)",
+    description: "Score de pertinence thématique de l'aide pour le projet",
   })
   matchingScore?: number;
 
@@ -210,18 +210,22 @@ export class AideWithClassification extends Aide {
   @ApiProperty({
     required: false,
     type: Number,
-    description: "Score du matching lexical (BM25 texte projet ↔ texte aide), 0-1",
+    description: "Score de pertinence textuelle (0-1). Présent si la recherche textuelle complémentaire est activée.",
   })
   textualScore?: number;
 
   @ApiProperty({
     required: false,
     type: Number,
-    description: "Score combiné thématique + textuel — c'est le critère de tri",
+    description: "Score de pertinence global de l'aide — critère de tri des résultats",
   })
   combinedScore?: number;
 
-  @ApiProperty({ required: false, type: [String], description: "Termes du projet retrouvés dans le texte de l'aide" })
+  @ApiProperty({
+    required: false,
+    type: [String],
+    description: "Termes du projet retrouvés dans le contenu de l'aide",
+  })
   matchedTerms?: string[];
 }
 
@@ -231,7 +235,7 @@ export class AidesListResponse {
   @ApiProperty({
     enum: ["ok", "no_match", "no_aides_on_perimeter"],
     description:
-      "Statut du résultat — `ok` : aides matchées triées par pertinence ; `no_match` : aides présentes sur le périmètre mais aucune ne partage de label de classification ≥ 0.8 avec le projet ; `no_aides_on_perimeter` : aucune aide AT n'a été trouvée pour les codes INSEE du projet.",
+      "Statut du résultat — `ok` : aides pertinentes trouvées, triées par pertinence ; `no_match` : des aides existent sur le périmètre mais aucune n'est jugée pertinente pour le projet ; `no_aides_on_perimeter` : aucune aide n'a été trouvée sur le territoire du projet.",
   })
   status!: AidesListStatus;
 


### PR DESCRIPTION
Consolidation des PR #471, #472, #473 + le rééquilibrage des poids (ex-#469) en une seule PR (4 commits, historique linéaire).

ℹ️ La PR #470 (*prompt system dédié aux aides*) a déjà été mergée dans `main` — elle ne fait donc plus partie de celle-ci (commit retiré automatiquement au rebase). Le script de requalification ci-dessous reste pertinent : il sert justement à reclassifier le catalogue avec ce nouveau prompt.

## 1. `chore(aides)` — script de requalification
`scripts/requalify-aides.ts` : force le recalcul LLM des classifications d'aides (nécessaire après le changement de prompt #470 — le `contentHash` ne couvre pas le prompt). Méthode douce (réécriture du `content_hash` avec un sentinel, pas de `TRUNCATE` → aucune coupure), déclenchement via job BullMQ. Modes dry-run / `--apply` / `--watch`.

## 2. `chore(aides)` — rééquilibrage du matching combiné
Le signal textuel ressortait surpondéré. Poids `W_THEMATIC` 0.7 → 0.85, `W_TEXTUAL` 0.3 → 0.15 ; plancher de rescue `MIN_TEXTUAL_RESCUE` 0.2 → 0.35. Le thématique (plus fiable) domine nettement.

## 3. `docs(aides)` — nettoyage du Swagger
Retrait des détails d'implémentation du contrat public : nom de variable d'env, algorithme (BM25), seuils chiffrés. Descriptions reformulées de façon fonctionnelle.

## 4. `feat(aides)` — params `cutoff` et seuils de confiance sur `GET /aides`
3 query params optionnels :
- `cutoff` : score de pertinence minimal (0-1) ; sans lui, comportement inchangé.
- `aideThreshold` / `projetThreshold` : seuil de confiance des labels, réglable indépendamment côté aide et projet (défaut 0.8).

## Test plan

- [x] `pnpm type-check` + `lint` + `format:check` OK
- [x] `pnpm jest src/aides` → **74/74**
- [ ] Staging : valider les params `cutoff`/`thresholds`, et lancer la requalif du catalogue.

---

Remplace #469 #471 #472 #473.

🤖 Generated with [Claude Code](https://claude.com/claude-code)