### PR TITLE
feat(aides): recherche d'aides par classification et communes

### DIFF
--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -381,6 +381,118 @@ describe("AidesController", () => {
     });
   });
 
+  describe("searchAides (POST /aides/recherche)", () => {
+    const baseDto = {
+      thematiques: [{ label: "Rénovation énergétique", score: 0.9 }],
+      sites: [],
+      interventions: [],
+      communes: ["44109"],
+    };
+
+    it("fetches aides by commune INSEE perimeter code (not via a projet)", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
+
+      await controller.searchAides({ ...baseDto });
+
+      // Pas de résolution de projet : on ne touche pas au registre projets.
+      expect(mockProjetsService.findOneWithSource).not.toHaveBeenCalled();
+      // Le matching reçoit bien la classification fournie en entrée.
+      expect(mockMatchingService.match).toHaveBeenCalledWith(
+        { thematiques: baseDto.thematiques, sites: [], interventions: [] },
+        expect.any(Map),
+        expect.any(Number),
+        expect.any(Object),
+      );
+    });
+
+    it("dedupes communes and queries AT once per unique perimeter code", async () => {
+      // Cache miss → fetch synchrone par code de périmètre.
+      mockCacheService.get.mockResolvedValue(null);
+      mockAtService.fetchAides.mockResolvedValue([makeAide(1)]);
+
+      await controller.searchAides({ ...baseDto, communes: ["44109", "44109", "75056"] });
+
+      // 2 codes uniques → 2 appels AT.
+      expect(mockAtService.fetchAides).toHaveBeenCalledTimes(2);
+      expect(mockAtService.fetchAides).toHaveBeenCalledWith({ "perimeter_codes[]": "44109" });
+      expect(mockAtService.fetchAides).toHaveBeenCalledWith({ "perimeter_codes[]": "75056" });
+    });
+
+    it("returns no_aides_on_perimeter when AT returns nothing on the communes", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [], status: "fresh" });
+      mockAtService.fetchAides.mockResolvedValue([]);
+
+      const result = await controller.searchAides({ ...baseDto });
+
+      expect(result.status).toBe("no_aides_on_perimeter");
+      expect(result.total).toBe(0);
+    });
+
+    it("returns no_match when aides exist but none is relevant", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1), makeAide(2)], status: "fresh" });
+      mockMatchingService.match.mockReturnValue([]);
+
+      const result = await controller.searchAides({ ...baseDto });
+
+      expect(result.status).toBe("no_match");
+      expect(result.total).toBe(2);
+    });
+
+    it("returns ok with aides sorted by relevance", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1), makeAide(2)], status: "fresh" });
+      mockMatchingService.match.mockReturnValue([
+        {
+          idAt: "2",
+          score: 0.8,
+          normalizedScore: 0.8,
+          scoreThematiques: 0.8,
+          scoreSites: 0,
+          scoreInterventions: 0,
+          axesMatched: 1,
+          labelsCommuns: { thematiques: ["Rénovation énergétique"], sites: [], interventions: [] },
+        },
+        {
+          idAt: "1",
+          score: 0.3,
+          normalizedScore: 0.3,
+          scoreThematiques: 0.3,
+          scoreSites: 0,
+          scoreInterventions: 0,
+          axesMatched: 1,
+          labelsCommuns: { thematiques: ["Rénovation énergétique"], sites: [], interventions: [] },
+        },
+      ]);
+
+      const result = await controller.searchAides({ ...baseDto });
+
+      expect(result.status).toBe("ok");
+      expect(result.aides).toHaveLength(2);
+      expect(result.aides[0].id).toBe(2); // meilleur score en tête
+      expect(result.total).toBe(2);
+    });
+
+    it("forwards the per-side thresholds to the matching service", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
+
+      await controller.searchAides({ ...baseDto, aideThreshold: 0.7, projetThreshold: 0.3 });
+
+      expect(mockMatchingService.match).toHaveBeenCalledWith(expect.anything(), expect.any(Map), expect.any(Number), {
+        projet: 0.3,
+        aide: 0.7,
+      });
+    });
+
+    it("runs textual matching only when textual=true", async () => {
+      mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
+
+      await controller.searchAides({ ...baseDto, textual: false });
+      expect(mockTextualMatchingService.score).not.toHaveBeenCalled();
+
+      await controller.searchAides({ ...baseDto, textual: true, query: "rénovation" });
+      expect(mockTextualMatchingService.score).toHaveBeenCalledWith("rénovation", expect.any(Array));
+    });
+  });
+
   describe("listAides textual matching", () => {
     it("should NOT call the textual service when the flag is off (default)", async () => {
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -35,12 +35,15 @@ import { AidesFeedbackService } from "./aides-feedback.service";
 import { AideFeedbackResponse, CreateAideFeedbackRequest, DeleteAideFeedbackRequest } from "./dto/aide-feedback.dto";
 import {
   Aide,
+  AideClassification,
   AideMatchResult,
   AidesListResponse,
+  AidesSearchRequest,
   AidesSyncResponse,
   AideWithClassification,
   ClassificationPendingResponse,
 } from "./dto/aides.dto";
+import { MatchThresholds } from "./aides-matching.service";
 
 const CLASSIFICATION_RETRY_AFTER_SECONDS = 15;
 
@@ -186,7 +189,7 @@ export class AidesController {
     }
 
     // 4. Fetch aides for each territory (union) — deduplicate by aide id
-    const allAides = await this.fetchAidesForTerritories(codesInsee);
+    const allAides = await this.fetchAidesForPerimeterCodes(codesInsee);
 
     if (allAides.length === 0) {
       return { status: "no_aides_on_perimeter", aides: [], total: 0 };
@@ -196,25 +199,95 @@ export class AidesController {
     const aideIds = allAides.map((a) => String(a.id));
     const classifications = await this.classificationService.getCachedClassifications(aideIds);
 
-    // 6. Thematic matching — pass allAides.length so nothing is pre-sliced
-    //    before the (optional) textual combination below.
-    const matchResults = new Map<string, AideMatchResult>();
-    const results = this.matchingService.match(projet.classificationScores, classifications, allAides.length, {
-      projet: projetThreshold,
-      aide: aideThreshold,
+    // 6-7. Matching thématique (+ textuel optionnel), enrichissement et tri —
+    //      logique partagée avec POST /aides/recherche.
+    const textualEnabled = this.isTextualMatchingEnabled(textualOverride);
+    return this.buildMatchedResponse(projet.classificationScores, allAides, classifications, {
+      maxResults,
+      cutoff,
+      thresholds: { projet: projetThreshold, aide: aideThreshold },
+      textualEnabled,
+      textualText: `${projet.nom} ${projet.description ?? ""}`,
     });
-    for (const r of results) {
+  }
+
+  @TrackApiUsage()
+  @Post("recherche")
+  @ApiOperation({
+    summary: "Rechercher des aides par classification et communes",
+    description:
+      "Variante de `GET /aides` sans projet de référence : on fournit directement une classification (thématiques / sites / interventions, typiquement issue de `POST /qualification/classification`) et un périmètre de communes (codes INSEE). Les aides du périmètre sont matchées contre cette classification et triées par pertinence. Même périmètre par INSEE que `GET /aides`, donc même cache.\n\n**Statuts** :\n- `200 ok` : aides pertinentes trouvées\n- `200 no_match` : des aides existent sur le périmètre mais aucune n'est jugée pertinente\n- `200 no_aides_on_perimeter` : aucune aide trouvée sur les communes demandées",
+  })
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: AidesListResponse,
+    description: "Aides enrichies avec score de matching (status: ok | no_match | no_aides_on_perimeter)",
+  })
+  async searchAides(@Body() dto: AidesSearchRequest): Promise<AidesListResponse> {
+    const maxResults = dto.limit ?? 20;
+    const cutoff = dto.cutoff ?? 0;
+
+    // Classification recherchée — reconstruite à partir des labels fournis.
+    const searchScores: AideClassification = {
+      thematiques: dto.thematiques ?? [],
+      sites: dto.sites ?? [],
+      interventions: dto.interventions ?? [],
+    };
+
+    // Périmètre : union des aides disponibles sur les communes demandées
+    // (codes INSEE — mêmes clés de cache que GET /aides).
+    const communes = [...new Set(dto.communes.map((c) => c.trim()).filter(Boolean))];
+    const allAides = await this.fetchAidesForPerimeterCodes(communes);
+
+    if (allAides.length === 0) {
+      return { status: "no_aides_on_perimeter", aides: [], total: 0 };
+    }
+
+    const aideIds = allAides.map((a) => String(a.id));
+    const classifications = await this.classificationService.getCachedClassifications(aideIds);
+
+    // Le texte libre ne sert qu'au matching textuel optionnel.
+    const textualEnabled = dto.textual === true;
+    return this.buildMatchedResponse(searchScores, allAides, classifications, {
+      maxResults,
+      cutoff,
+      thresholds: { projet: dto.projetThreshold, aide: dto.aideThreshold },
+      textualEnabled,
+      textualText: dto.query ?? "",
+    });
+  }
+
+  /**
+   * Matching thématique (+ textuel optionnel), enrichissement et tri d'un
+   * ensemble d'aides contre une classification. Partagé par GET /aides et
+   * POST /aides/recherche. `total` reflète le nombre d'aides du périmètre
+   * avant filtrage par le matching.
+   */
+  private buildMatchedResponse(
+    scores: AideClassification,
+    allAides: Aide[],
+    classifications: Map<string, AideClassification>,
+    options: {
+      maxResults: number;
+      cutoff: number;
+      thresholds: MatchThresholds;
+      textualEnabled: boolean;
+      textualText: string;
+    },
+  ): AidesListResponse {
+    const { maxResults, cutoff, thresholds, textualEnabled, textualText } = options;
+
+    // Matching thématique — on passe allAides.length pour ne rien pré-trancher
+    // avant la combinaison textuelle optionnelle.
+    const matchResults = new Map<string, AideMatchResult>();
+    for (const r of this.matchingService.match(scores, classifications, allAides.length, thresholds)) {
       matchResults.set(r.idAt, r);
     }
 
-    // 6b. Textual matching (BM25) — opt-in via flag. Runs on ALL aides of the
-    //     territory, including those not yet classified.
-    const textualEnabled = this.isTextualMatchingEnabled(textualOverride);
-    const textualResults = textualEnabled
-      ? this.textualMatchingService.score(`${projet.nom} ${projet.description ?? ""}`, allAides)
-      : null;
+    // Matching textuel (BM25) — opt-in. Tourne sur toutes les aides du
+    // périmètre, y compris celles non encore classifiées.
+    const textualResults = textualEnabled ? this.textualMatchingService.score(textualText, allAides) : null;
 
-    // 7. Enrich
     let enriched: AideWithClassification[] = allAides.map((aide) => {
       const idAt = String(aide.id);
       const classification = classifications.get(idAt);
@@ -462,19 +535,20 @@ export class AidesController {
 
   /**
    * Fetch aides for multiple territories (union). Deduplicates by aide id.
-   * Uses AT's perimeter_codes[] parameter which accepts code INSEE directly.
+   * Uses AT's perimeter_codes[] parameter which accepts any perimeter code
+   * (code INSEE de commune, code département…) directly.
    */
-  private async fetchAidesForTerritories(codesInsee: string[]): Promise<Aide[]> {
-    if (codesInsee.length === 0) {
+  private async fetchAidesForPerimeterCodes(codes: string[]): Promise<Aide[]> {
+    if (codes.length === 0) {
       return this.fetchAidesForTerritory({}, "no territory filter");
     }
 
     const seenIds = new Set<number>();
     const allAides: Aide[] = [];
 
-    for (const codeInsee of codesInsee) {
-      const params = { "perimeter_codes[]": codeInsee };
-      const aides = await this.fetchAidesForTerritory(params, `code_insee=${codeInsee}`);
+    for (const code of codes) {
+      const params = { "perimeter_codes[]": code };
+      const aides = await this.fetchAidesForTerritory(params, `perimeter_code=${code}`);
 
       // Deduplicate across territories
       for (const aide of aides) {
@@ -485,7 +559,7 @@ export class AidesController {
       }
     }
 
-    this.logger.log(`Fetched ${allAides.length} unique aides across ${codesInsee.length} territories`);
+    this.logger.log(`Fetched ${allAides.length} unique aides across ${codes.length} territories`);
     return allAides;
   }
 }

--- a/api/src/aides/dto/aides.dto.ts
+++ b/api/src/aides/dto/aides.dto.ts
@@ -1,4 +1,16 @@
-import { ApiProperty } from "@nestjs/swagger";
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { Type } from "class-transformer";
+import {
+  ArrayNotEmpty,
+  IsArray,
+  IsBoolean,
+  IsNumber,
+  IsOptional,
+  IsString,
+  Max,
+  Min,
+  ValidateNested,
+} from "class-validator";
 
 export class AideFinancerFull {
   @ApiProperty()
@@ -275,4 +287,115 @@ export class AidesSyncResponse {
 
   @ApiProperty()
   warmupStarted!: boolean;
+}
+
+/**
+ * Un label de classification fourni en entrée de la recherche d'aides
+ * (POST /aides/recherche), avec son niveau de confiance (0-1). Provient
+ * typiquement de POST /qualification/classification sur un texte libre.
+ */
+export class AidesSearchLabel {
+  @ApiProperty({ description: "Libellé du label", example: "Rénovation énergétique" })
+  @IsString()
+  label!: string;
+
+  @ApiProperty({ description: "Niveau de confiance du label (0-1)", example: 0.85 })
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  score!: number;
+}
+
+/**
+ * Recherche d'aides à partir d'une classification (thématiques / sites /
+ * interventions) et d'un périmètre de communes — sans projet de référence.
+ * Le matching et le tri par pertinence reprennent la même logique que GET /aides
+ * (même périmètre par code INSEE de commune, donc même cache).
+ */
+export class AidesSearchRequest {
+  @ApiPropertyOptional({ type: [AidesSearchLabel], description: "Thématiques recherchées (label + score)" })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AidesSearchLabel)
+  thematiques?: AidesSearchLabel[];
+
+  @ApiPropertyOptional({ type: [AidesSearchLabel], description: "Sites / lieux recherchés (label + score)" })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AidesSearchLabel)
+  sites?: AidesSearchLabel[];
+
+  @ApiPropertyOptional({
+    type: [AidesSearchLabel],
+    description: "Interventions / modalités recherchées (label + score)",
+  })
+  @IsOptional()
+  @IsArray()
+  @ValidateNested({ each: true })
+  @Type(() => AidesSearchLabel)
+  interventions?: AidesSearchLabel[];
+
+  @ApiProperty({
+    type: [String],
+    description: "Codes INSEE des communes à couvrir (périmètre Aides-Territoires). Au moins une.",
+    example: ["44109"],
+  })
+  @IsArray()
+  @ArrayNotEmpty()
+  @IsString({ each: true })
+  communes!: string[];
+
+  @ApiPropertyOptional({ description: "Nombre max de résultats (défaut: 20)", example: 20 })
+  @IsOptional()
+  @IsNumber()
+  @Min(1)
+  limit?: number;
+
+  @ApiPropertyOptional({
+    description: "Active une recherche de pertinence textuelle complémentaire (nécessite `query`).",
+    example: false,
+  })
+  @IsOptional()
+  @IsBoolean()
+  textual?: boolean;
+
+  @ApiPropertyOptional({
+    description: "Texte libre support du matching textuel complémentaire (utilisé si `textual` est activé).",
+  })
+  @IsOptional()
+  @IsString()
+  query?: string;
+
+  @ApiPropertyOptional({
+    description: "Score de pertinence minimal (0-1) sous lequel une aide est écartée. Défaut : aucun seuil.",
+    example: 0,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  cutoff?: number;
+
+  @ApiPropertyOptional({
+    description: "Seuil de confiance (0-1) des labels d'une aide pris en compte. Défaut : 0.8.",
+    example: 0.8,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  aideThreshold?: number;
+
+  @ApiPropertyOptional({
+    description:
+      "Seuil de confiance (0-1) des labels recherchés pris en compte. Défaut bas conseillé pour le texte libre (ex. 0.3).",
+    example: 0.3,
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  projetThreshold?: number;
 }


### PR DESCRIPTION
## Contexte

Ajoute un endpoint **`POST /aides/recherche`** : une variante de `GET /aides` **sans projet de référence**. On fournit directement une classification (thématiques / sites / interventions — typiquement issue de `POST /qualification/classification` sur un texte libre) et un périmètre de **communes** (codes INSEE). Les aides du périmètre sont matchées contre cette classification et triées par pertinence.

Motivation : un dashboard de démonstration souhaite un onglet « Aides » où l'on décrit un besoin en texte libre + choisit des communes, sans partir d'un projet existant. `GET /aides` exige un `projetId` ; ce nouvel endpoint réutilise la même mécanique de matching et le **même périmètre/cache par code INSEE** que `GET /aides`.

## Changements

- **`AidesSearchRequest` / `AidesSearchLabel`** (DTO, validés `class-validator`) : labels + score, `communes: string[]` (INSEE), et les mêmes paramètres réglables que `GET /aides` (`limit`, `textual`, `query`, `cutoff`, `aideThreshold`, `projetThreshold`).
- Extraction du bloc *matching thématique + textuel + tri* en un helper privé partagé **`buildMatchedResponse()`** — utilisé par `GET /aides` **et** `POST /aides/recherche`. Le comportement de `GET /aides` est inchangé.
- `fetchAidesForTerritories(codesInsee)` généralisé en **`fetchAidesForPerimeterCodes(codes)`** (mêmes clés de cache `perimeter_codes[]`).
- **7 tests unitaires** sur le nouvel endpoint (ok / no_match / no_aides_on_perimeter / dédoublonnage des communes / passage des seuils / matching textuel opt-in).

## Statuts de réponse

Identiques à `GET /aides` : `ok` | `no_match` | `no_aides_on_perimeter`.

## Tests

`pnpm --filter @les-communs/api test:unit` (aides.controller.spec) → **38 passants**. `type-check` + `lint` + `format:check` verts (hook de pré-commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)