### PR TITLE
fix(dashboard-te): corriger le filtre montant/financement (colonne projet_id)

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -454,9 +454,10 @@ export class DashboardTeService {
       conditions.push(sql`(${sql.join(labelPredicates, joiner)})`);
     }
 
-    // Financement filters. The financements table FK is inconsistent across rows
-    // (some use "projetId", some projet_id), so both are matched — same as projet().
-    const financementMatch = sql`(f."projetId" = p.id OR f.projet_id = p.id)`;
+    // Financement filters. The financements FK to a projet is the snake_case
+    // column projet_id — there is no "projetId" column (referencing it raised a
+    // 500 in the montant/financement filters).
+    const financementMatch = sql`f.projet_id = p.id`;
     if (financement === "avec") {
       conditions.push(sql`EXISTS (SELECT 1 FROM schema_commun_v2.financements f WHERE ${financementMatch})`);
     }
@@ -581,7 +582,7 @@ export class DashboardTeService {
         CAST(NULLIF("montantPaye", '') AS numeric) AS "montantPaye",
         statut
       FROM schema_commun_v2.financements
-      WHERE "projetId" = ${id} OR projet_id = ${id}
+      WHERE projet_id = ${id}
     `,
     ).catch(() => [] as Row[]);
 


### PR DESCRIPTION
## Problème

`/dashboard-te/projets?montantMin=...` (et `?montantMax=`, `?financement=avec|sans`) renvoie un **500** :

```
column f.projetId does not exist
```

Le `financementMatch` référence `f."projetId"`, colonne qui n'existe pas dans `schema_commun_v2.financements` — la FK vers un projet est `projet_id` (snake_case). Le commentaire du code prétendait à tort que la FK variait « selon les lignes ».

`projet()` faisait la même requête, masquée par un `.catch(() => [])` — donc le détail projet n'a en réalité **jamais** affiché ses financements.

## Correctif

- `financementMatch` → `f.projet_id = p.id`.
- `projet()` : `WHERE projet_id = ${id}` (le `.catch` est conservé en filet de sécurité).

## Note

Ce correctif aurait dû faire partie de #477 mais a été commité après le merge de cette PR — d'où cette PR séparée. Bug préexistant (commit `8e71a3e`).

## Tests

- `type-check` + `lint` + `format:check` OK (hook de validation pre-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)