### PR TITLE
ci(prod): scinder release et déploiement en deux jobs ré-exécutables

### DIFF
--- a/.github/workflows/prod-deployment.yml
+++ b/.github/workflows/prod-deployment.yml
@@ -8,13 +8,13 @@ on:
 permissions:
   contents: write
 
-defaults:
-  run:
-    working-directory: api
-
 jobs:
-  release-and-deploy:
+  # Job 1 — bump the version, update the changelog, commit and tag, push to main.
+  release:
     runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: .
 
     steps:
       - uses: actions/checkout@v6
@@ -24,7 +24,6 @@ jobs:
           # Using admin PAT to bypass branch protection rules for version bump
 
       - name: Enable Corepack
-        shell: bash
         run: corepack enable
 
       - name: Setup Node.js
@@ -34,27 +33,56 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        working-directory: .
         run: pnpm install
 
       - name: Setup Git hooks
-        working-directory: .
         run: pnpm prepare
 
-      - name: Configure Git #change the user/email
-        working-directory: .
+      - name: Configure Git
         run: |
           git config user.name "GitHub Actions Bot"
           git config user.email "actions@github.com"
 
       - name: Generate new version
-        working-directory: .
-        run: HUSKY=0 pnpm --filter api run release #do not need precommit check there
+        # Idempotent: if HEAD is already a release tag, the release has already
+        # happened (e.g. the workflow is re-dispatched after a deploy failure).
+        # Skip the bump instead of failing on "tag already exists".
+        run: |
+          if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
+            echo "✅ HEAD déjà taggé ($(git describe --tags --exact-match HEAD)) — release sautée."
+          else
+            HUSKY=0 pnpm --filter api run release
+          fi
 
       - name: Push changes and tags
+        run: git push --follow-tags origin main
+
+  # Job 2 — deploy main to Scalingo. Separate job so that re-running a failed
+  # deployment never replays the release step (which would collide on the tag).
+  deploy:
+    needs: release
+    runs-on: ubuntu-latest
+    defaults:
+      run:
         working-directory: .
+
+    steps:
+      # Check out main at its current tip — i.e. the release commit the
+      # `release` job just pushed, not the SHA that triggered the workflow.
+      - uses: actions/checkout@v6
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '22'
+
+      - name: Configure Git
         run: |
-          git push --follow-tags origin main
+          git config user.name "GitHub Actions Bot"
+          git config user.email "actions@github.com"
 
       - name: Setup SSH
         run: |
@@ -64,7 +92,6 @@ jobs:
           ssh-keyscan -H -t rsa,ecdsa,ed25519 ssh.osc-fr1.scalingo.com >> ~/.ssh/known_hosts
 
       - name: Prepare package.json for Scalingo
-        working-directory: .
         run: |
           set -e
           echo "🔧 Patching package.json files for Scalingo buildpack compatibility..."


### PR DESCRIPTION
## Problème

`prod-deployment.yml` était **un seul job** enchaînant : bump de version → commit → tag → push `main` → déploiement Scalingo.

Quand le déploiement Scalingo échoue, relancer le job (« Re-run ») rejoue l'étape `commit-and-tag-version` sur le commit d'origine → re-bump → `git tag vX.Y.Z` → **échec** :

```
fatal: tag 'v0.1.83' already exists
```

Le tag a déjà été créé par le 1ᵉʳ run. Le workflow n'est pas ré-exécutable.

## Correctif

**1. Deux jobs au lieu d'un**
- `release` — bump, changelog, commit, tag, push `main`.
- `deploy` (`needs: release`) — déploie sur Scalingo.

`deploy` checkout `ref: main` (le commit de release que `release` vient de pousser), et non le SHA déclencheur. Ainsi « Re-run failed jobs » après un échec Scalingo ne rejoue **que** `deploy` — la release n'est jamais relancée.

**2. Garde d'idempotence sur l'étape release**

```bash
if git describe --tags --exact-match HEAD >/dev/null 2>&1; then
  echo "✅ HEAD déjà taggé — release sautée."
else
  HUSKY=0 pnpm --filter api run release
fi
```

Si on re-dispatche le workflow entier sur un `main` déjà taggé, la release est sautée au lieu de planter sur le tag existant.

## Effet

| Scénario | Avant | Après |
| --- | --- | --- |
| Deploy Scalingo échoue → « Re-run failed jobs » | ❌ collision de tag | ✅ rejoue `deploy` seul |
| Re-dispatch du workflow sur `main` déjà taggé | ❌ collision de tag | ✅ release sautée, deploy seul |
| Release normale (commits non publiés) | ✅ | ✅ inchangé |

Aucun changement de comportement pour une release normale. Les étapes (SSH, patch `package.json` engines pour le buildpack, force-push Scalingo) sont identiques, juste réparties.

> Contexte : la release `0.1.83` est déjà sur `main` (tag `v0.1.83`). Une fois cette PR mergée, un simple re-dispatch de « Production Deployment » sautera la release et déploiera `0.1.83` sur Scalingo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
