### PR TITLE
feat(dashboard-te): millésimes des projets dans /projets/summary

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -813,6 +813,22 @@ export class DashboardTeService {
       GROUP BY 1
     `);
 
+    // Répartition par millésime (année de début / fin). Les dates sont
+    // stockées en texte ISO (YYYY-..., parfois avec heure) et souvent absentes
+    // (≈22 % début, ≈12 % fin, nulles sur ACV/PVD) : on n'extrait l'année que
+    // des valeurs au format année valide ; le frontend déduit la couverture
+    // en comparant la somme des compteurs au total des projets filtrés.
+    const parAnnee = (col: SQL) =>
+      this.query<{ key: string; count: string }>(sql`
+        WITH a AS (${actions})
+        SELECT substring(${col} FROM 1 FOR 4) AS key, count(*)::text AS count
+        FROM a
+        WHERE ${col} IS NOT NULL AND substring(${col} FROM 1 FOR 4) ~ '^[12][0-9]{3}$'
+        GROUP BY 1 ORDER BY key
+      `);
+    const parAnneeDebut = await parAnnee(sql`a."dateDebut"`);
+    const parAnneeFin = await parAnnee(sql`a."dateFin"`);
+
     const toMap = (rows: { key: string; count: string }[]): Record<string, number> =>
       Object.fromEntries(rows.map((r) => [r.key, Number(r.count)]));
 
@@ -830,6 +846,10 @@ export class DashboardTeService {
       parCompetence: toMap(parCompetence),
       parLevier: toMap(parLevier),
       parTrancheProbaTe: { elevee: 0, moyenne: 0, faible: 0, nonRenseigne: 0, ...toMap(parTrancheProbaTe) },
+      // Millésimes (année → nombre de projets). Ne contient que les projets
+      // dont la date est renseignée et au format année valide.
+      parAnneeDebut: toMap(parAnneeDebut),
+      parAnneeFin: toMap(parAnneeFin),
     };
   }
 


### PR DESCRIPTION
## Contexte

Ajoute deux agrégats **`parAnneeDebut`** et **`parAnneeFin`** à `GET /dashboard-te/projets/summary` : la répartition *année → nombre de projets* des dates de début / fin, **sous les mêmes filtres** que `/projets`. Objectif : afficher les « millésimes » des projets filtrés dans la synthèse du dashboard.

## Détail

- Extraction de l'année depuis le texte ISO des colonnes `dateDebut` / `dateFin` : `substring(col FROM 1 FOR 4)` + garde `~ '^[12][0-9]{3}$'` (ignore les valeurs absentes ou malformées).
- Réutilise la CTE `actions` existante → respecte tous les filtres et l'option `inclure_tet` comme les autres répartitions.
- Forme identique aux autres agrégats : `Record<année, count>`.

## Couverture des données

Les dates projet sont **lacunaires** (~22 % pour début, ~12 % pour fin sur l'échantillon prod ; nulles sur ACV/PVD, ~70 % sur Fonds Vert). Seuls les projets datés sont comptés — le consommateur déduit la couverture en comparant la somme des compteurs à `count`. (Le front affiche ce taux explicitement.)

## Tests

`type-check` + `lint` + `format:check` verts (hook de pré-commit `pnpm -r validate`). Pas de spec sur `dashboard-te.service` ; agrégat additif, sans impact sur les champs existants.

🤖 Generated with [Claude Code](https://claude.com/claude-code)