### PR TITLE
fix(dashboard-te): 500 sur filtre EPCI + fiches TeT

### DIFF
--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -583,10 +583,11 @@ export class DashboardTeService {
       )`);
     }
     if (f.siren) conditions.push(sql`f.collectivite_responsable_siren = ${f.siren}`);
-    // EPCI : fiche dont le territoire chevauche les communes membres du groupement.
+    // EPCI : fiche dont le territoire inclut une commune membre du groupement.
+    // (EXISTS + ANY plutôt que && : évite le conflit de type text[] && varchar[].)
     if (f.epci)
       conditions.push(
-        sql`f.territoire_communes && (SELECT array_agg(code_insee_commune) FROM api_referentiel.perimetres WHERE siren_groupement = ${f.epci})`,
+        sql`EXISTS (SELECT 1 FROM api_referentiel.perimetres pp WHERE pp.siren_groupement = ${f.epci} AND pp.code_insee_commune = ANY(f.territoire_communes))`,
       );
     if (f.phase) conditions.push(sql`f.source_metadata->>'phase' = ${f.phase}`);
     if (pattern) conditions.push(sql`f.nom ILIKE ${pattern}`);


### PR DESCRIPTION
## Bug
Filtrer par EPCI **et** inclure les fiches TeT (`inclure_tet=true` / source=TeT) renvoie **500** :
`operator does not exist: text[] && character varying[]`. La condition EPCI ajoutée à `buildFichesFilter` (#492) comparait `territoire_communes` (text[]) avec `array_agg(code_insee_commune)` (varchar[]) via `&&`.

## Correctif
Remplacement par `EXISTS (… WHERE code_insee_commune = ANY(f.territoire_communes))` — même schéma que le filtre `departement` existant, sans conflit de type. Vérifié en base (count=43 pour la CU d'Arras).

## Impact
Débloque la recherche/stats par EPCI quand les fiches TeT sont incluses (sans ce fix, list **et** summary 500 → le front conservait les stats nationales précédentes, d'où le "155 884").

🤖 Generated with [Claude Code](https://claude.com/claude-code)