### PR TITLE
feat(dashboard-te): filtre EPCI sur la recherche et les stats

### DIFF
--- a/api/src/dashboard-te/dashboard-te.controller.ts
+++ b/api/src/dashboard-te/dashboard-te.controller.ts
@@ -60,6 +60,7 @@ const parseProjetsFilter = (raw: RawQuery) => {
     commune: first(raw.commune),
     departement: first(raw.departement),
     siren: first(raw.siren),
+    epci: first(raw.epci),
     levier: toList(raw.levier),
     competence: toList(raw.competence),
     match: first(raw.match) === "all" ? ("all" as const) : ("any" as const),

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -48,6 +48,9 @@ export interface ProjetsFilter {
   commune?: string;
   departement?: string;
   siren?: string;
+  // EPCI (SIREN de groupement) : développé en ses communes membres via
+  // api_referentiel.perimetres pour agréger tous les projets du territoire.
+  epci?: string;
   levier?: string[];
   competence?: string[];
   match?: "all" | "any";
@@ -473,6 +476,11 @@ export class DashboardTeService {
     if (f.commune) conditions.push(sql`lpc.insee_com = ${f.commune}`);
     if (f.departement) conditions.push(sql`ar.code_departement = ${f.departement}`);
     if (f.siren) conditions.push(sql`p."collectiviteResponsableSiren" = ${f.siren}`);
+    // EPCI : projets rattachés à une commune membre du groupement.
+    if (f.epci)
+      conditions.push(
+        sql`lpc.insee_com IN (SELECT code_insee_commune FROM api_referentiel.perimetres WHERE siren_groupement = ${f.epci})`,
+      );
     if (f.source) conditions.push(sql`p.source_origine = ${f.source}`);
     if (f.phase) conditions.push(sql`p.phase = ${f.phase}`);
     if (pattern) conditions.push(sql`p.nom ILIKE ${pattern}`);
@@ -530,7 +538,7 @@ export class DashboardTeService {
       conditions.push(sql`p.llm_probabilite_te <= ${f.probaTeMax}`);
     }
 
-    const needsCommuneJoin = Boolean(f.commune ?? f.departement);
+    const needsCommuneJoin = Boolean(f.commune ?? f.departement ?? f.epci);
 
     let whereClause = sql``;
     if (conditions.length > 0) {
@@ -575,6 +583,11 @@ export class DashboardTeService {
       )`);
     }
     if (f.siren) conditions.push(sql`f.collectivite_responsable_siren = ${f.siren}`);
+    // EPCI : fiche dont le territoire chevauche les communes membres du groupement.
+    if (f.epci)
+      conditions.push(
+        sql`f.territoire_communes && (SELECT array_agg(code_insee_commune) FROM api_referentiel.perimetres WHERE siren_groupement = ${f.epci})`,
+      );
     if (f.phase) conditions.push(sql`f.source_metadata->>'phase' = ${f.phase}`);
     if (pattern) conditions.push(sql`f.nom ILIKE ${pattern}`);
 


### PR DESCRIPTION
## Pourquoi
Le dashboard filtre les projets par commune (unique), département ou SIREN responsable (exact), mais **pas par intercommunalité**. La donnée existe pourtant (`api_referentiel.perimetres` : `siren_groupement` ↔ `code_insee_commune`). On veut une vue **par EPCI** qui agrège les communes membres (recherche + stats).

## Quoi
Nouveau filtre **`epci`** (SIREN de groupement) dans `ProjetsFilter`, parsé depuis la query (`parseProjetsFilter`) et appliqué dans :
- `buildProjetsFilter` : `lpc.insee_com IN (SELECT code_insee_commune FROM api_referentiel.perimetres WHERE siren_groupement = :epci)` (+ activation du join communes) ;
- `buildFichesFilter` (fiches TeT du summary) : `territoire_communes && (communes du groupement)`.

Se propage automatiquement à **`GET /projets`** et **`GET /projets/summary`** → liste + stats agrégées par EPCI.

## Vérifié
Comptes cohérents avec le périmètre (ex. `epci=244400404` → 906 projets pour Nantes Métropole, `epci=200033579` → 399 pour la CU d'Arras). Additif, rétrocompatible (nouveau param optionnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)