### PR TITLE
feat(api): pondération du matching aides/projets + filtre montant sur dashboard-te

### DIFF
--- a/api/src/aides/aides-matching.service.spec.ts
+++ b/api/src/aides/aides-matching.service.spec.ts
@@ -138,6 +138,30 @@ describe("AidesMatchingService", () => {
       expect(results[0].labelsCommuns.thematiques).toEqual(["A"]);
     });
 
+    it("should weight axes 45% thématiques / 35% sites / 20% interventions", () => {
+      // Project has one label per axis, all at the same confidence (0.9).
+      // Each aide is a perfect match (1.0) on exactly one axis, so its
+      // normalizedScore reflects that axis' relative weight.
+      const projet = makeScores(
+        [{ label: "Th", score: 0.9 }],
+        [{ label: "Si", score: 0.9 }],
+        [{ label: "In", score: 0.9 }],
+      );
+
+      const aides = new Map([
+        ["aide-th", makeScores([{ label: "Th", score: 1.0 }], [], [])],
+        ["aide-si", makeScores([], [{ label: "Si", score: 1.0 }], [])],
+        ["aide-in", makeScores([], [], [{ label: "In", score: 1.0 }])],
+      ]);
+
+      const results = service.match(projet, aides);
+      const byId = (id: string) => results.find((r) => r.idAt === id)!;
+
+      expect(byId("aide-th").normalizedScore).toBeCloseTo(0.45, 2);
+      expect(byId("aide-si").normalizedScore).toBeCloseTo(0.35, 2);
+      expect(byId("aide-in").normalizedScore).toBeCloseTo(0.2, 2);
+    });
+
     it("should handle empty inputs", () => {
       expect(service.match(makeScores(), new Map())).toEqual([]);
     });

--- a/api/src/aides/aides-matching.service.ts
+++ b/api/src/aides/aides-matching.service.ts
@@ -19,7 +19,9 @@
  *   4. Axis score = sum(terms) / number of project labels on this axis
  *      Division normalizes so projects with fewer labels aren't penalized
  *
- * Total score = score_thématiques + score_sites + score_interventions
+ * Total score = 0.45 × score_thématiques + 0.35 × score_sites + 0.20 × score_interventions
+ *   The axis weights make the thematic relevance dominant, the location
+ *   secondary, and the intervention type a lighter tie-breaker.
  */
 
 import { Injectable } from "@nestjs/common";
