### PR TITLE
feat(dashboard-te): communes (INSEE) du projet dans le détail /projets/:id

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -890,6 +890,17 @@ export class DashboardTeService {
         p.llm_interventions->0->>'label' AS "llmIntervention",
         p.llm_thematiques->0->>'label' AS "llmThematique",
         p.llm_probabilite_te AS "llmProbabiliteTe",
+        -- Communes (INSEE) du projet : union des liens explicites et du champ
+        -- territoireCommunes (CSV). Sert au moteur d'aides par lieu+labels
+        -- (POST /aides/recherche) pour les projets hors registre natif.
+        (
+          SELECT array_agg(DISTINCT cc) FROM (
+            SELECT unnest(
+              COALESCE((SELECT array_agg(l.insee_com) FROM schema_commun_v2.liens_projets_communes l WHERE l.projet_id = p.id), ARRAY[]::text[])
+              || COALESCE(string_to_array(NULLIF(p."territoireCommunes", ''), ','), ARRAY[]::text[])
+            ) AS cc
+          ) s WHERE cc <> ''
+        ) AS "communesInsee",
         cm.cluster_id AS "clusterId",
         c.confiance AS "clusterConfiance"
       FROM schema_commun_v2.projets_operationnels p


### PR DESCRIPTION
## Pourquoi
Le bouton « Voir les aides » du dashboard ne fonctionne aujourd'hui que pour les projets du **registre natif** (matching par `projetId` via `GET /aides`). Pour les autres (DGCL, etc.), on veut basculer sur la recherche d'aides par **lieu + labels** (`POST /aides/recherche`), qui a besoin des **communes** du projet — non exposées par le détail projet.

## Quoi
`GET /dashboard-te/projets/:id` renvoie désormais le champ **`communesInsee`** (codes INSEE) : union des liens explicites (`schema_commun_v2.liens_projets_communes`) et du champ `territoireCommunes` (CSV), dédupliqués.

## Impact
- Additif, rétrocompatible (nouveau champ optionnel ; aucun champ existant modifié).
- Aucune nouvelle requête : sous-requête intégrée au SELECT du détail.
- Débloque côté front l'extension du moteur d'aides à tous les projets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)