### PR TITLE
feat(dashboard-te): alias de tri intuitifs (budget, orderBy)

### DIFF
--- a/api/src/dashboard-te/dashboard-te.controller.ts
+++ b/api/src/dashboard-te/dashboard-te.controller.ts
@@ -133,7 +133,7 @@ export class DashboardTeController {
     const l = Math.min(toInt(first(query.limit), 50), 200);
     const result = await this.svc.projets({
       ...parseProjetsFilter(query),
-      sort: first(query.sort),
+      sort: first(query.sort) ?? first(query.orderBy),
       order: first(query.order) === "desc" ? "desc" : "asc",
       page: p,
       limit: l,

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -499,12 +499,16 @@ export class DashboardTeService {
 
     // Whitelisted sort. `sort` from the request never reaches the SQL as raw text:
     // it only picks one of these fixed output-column names. Ordering by an output
-    // column keeps it valid under SELECT DISTINCT and lets `montant` follow the
-    // capped budget transparently. Unknown/missing `sort` falls back to nom; a
-    // secondary sort on nom keeps pagination stable when the primary column ties.
+    // column keeps it valid under SELECT DISTINCT and lets the budget sort follow
+    // the capped budget transparently. Plusieurs alias sont acceptés pour le tri
+    // budget (montant/budget/budgetPrevisionnel) car le param filtre s'appelle
+    // montantMin/Max et le champ de réponse budgetPrevisionnel. Unknown/missing
+    // `sort` falls back to nom; a secondary sort on nom keeps pagination stable.
     const sortColumns: Record<string, SQL> = {
       nom: sql`nom`,
       montant: sql`"budgetPrevisionnel"`,
+      budget: sql`"budgetPrevisionnel"`,
+      budgetPrevisionnel: sql`"budgetPrevisionnel"`,
       dateDebut: sql`"dateDebut"`,
       dateFin: sql`"dateFin"`,
     };


### PR DESCRIPTION
## Contexte

Le tri de `/dashboard-te/projets` fonctionne, mais la valeur pour trier par budget était `sort=montant` — peu intuitive : le param de filtre s'appelle `montantMin/Max` et le champ de réponse `budgetPrevisionnel`. Côté dashboard, les essais `sort=budget`, `sort=budgetPrevisionnel`, `orderBy=budget` retombaient silencieusement sur le tri par `nom`.

## Changement

- `sort` accepte désormais, pour le tri budget : `montant` | `budget` | `budgetPrevisionnel` (alias de la même colonne).
- Le champ de tri peut être passé via `sort` **ou** `orderBy` (`sort` prioritaire).
- Inchangé : valeurs `nom` | `dateDebut` | `dateFin` ; direction `order=asc|desc` ; défaut `sort=nom&order=asc`.

Whitelist stricte conservée (anti-injection) — une valeur inconnue retombe sur `nom`.

## Tests

`type-check` + `lint` + `format:check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)