@@ -37,6 +39,11 @@ export class AidesMatchingService {
   /** Default confidence threshold (Gaëtan's script: THRESHOLD=80 on the 0-100 scale). */
   static readonly DEFAULT_THRESHOLD = 0.8;
   private readonly SCORE_OFFSET = 0.1;
+
+  // Relative weight of each axis in the total score (must sum to 1)
+  private readonly WEIGHT_THEMATIQUES = 0.45;
+  private readonly WEIGHT_SITES = 0.35;
+  private readonly WEIGHT_INTERVENTIONS = 0.2;
 
   constructor(private readonly logger: CustomLogger) {}
 
@@ -81,7 +88,10 @@ export class AidesMatchingService {
       const siResult = this.scoreAxis(pSites, aSites, projetThreshold, aideThreshold);
       const inResult = this.scoreAxis(pInterventions, aInterventions, projetThreshold, aideThreshold);
 
-      const totalScore = thResult.score + siResult.score + inResult.score;
+      const totalScore =
+        this.WEIGHT_THEMATIQUES * thResult.score +
+        this.WEIGHT_SITES * siResult.score +
+        this.WEIGHT_INTERVENTIONS * inResult.score;
 
       if (totalScore > 0) {
         const axesMatched =
@@ -113,7 +123,8 @@ export class AidesMatchingService {
 
   /**
    * Theoretical max score for a project: the score if a hypothetical aide
-   * matched every project label at confidence 1.0.
+   * matched every project label at confidence 1.0. Uses the same axis
+   * weights as the total score so normalizedScore stays in [0, 1].
    */
   private computeProjectMax(
     pThematiques: Map<string, number>,
@@ -123,9 +134,9 @@ export class AidesMatchingService {
     aideThreshold: number,
   ): number {
     return (
-      this.axisMax(pThematiques, projetThreshold, aideThreshold) +
-      this.axisMax(pSites, projetThreshold, aideThreshold) +
-      this.axisMax(pInterventions, projetThreshold, aideThreshold)
+      this.WEIGHT_THEMATIQUES * this.axisMax(pThematiques, projetThreshold, aideThreshold) +
+      this.WEIGHT_SITES * this.axisMax(pSites, projetThreshold, aideThreshold) +
+      this.WEIGHT_INTERVENTIONS * this.axisMax(pInterventions, projetThreshold, aideThreshold)
     );
   }
 

--- a/api/src/dashboard-te/dashboard-te.controller.ts
+++ b/api/src/dashboard-te/dashboard-te.controller.ts
@@ -103,6 +103,9 @@ export class DashboardTeController {
     @Query("scoreMin") scoreMin?: string,
     @Query("source") source?: string,
     @Query("phase") phase?: string,
+    @Query("financement") financement?: string,
+    @Query("montantMin") montantMin?: string,
+    @Query("montantMax") montantMax?: string,
     @Query("q") q?: string,
     @Query("page") page?: string,
     @Query("limit") limit?: string,
@@ -110,6 +113,9 @@ export class DashboardTeController {
     const p = toInt(page, 0);
     const l = Math.min(toInt(limit, 50), 200);
     const scoreMinNum = scoreMin != null && scoreMin !== "" ? Number(scoreMin) : undefined;
+    const montantMinNum = montantMin != null && montantMin !== "" ? Number(montantMin) : undefined;
+    const montantMaxNum = montantMax != null && montantMax !== "" ? Number(montantMax) : undefined;
+    const financementFilter = financement === "avec" || financement === "sans" ? financement : undefined;
     const result = await this.svc.projets({
       commune,
       departement,
@@ -122,6 +128,9 @@ export class DashboardTeController {
       scoreMin: Number.isFinite(scoreMinNum) ? scoreMinNum : undefined,
       source,
       phase,
+      financement: financementFilter,
+      montantMin: Number.isFinite(montantMinNum) && montantMinNum! >= 0 ? montantMinNum : undefined,
+      montantMax: Number.isFinite(montantMaxNum) && montantMaxNum! >= 0 ? montantMaxNum : undefined,
       q,
       page: p,
       limit: l,

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -360,6 +360,9 @@ export class DashboardTeService {
     scoreMin?: number;
     source?: string;
     phase?: string;
+    financement?: "avec" | "sans";
+    montantMin?: number;
+    montantMax?: number;
     q?: string;
     page: number;
     limit: number;
@@ -375,6 +378,9 @@ export class DashboardTeService {
       thematique,
       source,
       phase,
+      financement,
+      montantMin,
+      montantMax,
       q,
       page,
       limit,
@@ -406,6 +412,30 @@ export class DashboardTeService {
     if (site && site.length > 0) conditions.push(classifClause(sql`p.llm_sites`, site));
     if (intervention && intervention.length > 0) conditions.push(classifClause(sql`p.llm_interventions`, intervention));
     if (thematique && thematique.length > 0) conditions.push(classifClause(sql`p.llm_thematiques`, thematique));
+
+    // Financement filters. The financements table FK is inconsistent across rows
+    // (some use "projetId", some projet_id), so both are matched — same as projet().
+    const financementMatch = sql`(f."projetId" = p.id OR f.projet_id = p.id)`;
+    if (financement === "avec") {
+      conditions.push(sql`EXISTS (SELECT 1 FROM schema_commun_v2.financements f WHERE ${financementMatch})`);
+    }
+    if (financement === "sans") {
+      conditions.push(sql`NOT EXISTS (SELECT 1 FROM schema_commun_v2.financements f WHERE ${financementMatch})`);
+    }
+    // montantMin/Max filter on the total amount attributed per project (fallback:
+    // amount requested). The aggregate over zero rows is NULL, so projects with no
+    // financement never satisfy the HAVING — i.e. a montant filter implies financement=avec.
+    if (montantMin !== undefined || montantMax !== undefined) {
+      const montantTotal = sql`SUM(COALESCE(CAST(NULLIF(f."montantAttribue", '') AS numeric), CAST(NULLIF(f."montantDemande", '') AS numeric), 0))`;
+      const havingParts: SQL[] = [];
+      if (montantMin !== undefined) havingParts.push(sql`${montantTotal} >= ${montantMin}`);
+      if (montantMax !== undefined) havingParts.push(sql`${montantTotal} <= ${montantMax}`);
+      conditions.push(sql`EXISTS (
+        SELECT 1 FROM schema_commun_v2.financements f
+        WHERE ${financementMatch}
+        HAVING ${sql.join(havingParts, sql` AND `)}
+      )`);
+    }
 
     const needsCommuneJoin = Boolean(commune ?? departement);
 

--- a/docs/api/classification-et-aides.md
+++ b/docs/api/classification-et-aides.md
@@ -254,7 +254,9 @@ Le matching ne fait **aucun appel à l'IA**. C'est un calcul mathématique pur b
 3. Score axe = somme(termes) / nombre de labels du projet sur cet axe
 ```
 
-**Score total** = score thématiques + score sites + score interventions
+**Score total** = 0.45 × score thématiques + 0.35 × score sites + 0.20 × score interventions
+
+Les trois axes ne pèsent pas autant : la pertinence **thématique** est dominante (45 %), le **lieu** est secondaire (35 %) et le **type d'intervention** sert de critère d'appoint (20 %).
 
 **Pourquoi le `- 0.7` ?** C'est un décalage qui donne plus de poids aux labels dont le modèle est très sûr :
 
@@ -292,7 +294,7 @@ Score interventions :
   = (0.95 - 0.7) × (0.90 - 0.7) / 1 label projet
   = 0.25 × 0.20 = 0.05
 
-Score total = 0.0165 + 0 + 0.05 = 0.0665
+Score total = 0.45 × 0.0165 + 0.35 × 0 + 0.20 × 0.05 = 0.0174
 ```
 
 ### 4. Classifier un texte à la volée (optionnel)


### PR DESCRIPTION
## Contexte

Deux évolutions API regroupées.

## 1. Pondération des axes du matching aides/projets

`AidesMatchingService` combinait les 3 axes de classification (thématiques, sites, interventions) à **poids égal**. Le score total applique désormais une pondération :

| Axe | Poids |
| --- | --- |
| Thématiques | 45 % |
| Lieu (sites) | 35 % |
| Interventions | 20 % |

- `computeProjectMax` applique les mêmes poids → `normalizedScore` reste dans `[0, 1]`.
- Les scores par axe (`scoreThematiques` / `scoreSites` / `scoreInterventions`) restent **bruts** (non pondérés) ; seuls `score` et `normalizedScore` intègrent la pondération.
- Test ajouté : trois aides matchant parfaitement un seul axe chacune → `normalizedScore` de 0.45 / 0.35 / 0.20.

## 2. Filtre financement / montant sur `GET /dashboard-te/projets`

Trois nouveaux paramètres de query :

- `financement=avec|sans` — présence d'au moins un financement (`EXISTS` / `NOT EXISTS`).
- `montantMin` / `montantMax` — bornes (ouvertes si une seule fournie) sur la **somme attribuée par projet** (`montantAttribue`, fallback `montantDemande`), via `EXISTS (… HAVING SUM(…))`.

Détails :
- Un filtre de montant **implique la présence d'un financement** : `SUM` sur zéro ligne vaut `NULL`, donc le `HAVING` exclut les projets sans financement (cohérent avec `financement=avec`).
- La FK de `financements` est incohérente selon les lignes (`"projetId"` vs `projet_id`) — les deux sont matchées, comme dans `projet()`.
- Toutes les valeurs passent par les placeholders du template `sql` (anti-injection).
- Filtres combinables avec les filtres existants et reflétés dans le total de pagination.
- Suit la convention de la route : `@Query()` inline, pas de DTO de classe (les 14 autres filtres n'en utilisent pas).

## Tests

- `aides-matching.service.spec.ts` : 12/12 ✅
- `pnpm type-check` : ✅

Aucun changement front nécessaire — le SPA Dashboard TE envoie déjà `financement`, `montantMin`, `montantMax`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
