### PR TITLE
feat(dashboard-te): exclure les projets DGCL par défaut (param inclure_dgcl)

### DIFF
--- a/api/src/dashboard-te/dashboard-te.controller.ts
+++ b/api/src/dashboard-te/dashboard-te.controller.ts
@@ -75,6 +75,7 @@ const parseProjetsFilter = (raw: RawQuery) => {
     probaTeMin: Number.isFinite(probaTeMinNum) ? probaTeMinNum : undefined,
     probaTeMax: Number.isFinite(probaTeMaxNum) ? probaTeMaxNum : undefined,
     q: first(raw.q),
+    inclureDgcl: first(raw.inclure_dgcl) === "true",
   };
 };
 

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -63,6 +63,9 @@ export interface ProjetsFilter {
   probaTeMin?: number;
   probaTeMax?: number;
   q?: string;
+  // false (défaut) : exclut les projets DGCL (source_origine LIKE 'DGCL%'),
+  // non synchronisés / non qualifiés / non dédoublonnés. true : les inclut.
+  inclureDgcl?: boolean;
 }
 
 @Injectable()
@@ -462,6 +465,11 @@ export class DashboardTeService {
     };
 
     const conditions: SQL[] = [];
+    // Les projets DGCL (data.gouv) sont exclus par défaut : non synchronisés,
+    // non qualifiés, non dédoublonnés. inclure_dgcl=true les réintègre.
+    if (!f.inclureDgcl) {
+      conditions.push(sql`(p.source_origine IS NULL OR p.source_origine NOT LIKE 'DGCL%')`);
+    }
     if (f.commune) conditions.push(sql`lpc.insee_com = ${f.commune}`);
     if (f.departement) conditions.push(sql`ar.code_departement = ${f.departement}`);
     if (f.siren) conditions.push(sql`p."collectiviteResponsableSiren" = ${f.siren}`);


### PR DESCRIPTION
## Contexte

Le stock DGCL (dotations data.gouv : DETR/DSIL/DPV…, `source_origine LIKE 'DGCL%'`) a été ingéré dans `schema_commun_v2.projets_operationnels`. Ces projets ne sont **ni synchronisés, ni qualifiés (LLM), ni dédoublonnés**. Ils ne doivent donc pas polluer la vue par défaut du dashboard.

## Changement

Nouveau paramètre **`inclure_dgcl`** (défaut `false`) sur `GET /dashboard-te/projets` et `/projets/summary` :
- par défaut, les projets DGCL sont **exclus** ;
- `inclure_dgcl=true` les réintègre (toggle opt-in côté dashboard, sur le modèle de `inclure_tet`).

Le filtre est appliqué dans `buildProjetsFilter` (partagé liste + résumé). Le **détail d'un projet** et les **stats nationales** ne sont pas impactés (DGCL y restent visibles).

## Détails

- `ProjetsFilter.inclureDgcl` + parsing `inclure_dgcl` dans le contrôleur.
- Condition `(p.source_origine IS NULL OR p.source_origine NOT LIKE 'DGCL%')` quand `inclure_dgcl` est absent/false.
- Pas de migration de schéma.
- `pnpm validate` (type-check + lint + format) OK.

Vérif base (read-only) : 155 884 projets par défaut / 342 840 avec `inclure_dgcl=true`.

S'accompagne d'un toggle « Inclure les projets DGCL (DSIL, DETR…) » côté dashboard (déployé séparément une fois cette PR en prod).

🤖 Generated with [Claude Code](https://claude.com/claude-code)