### PR TITLE
feat(dashboard-te): filtre et synthèse par probabilité de transition écologique

### DIFF
--- a/api/src/dashboard-te/dashboard-te.controller.ts
+++ b/api/src/dashboard-te/dashboard-te.controller.ts
@@ -51,6 +51,8 @@ const first = (v: string | string[] | undefined): string | undefined => (Array.i
 const parseProjetsFilter = (raw: RawQuery) => {
   const montantMinNum = first(raw.montantMin) ? Number(first(raw.montantMin)) : undefined;
   const montantMaxNum = first(raw.montantMax) ? Number(first(raw.montantMax)) : undefined;
+  const probaTeMinNum = first(raw.probaTeMin) ? Number(first(raw.probaTeMin)) : undefined;
+  const probaTeMaxNum = first(raw.probaTeMax) ? Number(first(raw.probaTeMax)) : undefined;
   const financementRaw = first(raw.financement);
   const financement: "avec" | "sans" | undefined =
     financementRaw === "avec" || financementRaw === "sans" ? financementRaw : undefined;
@@ -70,6 +72,8 @@ const parseProjetsFilter = (raw: RawQuery) => {
     financement,
     montantMin: Number.isFinite(montantMinNum) && montantMinNum! >= 0 ? montantMinNum : undefined,
     montantMax: Number.isFinite(montantMaxNum) && montantMaxNum! >= 0 ? montantMaxNum : undefined,
+    probaTeMin: Number.isFinite(probaTeMinNum) ? probaTeMinNum : undefined,
+    probaTeMax: Number.isFinite(probaTeMaxNum) ? probaTeMaxNum : undefined,
     q: first(raw.q),
   };
 };

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -60,6 +60,8 @@ export interface ProjetsFilter {
   financement?: "avec" | "sans";
   montantMin?: number;
   montantMax?: number;
+  probaTeMin?: number;
+  probaTeMax?: number;
   q?: string;
 }
 
@@ -472,6 +474,14 @@ export class DashboardTeService {
     if (f.montantMax !== undefined) {
       conditions.push(sql`${cappedBudget(sql`p."budgetPrevisionnel"`)} <= ${f.montantMax}`);
     }
+    // probaTeMin/Max : filtre sur la probabilité de transition écologique (llm_probabilite_te,
+    // double precision sur 0–1). Un projet sans proba (NULL) ne matche aucun intervalle.
+    if (f.probaTeMin !== undefined) {
+      conditions.push(sql`p.llm_probabilite_te >= ${f.probaTeMin}`);
+    }
+    if (f.probaTeMax !== undefined) {
+      conditions.push(sql`p.llm_probabilite_te <= ${f.probaTeMax}`);
+    }
 
     const needsCommuneJoin = Boolean(f.commune ?? f.departement);
 
@@ -565,16 +575,22 @@ export class DashboardTeService {
     // Une ligne par projet : la jointure communes peut dédoubler les lignes.
     const filtered = sql`
       SELECT DISTINCT p.id, p.phase, p.source_origine,
-        p."budgetPrevisionnel", p.llm_thematiques, p."competencesM57", p."leviersSgpe"
+        p."budgetPrevisionnel", p.llm_thematiques, p."competencesM57", p."leviersSgpe",
+        p.llm_probabilite_te
       ${joinClause}
       ${whereClause}
     `;
 
-    const [totals] = await this.query<{ count: string; sumBudget: string }>(sql`
+    // probaTePondere = Σ(probaTE × budget) / Σ(budget), sur les projets ayant À LA
+    // FOIS une proba TE et un budget (plafonné) renseignés. NULL si aucun.
+    const [totals] = await this.query<{ count: string; sumBudget: string; probaTePondere: string | null }>(sql`
       WITH filtered AS (${filtered})
       SELECT
         count(*)::text AS count,
-        COALESCE(SUM(${cappedBudget(sql`"budgetPrevisionnel"`)}), 0)::text AS "sumBudget"
+        COALESCE(SUM(${cappedBudget(sql`"budgetPrevisionnel"`)}), 0)::text AS "sumBudget",
+        (SUM(llm_probabilite_te * ${cappedBudget(sql`"budgetPrevisionnel"`)})
+          / NULLIF(SUM(${cappedBudget(sql`"budgetPrevisionnel"`)})
+              FILTER (WHERE llm_probabilite_te IS NOT NULL), 0))::text AS "probaTePondere"
       FROM filtered
     `);
 
@@ -631,6 +647,22 @@ export class DashboardTeService {
       LIMIT 25
     `);
 
+    // Répartition par tranche de proba TE : élevée ≥ 0.8, moyenne 0.5–0.8,
+    // faible < 0.5, plus les projets sans proba.
+    const parTrancheProbaTe = await this.query<{ key: string; count: string }>(sql`
+      WITH filtered AS (${filtered})
+      SELECT
+        CASE
+          WHEN llm_probabilite_te IS NULL THEN 'nonRenseigne'
+          WHEN llm_probabilite_te >= 0.8 THEN 'elevee'
+          WHEN llm_probabilite_te >= 0.5 THEN 'moyenne'
+          ELSE 'faible'
+        END AS key,
+        count(*)::text AS count
+      FROM filtered
+      GROUP BY 1
+    `);
+
     const toMap = (rows: { key: string; count: string }[]): Record<string, number> =>
       Object.fromEntries(rows.map((r) => [r.key, Number(r.count)]));
 
@@ -639,11 +671,13 @@ export class DashboardTeService {
       sumBudgetPrevisionnel: Number(totals?.sumBudget ?? 0),
       sumFinancementAttribue: Number(fin?.sumAttribue ?? 0),
       avecFinancementCount: Number(fin?.avecCount ?? 0),
+      probaTeMoyennePonderee: totals?.probaTePondere != null ? Number(totals.probaTePondere) : null,
       parPhase: toMap(parPhase),
       parSource: toMap(parSource),
       parThematique: toMap(parThematique),
       parCompetence: toMap(parCompetence),
       parLevier: toMap(parLevier),
+      parTrancheProbaTe: { elevee: 0, moyenne: 0, faible: 0, nonRenseigne: 0, ...toMap(parTrancheProbaTe) },
     };
   }
 


### PR DESCRIPTION
Filtrer les projets par probabilité de transition écologique, et l'agréger dans `/projets/summary`.

Colonne : `schema_commun_v2.projets_operationnels.llm_probabilite_te` (`double precision`, échelle 0–1) — **vérifiée via `information_schema`**.

## Filtre — `/projets` et `/projets/summary`

| Param | Effet |
|-------|-------|
| `probaTeMin` | `llm_probabilite_te >= probaTeMin` |
| `probaTeMax` | `llm_probabilite_te <= probaTeMax` |

Bornes incluses, combinables. Un projet sans proba (`NULL`) ne matche aucun intervalle. Valeurs non numériques ignorées.

## `/projets/summary` — deux champs ajoutés

- **`probaTeMoyennePonderee`** : moyenne de la proba TE **pondérée par le budget** — `Σ(probaTE × budget) / Σ(budget)`, calculée sur les projets ayant *à la fois* une proba TE et un budget (plafonné) renseignés. `null` si aucun projet éligible.
- **`parTrancheProbaTe`** : répartition du nombre de projets par tranche —
  - `elevee` : proba ≥ 0,8
  - `moyenne` : 0,5 ≤ proba < 0,8
  - `faible` : proba < 0,5
  - `nonRenseigne` : pas de proba

  Les 4 clés sont toujours présentes (0 par défaut).

Seuils de tranches ajustables si besoin — me le dire.

## Tests

`type-check` + `lint` + `format:check` OK. Schéma vérifié contre la vraie base.

🤖 Generated with [Claude Code](https://claude.com/claude-code)