### PR TITLE
feat(dashboard-te): exposer la proba TE par projet

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -547,6 +547,7 @@ export class DashboardTeService {
         ${classifLabels(sql`p.llm_interventions`)} AS "classificationInterventions",
         p.llm_sites->0->>'label' AS "llmSite",
         p.llm_sites->0->>'nom_propre' AS "llmSiteNomPropre",
+        p.llm_probabilite_te AS "llmProbabiliteTe",
         cm.cluster_id AS "clusterId",
         c.confiance AS "clusterConfiance"
       ${joinClause}
@@ -713,6 +714,7 @@ export class DashboardTeService {
         p.llm_sites->0->>'nom_propre' AS "llmSiteNomPropre",
         p.llm_interventions->0->>'label' AS "llmIntervention",
         p.llm_thematiques->0->>'label' AS "llmThematique",
+        p.llm_probabilite_te AS "llmProbabiliteTe",
         cm.cluster_id AS "clusterId",
         c.confiance AS "clusterConfiance"
       FROM schema_commun_v2.projets_operationnels p


### PR DESCRIPTION
La probabilité de transition écologique est désormais renvoyée **par projet** dans les réponses :

- `GET /dashboard-te/projets` (liste)
- `GET /dashboard-te/projets/:id` (détail)

Nouveau champ : **`llmProbabiliteTe`** — `number` sur 0–1, ou `null` si non renseignée. Source : colonne `llm_probabilite_te` (`double precision`). Nommage cohérent avec les autres champs `llm*` de ces réponses (`llmSite`, `llmThematique`…).

Permet au dashboard d'afficher la proba TE projet par projet (en complément du filtre `probaTeMin/Max` et des agrégats du `/summary`).

## Tests

`type-check` + `lint` + `format:check` OK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)