### PR TITLE
feat(dashboard-te): classification scorée sur le détail projet

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -903,6 +903,13 @@ export class DashboardTeService {
         p.llm_interventions->0->>'label' AS "llmIntervention",
         p.llm_thematiques->0->>'label' AS "llmThematique",
         p.llm_probabilite_te AS "llmProbabiliteTe",
+        -- Classification SCORÉE ({label, score} par axe) pour le matching d'aides
+        -- par lieu+labels (qualité du tri) — même forme que la fiche TeT.
+        jsonb_build_object(
+          'thematiques', COALESCE(p.llm_thematiques, '[]'::jsonb),
+          'sites', COALESCE(p.llm_sites, '[]'::jsonb),
+          'interventions', COALESCE(p.llm_interventions, '[]'::jsonb)
+        ) AS "classificationScores",
         -- Communes (INSEE) du projet : union des liens explicites et du champ
         -- territoireCommunes (CSV). Sert au moteur d'aides par lieu+labels
         -- (POST /aides/recherche) pour les projets hors registre natif.


### PR DESCRIPTION
## Pourquoi
Le moteur d'aides par lieu+labels (`POST /aides/recherche`) pondère par le **score** de chaque label du projet. Le détail projet (`GET /projets/:id`) ne renvoyait que les **labels** (sans score), obligeant le front à fabriquer un score uniforme (0,9) → pertinence du tri dégradée. (Les fiches TeT renvoient déjà `classification_scores`.)

## Quoi
`GET /projets/:id` renvoie désormais `classificationScores` ({label, score} par axe, depuis `llm_thematiques/sites/interventions`), même forme que pour les fiches TeT et le registre natif.

## Note
Complément de #491 (un commit identique avait été poussé trop tard sur la branche de #491, après son merge — d'où cette PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)