### PR TITLE
feat: endpoints territoires + décisions humaines (vue territoriale DDT via MEC)

### DIFF
--- a/api/drizzle.config.ts
+++ b/api/drizzle.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "./src/database/plans-fiches-schema.ts",
     "./src/database/tet-schema.ts",
     "./src/database/mec-schema.ts",
+    "./src/database/decisions-schema.ts",
   ],
   out: "./drizzle",
   dialect: "postgresql",

--- a/api/drizzle/0040_decisions_humaines.sql
+++ b/api/drizzle/0040_decisions_humaines.sql
@@ -3,7 +3,9 @@
 -- les décisions survivent aux re-runs de l'ETL.
 --
 -- Invariants applicatifs (non contraints en base) :
---   - append-only : jamais d'UPDATE/DELETE ; une révocation = nouvel événement + superseded_by
+--   - append-only : jamais d'UPDATE/DELETE ; une révocation = NOUVEL événement dont
+--     la colonne `supersedes` pointe vers l'événement révoqué (le pointeur est sur la
+--     nouvelle ligne → aucune ligne existante n'est mutée)
 --   - objet_*_id = IDs objets STABLES (UUID sources, cop_*…), JAMAIS un cluster_id
 CREATE SCHEMA IF NOT EXISTS "decisions_humaines";
 
@@ -20,7 +22,7 @@ CREATE TABLE "decisions_humaines"."decisions" (
   "plateforme_source" text NOT NULL,
   "commentaire" text,
   "payload" jsonb,
-  "superseded_by" uuid REFERENCES "decisions_humaines"."decisions"("id")
+  "supersedes" uuid REFERENCES "decisions_humaines"."decisions"("id")
 );
 
 CREATE INDEX "decisions_objet_a_idx" ON "decisions_humaines"."decisions" ("objet_a_id");

--- a/api/drizzle/0040_decisions_humaines.sql
+++ b/api/drizzle/0040_decisions_humaines.sql
@@ -1,0 +1,38 @@
+-- Schéma decisions_humaines : journal append-only des décisions humaines (MEC, TeT, DDT, interne)
+-- sur les objets du schéma commun. Vit HORS du cycle blue-green de rebuild de schema_commun_v2 :
+-- les décisions survivent aux re-runs de l'ETL.
+--
+-- Invariants applicatifs (non contraints en base) :
+--   - append-only : jamais d'UPDATE/DELETE ; une révocation = nouvel événement + superseded_by
+--   - objet_*_id = IDs objets STABLES (UUID sources, cop_*…), JAMAIS un cluster_id
+CREATE SCHEMA IF NOT EXISTS "decisions_humaines";
+
+CREATE TABLE "decisions_humaines"."decisions" (
+  "id" uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  "created_at" timestamp with time zone DEFAULT now() NOT NULL,
+  "type_decision" text NOT NULL,
+  "objet_a_type" text NOT NULL,
+  "objet_a_id" text NOT NULL,
+  "objet_b_type" text,
+  "objet_b_id" text,
+  "verdict" text,
+  "auteur" text,
+  "plateforme_source" text NOT NULL,
+  "commentaire" text,
+  "payload" jsonb,
+  "superseded_by" uuid REFERENCES "decisions_humaines"."decisions"("id")
+);
+
+CREATE INDEX "decisions_objet_a_idx" ON "decisions_humaines"."decisions" ("objet_a_id");
+CREATE INDEX "decisions_objet_b_idx" ON "decisions_humaines"."decisions" ("objet_b_id");
+CREATE INDEX "decisions_type_created_idx" ON "decisions_humaines"."decisions" ("type_decision", "created_at");
+
+-- Lecture pour le user readonly de prod (absent des bases locales/e2e → garde conditionnelle)
+DO $$
+BEGIN
+  IF EXISTS (SELECT FROM pg_roles WHERE rolname = 'readonlyuser') THEN
+    GRANT USAGE ON SCHEMA "decisions_humaines" TO readonlyuser;
+    GRANT SELECT ON ALL TABLES IN SCHEMA "decisions_humaines" TO readonlyuser;
+    ALTER DEFAULT PRIVILEGES IN SCHEMA "decisions_humaines" GRANT SELECT ON TABLES TO readonlyuser;
+  END IF;
+END $$;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1777689700000,
       "tag": "0039_aide_feedbacks",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1783419912637,
+      "tag": "0040_decisions_humaines",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -30,6 +30,8 @@ import { ProjetsV2Module } from "@/projets-v2/projets-v2.module";
 import { BatchClassificationModule } from "@/batch-classification/batch-classification.module";
 import { DashboardTeModule } from "@/dashboard-te/dashboard-te.module";
 import { MecModule } from "@/mec/mec.module";
+import { DecisionsModule } from "@/decisions/decisions.module";
+import { TerritoiresModule } from "@/territoires/territoires.module";
 
 @Module({
   imports: [
@@ -84,6 +86,8 @@ import { MecModule } from "@/mec/mec.module";
     BatchClassificationModule,
     DashboardTeModule,
     MecModule,
+    DecisionsModule,
+    TerritoiresModule,
   ],
   controllers: [HealthController],
   providers: [AppService, ThrottlerGuardProvider, RequestLoggingInterceptor],

--- a/api/src/dashboard-te/dashboard-te.service.ts
+++ b/api/src/dashboard-te/dashboard-te.service.ts
@@ -466,7 +466,10 @@ export class DashboardTeService {
     const hasDept = !!(f.departement && f.departement.length > 0);
     const hasSource = !!(f.source && f.source.length > 0);
     const textArray = (vals: string[]): SQL =>
-      sql`ARRAY[${sql.join(vals.map((v) => sql`${v}`), sql`, `)}]::text[]`;
+      sql`ARRAY[${sql.join(
+        vals.map((v) => sql`${v}`),
+        sql`, `,
+      )}]::text[]`;
 
     // Builds `(label=X1 AND score>=S1) OR (label=X2 AND score>=S2) ...`
     // where Sn falls back to the request-level scoreMin if not set per-entry.
@@ -589,8 +592,7 @@ export class DashboardTeService {
     // comptées (les sous-actions gonfleraient les totaux).
     const conditions: SQL[] = [sql`f.parent_id IS NULL`];
     // Recouvrement de tableaux : au moins une commune de la sélection ∈ territoire de la fiche.
-    if (f.commune && f.commune.length > 0)
-      conditions.push(sql`f.territoire_communes && ${pgArray(f.commune)}`);
+    if (f.commune && f.commune.length > 0) conditions.push(sql`f.territoire_communes && ${pgArray(f.commune)}`);
     if (f.departement && f.departement.length > 0) {
       conditions.push(sql`EXISTS (
         SELECT 1 FROM api_referentiel.communes ar

--- a/api/src/database/decisions-schema.ts
+++ b/api/src/database/decisions-schema.ts
@@ -1,0 +1,49 @@
+import { index, jsonb, pgSchema, text, timestamp, uuid, type AnyPgColumn } from "drizzle-orm/pg-core";
+
+// ============================================================
+// Schema: decisions_humaines — Persistent human decisions
+// ============================================================
+//
+// Append-only event log of human decisions (MEC, TeT, DDT agents, internal)
+// about objects of schema_commun_v2 (projects, fiches, plans, financements).
+//
+// CRITICAL INVARIANTS:
+// - This schema lives OUTSIDE the schema_commun_v2 blue-green rebuild cycle:
+//   decisions MUST survive every ETL re-run.
+// - Append-only at the application level: never UPDATE / DELETE. A revocation
+//   is a new event referencing the revoked one via superseded_by.
+// - objet_*_id always reference STABLE object IDs (source UUIDs, cop_* ids…),
+//   NEVER cluster ids (cluster ids are recomputed on every pipeline run).
+
+export const decisionsHumainesSchema = pgSchema("decisions_humaines");
+
+export const decisions = decisionsHumainesSchema.table(
+  "decisions",
+  {
+    id: uuid("id").primaryKey().defaultRandom(),
+    createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+    // lien_confirme | lien_infirme | doublon_signale | projet_valide | projet_obsolete | rattachement_pcaet | …
+    typeDecision: text("type_decision").notNull(),
+    // projet | fiche_action | plan | financement
+    objetAType: text("objet_a_type").notNull(),
+    objetAId: text("objet_a_id").notNull(),
+    // For binary decisions (links between two objects)
+    objetBType: text("objet_b_type"),
+    objetBId: text("objet_b_id"),
+    // confirme | infirme | fusionner | …
+    verdict: text("verdict"),
+    // Agent identifier if transmitted by the platform
+    auteur: text("auteur"),
+    // MEC | TET | interne — validated against the authenticated service
+    plateformeSource: text("plateforme_source").notNull(),
+    commentaire: text("commentaire"),
+    payload: jsonb("payload"),
+    // Revocation chain: a new event supersedes an older one (no UPDATE/DELETE)
+    supersededBy: uuid("superseded_by").references((): AnyPgColumn => decisions.id),
+  },
+  (t) => [
+    index("decisions_objet_a_idx").on(t.objetAId),
+    index("decisions_objet_b_idx").on(t.objetBId),
+    index("decisions_type_created_idx").on(t.typeDecision, t.createdAt),
+  ],
+);

--- a/api/src/database/decisions-schema.ts
+++ b/api/src/database/decisions-schema.ts
@@ -10,8 +10,9 @@ import { index, jsonb, pgSchema, text, timestamp, uuid, type AnyPgColumn } from 
 // CRITICAL INVARIANTS:
 // - This schema lives OUTSIDE the schema_commun_v2 blue-green rebuild cycle:
 //   decisions MUST survive every ETL re-run.
-// - Append-only at the application level: never UPDATE / DELETE. A revocation
-//   is a new event referencing the revoked one via superseded_by.
+// - Append-only at the application level: never UPDATE / DELETE. A revocation is
+//   a NEW event that points, via `supersedes`, to the older event it revokes.
+//   (The pointer is on the new row, so no existing row is ever mutated.)
 // - objet_*_id always reference STABLE object IDs (source UUIDs, cop_* ids…),
 //   NEVER cluster ids (cluster ids are recomputed on every pipeline run).
 
@@ -38,8 +39,9 @@ export const decisions = decisionsHumainesSchema.table(
     plateformeSource: text("plateforme_source").notNull(),
     commentaire: text("commentaire"),
     payload: jsonb("payload"),
-    // Revocation chain: a new event supersedes an older one (no UPDATE/DELETE)
-    supersededBy: uuid("superseded_by").references((): AnyPgColumn => decisions.id),
+    // Revocation chain: THIS (new) event supersedes an older one it points to.
+    // The pointer lives on the new row → append-only preserved (no UPDATE/DELETE).
+    supersedes: uuid("supersedes").references((): AnyPgColumn => decisions.id),
   },
   (t) => [
     index("decisions_objet_a_idx").on(t.objetAId),

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -271,3 +271,4 @@ export * from "./referentiel-schema";
 export * from "./plans-fiches-schema";
 export * from "./tet-schema";
 export * from "./mec-schema";
+export * from "./decisions-schema";

--- a/api/src/decisions/decisions.controller.spec.ts
+++ b/api/src/decisions/decisions.controller.spec.ts
@@ -1,0 +1,43 @@
+import { BadRequestException } from "@nestjs/common";
+import { Request } from "express";
+import { DecisionsController } from "./decisions.controller";
+import { DecisionsService } from "./decisions.service";
+import { CreateDecisionDto } from "./dto/create-decision.dto";
+
+describe("DecisionsController", () => {
+  let controller: DecisionsController;
+  let service: { create: jest.Mock; findByObjet: jest.Mock };
+
+  const mockRequest = (serviceType: string) => ({ serviceType }) as unknown as Request;
+
+  beforeEach(() => {
+    service = { create: jest.fn(), findByObjet: jest.fn() };
+    controller = new DecisionsController(service as unknown as DecisionsService);
+  });
+
+  describe("create", () => {
+    it("dérive plateformeSource de request.serviceType (jamais du body)", async () => {
+      service.create.mockResolvedValue({ id: "dec-1", createdAt: "2026-07-07T10:00:00.000Z" });
+      const dto = { typeDecision: "lien_confirme", objetAType: "projet", objetAId: "p1" } as CreateDecisionDto;
+
+      await controller.create(mockRequest("MEC"), dto);
+
+      expect(service.create).toHaveBeenCalledWith(dto, "MEC");
+    });
+  });
+
+  describe("findByObjet", () => {
+    it("transmet la plateforme appelante au service (cloisonnement)", async () => {
+      service.findByObjet.mockResolvedValue({ items: [] });
+
+      await controller.findByObjet(mockRequest("TeT"), "p1");
+
+      expect(service.findByObjet).toHaveBeenCalledWith("p1", "TeT");
+    });
+
+    it("400 si objetId manquant", () => {
+      expect(() => controller.findByObjet(mockRequest("MEC"), undefined)).toThrow(BadRequestException);
+      expect(service.findByObjet).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/api/src/decisions/decisions.controller.ts
+++ b/api/src/decisions/decisions.controller.ts
@@ -36,7 +36,9 @@ export class DecisionsController {
   @Get()
   @ApiOperation({
     summary: "Lister les décisions portant sur un objet",
-    description: "Retourne les décisions référençant l'objet (en A ou en B), triées anté-chronologiquement (max 100).",
+    description:
+      "Retourne les décisions référençant l'objet (en A ou en B), triées anté-chronologiquement (max 100). " +
+      "Cloisonnement : chaque plateforme ne voit QUE ses propres décisions (celles émises avec sa clé API).",
   })
   @ApiQuery({ name: "objetId", required: true, description: "ID stable de l'objet à inspecter." })
   @ApiEndpointResponses({
@@ -44,10 +46,10 @@ export class DecisionsController {
     response: DecisionListResponse,
     description: "Décisions portant sur l'objet",
   })
-  findByObjet(@Query("objetId") objetId?: string) {
+  findByObjet(@Req() request: Request, @Query("objetId") objetId?: string) {
     if (!objetId) {
       throw new BadRequestException("objetId requis");
     }
-    return this.decisionsService.findByObjet(objetId);
+    return this.decisionsService.findByObjet(objetId, request.serviceType!);
   }
 }

--- a/api/src/decisions/decisions.controller.ts
+++ b/api/src/decisions/decisions.controller.ts
@@ -1,0 +1,53 @@
+import { BadRequestException, Body, Controller, Get, Post, Query, Req, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
+import { ApiKeyGuard } from "@/auth/api-key-guard";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
+import { DecisionsService } from "./decisions.service";
+import { CreateDecisionDto, DecisionCreatedResponse, DecisionListResponse } from "./dto/create-decision.dto";
+
+@ApiBearerAuth()
+@ApiTags("Décisions")
+@Controller("decisions")
+@UseGuards(ApiKeyGuard)
+export class DecisionsController {
+  constructor(private readonly decisionsService: DecisionsService) {}
+
+  @TrackApiUsage()
+  @Post()
+  @ApiOperation({
+    summary: "Enregistrer une décision humaine",
+    description:
+      "Journal append-only : aucune mise à jour ni suppression. La plateforme émettrice " +
+      "(plateformeSource) est dérivée de la clé API authentifiée, pas du corps de requête. " +
+      "Les objets référencés doivent utiliser leurs IDs stables, jamais un cluster_id.",
+  })
+  @ApiEndpointResponses({
+    successStatus: 201,
+    response: DecisionCreatedResponse,
+    description: "Décision enregistrée",
+  })
+  create(@Req() request: Request, @Body() dto: CreateDecisionDto): Promise<DecisionCreatedResponse> {
+    return this.decisionsService.create(dto, request.serviceType!);
+  }
+
+  @TrackApiUsage()
+  @Get()
+  @ApiOperation({
+    summary: "Lister les décisions portant sur un objet",
+    description: "Retourne les décisions référençant l'objet (en A ou en B), triées anté-chronologiquement (max 100).",
+  })
+  @ApiQuery({ name: "objetId", required: true, description: "ID stable de l'objet à inspecter." })
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: DecisionListResponse,
+    description: "Décisions portant sur l'objet",
+  })
+  findByObjet(@Query("objetId") objetId?: string) {
+    if (!objetId) {
+      throw new BadRequestException("objetId requis");
+    }
+    return this.decisionsService.findByObjet(objetId);
+  }
+}

--- a/api/src/decisions/decisions.module.ts
+++ b/api/src/decisions/decisions.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { DatabaseModule } from "@database/database.module";
+import { DecisionsController } from "./decisions.controller";
+import { DecisionsService } from "./decisions.service";
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [DecisionsController],
+  providers: [DecisionsService],
+})
+export class DecisionsModule {}

--- a/api/src/decisions/decisions.service.spec.ts
+++ b/api/src/decisions/decisions.service.spec.ts
@@ -5,6 +5,7 @@ import { CreateDecisionDto } from "./dto/create-decision.dto";
 describe("DecisionsService", () => {
   let service: DecisionsService;
   let insertedValues: Record<string, unknown> | undefined;
+  let whereArg: unknown;
 
   const createdAt = new Date("2026-07-07T10:00:00.000Z");
 
@@ -19,7 +20,10 @@ describe("DecisionsService", () => {
 
     const limit = jest.fn().mockResolvedValue(opts.selectRows ?? []);
     const orderBy = jest.fn().mockReturnValue({ limit });
-    const where = jest.fn().mockReturnValue({ orderBy });
+    const where = jest.fn().mockImplementation((w: unknown) => {
+      whereArg = w;
+      return { orderBy };
+    });
     const from = jest.fn().mockReturnValue({ where });
     const select = jest.fn().mockReturnValue({ from });
 
@@ -33,6 +37,7 @@ describe("DecisionsService", () => {
 
   beforeEach(() => {
     insertedValues = undefined;
+    whereArg = undefined;
   });
 
   describe("create", () => {
@@ -62,7 +67,15 @@ describe("DecisionsService", () => {
       });
     });
 
-    it("normalise les champs optionnels absents en null", async () => {
+    it("persiste supersedes quand fourni (chaîne de révocation)", async () => {
+      service = buildService({ returning: [{ id: "dec-3", createdAt }] });
+
+      await service.create({ ...dto, supersedes: "dec-1" }, "MEC");
+
+      expect(insertedValues).toMatchObject({ supersedes: "dec-1" });
+    });
+
+    it("normalise les champs optionnels absents en null (dont supersedes)", async () => {
       service = buildService({ returning: [{ id: "dec-2", createdAt }] });
 
       await service.create({ typeDecision: "projet_valide", objetAType: "projet", objetAId: "proj-a" }, "TeT");
@@ -74,19 +87,22 @@ describe("DecisionsService", () => {
         auteur: null,
         commentaire: null,
         payload: null,
+        supersedes: null,
         plateformeSource: "TeT",
       });
     });
   });
 
   describe("findByObjet", () => {
-    it("renvoie les décisions trouvées sous forme { items }", async () => {
+    it("renvoie les décisions trouvées sous forme { items } et applique un filtre WHERE (cloisonnement)", async () => {
       const rows = [{ id: "dec-1" }, { id: "dec-2" }];
       service = buildService({ selectRows: rows });
 
-      const result = await service.findByObjet("proj-a");
+      const result = await service.findByObjet("proj-a", "MEC");
 
       expect(result).toEqual({ items: rows });
+      // Le cloisonnement par plateforme est appliqué dans la clause WHERE.
+      expect(whereArg).toBeDefined();
     });
   });
 });

--- a/api/src/decisions/decisions.service.spec.ts
+++ b/api/src/decisions/decisions.service.spec.ts
@@ -1,0 +1,92 @@
+import { DecisionsService } from "./decisions.service";
+import { DatabaseService } from "@database/database.service";
+import { CreateDecisionDto } from "./dto/create-decision.dto";
+
+describe("DecisionsService", () => {
+  let service: DecisionsService;
+  let insertedValues: Record<string, unknown> | undefined;
+
+  const createdAt = new Date("2026-07-07T10:00:00.000Z");
+
+  // Chaîne Drizzle : insert().values().returning() et select().from().where().orderBy().limit()
+  const makeDb = (opts: { returning?: unknown[]; selectRows?: unknown[] }) => {
+    const returning = jest.fn().mockResolvedValue(opts.returning ?? []);
+    const values = jest.fn().mockImplementation((v: Record<string, unknown>) => {
+      insertedValues = v;
+      return { returning };
+    });
+    const insert = jest.fn().mockReturnValue({ values });
+
+    const limit = jest.fn().mockResolvedValue(opts.selectRows ?? []);
+    const orderBy = jest.fn().mockReturnValue({ limit });
+    const where = jest.fn().mockReturnValue({ orderBy });
+    const from = jest.fn().mockReturnValue({ where });
+    const select = jest.fn().mockReturnValue({ from });
+
+    return { insert, select } as unknown as DatabaseService["database"];
+  };
+
+  const buildService = (opts: { returning?: unknown[]; selectRows?: unknown[] }) => {
+    const dbService = { database: makeDb(opts) } as unknown as DatabaseService;
+    return new DecisionsService(dbService);
+  };
+
+  beforeEach(() => {
+    insertedValues = undefined;
+  });
+
+  describe("create", () => {
+    const dto: CreateDecisionDto = {
+      typeDecision: "lien_confirme",
+      objetAType: "projet",
+      objetAId: "proj-a",
+      objetBType: "projet",
+      objetBId: "proj-b",
+      verdict: "confirme",
+    };
+
+    it("dérive plateformeSource de l'argument (jamais du DTO) et renvoie id + createdAt ISO", async () => {
+      service = buildService({ returning: [{ id: "dec-1", createdAt }] });
+
+      const result = await service.create(dto, "MEC");
+
+      expect(result).toEqual({ id: "dec-1", createdAt: "2026-07-07T10:00:00.000Z" });
+      expect(insertedValues).toMatchObject({
+        typeDecision: "lien_confirme",
+        objetAType: "projet",
+        objetAId: "proj-a",
+        objetBType: "projet",
+        objetBId: "proj-b",
+        verdict: "confirme",
+        plateformeSource: "MEC",
+      });
+    });
+
+    it("normalise les champs optionnels absents en null", async () => {
+      service = buildService({ returning: [{ id: "dec-2", createdAt }] });
+
+      await service.create({ typeDecision: "projet_valide", objetAType: "projet", objetAId: "proj-a" }, "TeT");
+
+      expect(insertedValues).toMatchObject({
+        objetBType: null,
+        objetBId: null,
+        verdict: null,
+        auteur: null,
+        commentaire: null,
+        payload: null,
+        plateformeSource: "TeT",
+      });
+    });
+  });
+
+  describe("findByObjet", () => {
+    it("renvoie les décisions trouvées sous forme { items }", async () => {
+      const rows = [{ id: "dec-1" }, { id: "dec-2" }];
+      service = buildService({ selectRows: rows });
+
+      const result = await service.findByObjet("proj-a");
+
+      expect(result).toEqual({ items: rows });
+    });
+  });
+});

--- a/api/src/decisions/decisions.service.ts
+++ b/api/src/decisions/decisions.service.ts
@@ -1,0 +1,53 @@
+import { Injectable } from "@nestjs/common";
+import { DatabaseService } from "@database/database.service";
+import { decisions } from "@database/schema";
+import { desc, eq, or } from "drizzle-orm";
+import { CreateDecisionDto, DecisionCreatedResponse } from "./dto/create-decision.dto";
+
+// Journal append-only des décisions humaines (schema decisions_humaines).
+// Aucune méthode UPDATE/DELETE : une révocation est un nouvel événement
+// référençant l'ancien via superseded_by (invariant applicatif).
+@Injectable()
+export class DecisionsService {
+  constructor(private readonly dbService: DatabaseService) {}
+
+  /**
+   * Enregistre une décision. `plateformeSource` est DÉRIVÉE du service authentifié
+   * (request.serviceType), jamais du corps de requête : un service ne peut pas se
+   * faire passer pour un autre.
+   */
+  async create(dto: CreateDecisionDto, plateformeSource: string): Promise<DecisionCreatedResponse> {
+    const [row] = await this.dbService.database
+      .insert(decisions)
+      .values({
+        typeDecision: dto.typeDecision,
+        objetAType: dto.objetAType,
+        objetAId: dto.objetAId,
+        objetBType: dto.objetBType ?? null,
+        objetBId: dto.objetBId ?? null,
+        verdict: dto.verdict ?? null,
+        auteur: dto.auteur ?? null,
+        plateformeSource,
+        commentaire: dto.commentaire ?? null,
+        payload: dto.payload ?? null,
+      })
+      .returning({ id: decisions.id, createdAt: decisions.createdAt });
+
+    return { id: row.id, createdAt: row.createdAt.toISOString() };
+  }
+
+  /**
+   * Décisions référençant un objet, en A ou en B. Tri anté-chronologique,
+   * bornée à 100 — vérification/audit d'un objet, pas de pagination.
+   */
+  async findByObjet(objetId: string) {
+    const rows = await this.dbService.database
+      .select()
+      .from(decisions)
+      .where(or(eq(decisions.objetAId, objetId), eq(decisions.objetBId, objetId)))
+      .orderBy(desc(decisions.createdAt))
+      .limit(100);
+
+    return { items: rows };
+  }
+}

--- a/api/src/decisions/decisions.service.ts
+++ b/api/src/decisions/decisions.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from "@nestjs/common";
 import { DatabaseService } from "@database/database.service";
 import { decisions } from "@database/schema";
-import { desc, eq, or } from "drizzle-orm";
+import { and, desc, eq, or } from "drizzle-orm";
 import { CreateDecisionDto, DecisionCreatedResponse } from "./dto/create-decision.dto";
 
 // Journal append-only des décisions humaines (schema decisions_humaines).
@@ -30,6 +30,7 @@ export class DecisionsService {
         plateformeSource,
         commentaire: dto.commentaire ?? null,
         payload: dto.payload ?? null,
+        supersedes: dto.supersedes ?? null,
       })
       .returning({ id: decisions.id, createdAt: decisions.createdAt });
 
@@ -39,12 +40,19 @@ export class DecisionsService {
   /**
    * Décisions référençant un objet, en A ou en B. Tri anté-chronologique,
    * bornée à 100 — vérification/audit d'un objet, pas de pagination.
+   * Cloisonnement : chaque plateforme ne lit QUE ses propres décisions
+   * (plateformeSource = service authentifié).
    */
-  async findByObjet(objetId: string) {
+  async findByObjet(objetId: string, plateformeSource: string) {
     const rows = await this.dbService.database
       .select()
       .from(decisions)
-      .where(or(eq(decisions.objetAId, objetId), eq(decisions.objetBId, objetId)))
+      .where(
+        and(
+          eq(decisions.plateformeSource, plateformeSource),
+          or(eq(decisions.objetAId, objetId), eq(decisions.objetBId, objetId)),
+        ),
+      )
       .orderBy(desc(decisions.createdAt))
       .limit(100);
 

--- a/api/src/decisions/dto/create-decision.dto.spec.ts
+++ b/api/src/decisions/dto/create-decision.dto.spec.ts
@@ -1,0 +1,53 @@
+import "reflect-metadata";
+import { plainToInstance } from "class-transformer";
+import { validateSync } from "class-validator";
+import { CreateDecisionDto, PAYLOAD_MAX_BYTES } from "./create-decision.dto";
+
+const validBase = {
+  typeDecision: "lien_confirme",
+  objetAType: "projet",
+  objetAId: "proj-a",
+};
+
+const validate = (payload: Record<string, unknown>) => {
+  const dto = plainToInstance(CreateDecisionDto, payload);
+  return validateSync(dto, { whitelist: true, forbidNonWhitelisted: true });
+};
+
+const errorsOn = (payload: Record<string, unknown>) => validate(payload).map((e) => e.property);
+
+describe("CreateDecisionDto validation", () => {
+  it("accepte un payload minimal valide", () => {
+    expect(validate(validBase)).toHaveLength(0);
+  });
+
+  it("rejette objetAType hors énumération", () => {
+    expect(errorsOn({ ...validBase, objetAType: "cluster" })).toContain("objetAType");
+  });
+
+  it("applique MaxLength(100) sur typeDecision", () => {
+    expect(errorsOn({ ...validBase, typeDecision: "x".repeat(101) })).toContain("typeDecision");
+  });
+
+  it("applique MaxLength(200) sur objetAId", () => {
+    expect(errorsOn({ ...validBase, objetAId: "x".repeat(201) })).toContain("objetAId");
+  });
+
+  it("applique MaxLength(2000) sur commentaire", () => {
+    expect(errorsOn({ ...validBase, commentaire: "x".repeat(2001) })).toContain("commentaire");
+  });
+
+  it("exige un UUID pour supersedes", () => {
+    expect(errorsOn({ ...validBase, supersedes: "pas-un-uuid" })).toContain("supersedes");
+    expect(errorsOn({ ...validBase, supersedes: "3f2504e0-4f89-41d3-9a0c-0305e82c3301" })).not.toContain("supersedes");
+  });
+
+  it("rejette un payload sérialisé au-delà de la limite d'octets", () => {
+    const big = { blob: "x".repeat(PAYLOAD_MAX_BYTES + 1) };
+    expect(errorsOn({ ...validBase, payload: big })).toContain("payload");
+  });
+
+  it("accepte un payload objet sous la limite", () => {
+    expect(errorsOn({ ...validBase, payload: { a: 1, b: "ok" } })).not.toContain("payload");
+  });
+});

--- a/api/src/decisions/dto/create-decision.dto.ts
+++ b/api/src/decisions/dto/create-decision.dto.ts
@@ -1,10 +1,48 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsIn, IsNotEmpty, IsObject, IsOptional, IsString } from "class-validator";
+import {
+  IsIn,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  MaxLength,
+  registerDecorator,
+  ValidationArguments,
+  ValidationOptions,
+} from "class-validator";
 
 // Types d'objets référençables. Les IDs pointés doivent TOUJOURS être des IDs
 // objets stables (UUID sources, ids cop_*, dgcl-*…), jamais un cluster_id.
 export const OBJET_TYPES = ["projet", "fiche_action", "plan", "financement"] as const;
 export type ObjetType = (typeof OBJET_TYPES)[number];
+
+// Taille maximale du payload jsonb (protège la base et les logs d'un abus).
+export const PAYLOAD_MAX_BYTES = 10_240;
+
+// Valide qu'une valeur sérialisée en JSON ne dépasse pas `maxBytes` octets (UTF-8).
+function MaxJsonBytes(maxBytes: number, validationOptions?: ValidationOptions) {
+  return function (object: object, propertyName: string) {
+    registerDecorator({
+      name: "maxJsonBytes",
+      target: object.constructor,
+      propertyName,
+      constraints: [maxBytes],
+      options: validationOptions,
+      validator: {
+        validate(value: unknown, args: ValidationArguments) {
+          if (value == null) return true;
+          const [limit] = args.constraints as [number];
+          return Buffer.byteLength(JSON.stringify(value), "utf8") <= limit;
+        },
+        defaultMessage(args: ValidationArguments) {
+          const [limit] = args.constraints as [number];
+          return `payload dépasse la taille maximale de ${limit} octets`;
+        },
+      },
+    });
+  };
+}
 
 export class CreateDecisionDto {
   @ApiProperty({
@@ -12,9 +50,11 @@ export class CreateDecisionDto {
       "Type de décision. Vocabulaire évolutif, non contraint par une enum stricte " +
       "(ex. lien_confirme, lien_infirme, doublon_signale, projet_valide, projet_obsolete, rattachement_pcaet).",
     example: "lien_confirme",
+    maxLength: 100,
   })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(100)
   typeDecision!: string;
 
   @ApiProperty({
@@ -28,9 +68,11 @@ export class CreateDecisionDto {
     description:
       "ID STABLE de l'objet A (UUID source, id cop_*, dgcl-*…). " +
       "JAMAIS un cluster_id : les identifiants de cluster sont recalculés à chaque run de l'ETL.",
+    maxLength: 200,
   })
   @IsString()
   @IsNotEmpty()
+  @MaxLength(200)
   objetAId!: string;
 
   @ApiPropertyOptional({
@@ -43,32 +85,47 @@ export class CreateDecisionDto {
 
   @ApiPropertyOptional({
     description: "ID STABLE de l'objet B (mêmes règles que objetAId — jamais un cluster_id).",
+    maxLength: 200,
   })
   @IsOptional()
   @IsString()
+  @MaxLength(200)
   objetBId?: string;
 
-  @ApiPropertyOptional({ description: "Verdict associé (ex. confirme, infirme, fusionner)." })
+  @ApiPropertyOptional({ description: "Verdict associé (ex. confirme, infirme, fusionner).", maxLength: 100 })
   @IsOptional()
   @IsString()
+  @MaxLength(100)
   verdict?: string;
 
-  @ApiPropertyOptional({ description: "Identifiant de l'agent auteur, si transmis par la plateforme." })
+  @ApiPropertyOptional({ description: "Identifiant de l'agent auteur, si transmis par la plateforme.", maxLength: 200 })
   @IsOptional()
   @IsString()
+  @MaxLength(200)
   auteur?: string;
 
-  @ApiPropertyOptional({ description: "Commentaire libre." })
+  @ApiPropertyOptional({ description: "Commentaire libre.", maxLength: 2000 })
   @IsOptional()
   @IsString()
+  @MaxLength(2000)
   commentaire?: string;
 
   @ApiPropertyOptional({
+    description:
+      "ID de la décision que celle-ci révoque (chaîne de révocation append-only : " +
+      "le nouvel événement pointe vers l'ancien, aucune ligne n'est mutée).",
+  })
+  @IsOptional()
+  @IsUUID()
+  supersedes?: string;
+
+  @ApiPropertyOptional({
     type: Object,
-    description: "Charge utile structurée additionnelle propre à la décision.",
+    description: `Charge utile structurée additionnelle propre à la décision (max ${PAYLOAD_MAX_BYTES} octets sérialisés).`,
   })
   @IsOptional()
   @IsObject()
+  @MaxJsonBytes(PAYLOAD_MAX_BYTES)
   payload?: Record<string, unknown>;
 }
 
@@ -117,8 +174,8 @@ export class DecisionRecordResponse {
   @ApiPropertyOptional({ type: Object, nullable: true })
   payload!: Record<string, unknown> | null;
 
-  @ApiPropertyOptional({ nullable: true, description: "ID de la décision qui révoque celle-ci, le cas échéant." })
-  supersededBy!: string | null;
+  @ApiPropertyOptional({ nullable: true, description: "ID de la décision que celle-ci révoque, le cas échéant." })
+  supersedes!: string | null;
 }
 
 export class DecisionListResponse {

--- a/api/src/decisions/dto/create-decision.dto.ts
+++ b/api/src/decisions/dto/create-decision.dto.ts
@@ -1,0 +1,127 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsIn, IsNotEmpty, IsObject, IsOptional, IsString } from "class-validator";
+
+// Types d'objets référençables. Les IDs pointés doivent TOUJOURS être des IDs
+// objets stables (UUID sources, ids cop_*, dgcl-*…), jamais un cluster_id.
+export const OBJET_TYPES = ["projet", "fiche_action", "plan", "financement"] as const;
+export type ObjetType = (typeof OBJET_TYPES)[number];
+
+export class CreateDecisionDto {
+  @ApiProperty({
+    description:
+      "Type de décision. Vocabulaire évolutif, non contraint par une enum stricte " +
+      "(ex. lien_confirme, lien_infirme, doublon_signale, projet_valide, projet_obsolete, rattachement_pcaet).",
+    example: "lien_confirme",
+  })
+  @IsString()
+  @IsNotEmpty()
+  typeDecision!: string;
+
+  @ApiProperty({
+    description: "Type de l'objet A concerné par la décision.",
+    enum: OBJET_TYPES,
+  })
+  @IsIn(OBJET_TYPES)
+  objetAType!: ObjetType;
+
+  @ApiProperty({
+    description:
+      "ID STABLE de l'objet A (UUID source, id cop_*, dgcl-*…). " +
+      "JAMAIS un cluster_id : les identifiants de cluster sont recalculés à chaque run de l'ETL.",
+  })
+  @IsString()
+  @IsNotEmpty()
+  objetAId!: string;
+
+  @ApiPropertyOptional({
+    description: "Type de l'objet B (décisions binaires, ex. lien entre deux objets).",
+    enum: OBJET_TYPES,
+  })
+  @IsOptional()
+  @IsIn(OBJET_TYPES)
+  objetBType?: ObjetType;
+
+  @ApiPropertyOptional({
+    description: "ID STABLE de l'objet B (mêmes règles que objetAId — jamais un cluster_id).",
+  })
+  @IsOptional()
+  @IsString()
+  objetBId?: string;
+
+  @ApiPropertyOptional({ description: "Verdict associé (ex. confirme, infirme, fusionner)." })
+  @IsOptional()
+  @IsString()
+  verdict?: string;
+
+  @ApiPropertyOptional({ description: "Identifiant de l'agent auteur, si transmis par la plateforme." })
+  @IsOptional()
+  @IsString()
+  auteur?: string;
+
+  @ApiPropertyOptional({ description: "Commentaire libre." })
+  @IsOptional()
+  @IsString()
+  commentaire?: string;
+
+  @ApiPropertyOptional({
+    type: Object,
+    description: "Charge utile structurée additionnelle propre à la décision.",
+  })
+  @IsOptional()
+  @IsObject()
+  payload?: Record<string, unknown>;
+}
+
+export class DecisionCreatedResponse {
+  @ApiProperty({ description: "ID de la décision créée." })
+  id!: string;
+
+  @ApiProperty({ description: "Horodatage de création (ISO 8601)." })
+  createdAt!: string;
+}
+
+export class DecisionRecordResponse {
+  @ApiProperty()
+  id!: string;
+
+  @ApiProperty()
+  createdAt!: string;
+
+  @ApiProperty()
+  typeDecision!: string;
+
+  @ApiProperty({ enum: OBJET_TYPES })
+  objetAType!: string;
+
+  @ApiProperty()
+  objetAId!: string;
+
+  @ApiPropertyOptional({ enum: OBJET_TYPES, nullable: true })
+  objetBType!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  objetBId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  verdict!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  auteur!: string | null;
+
+  @ApiProperty({ description: "Plateforme émettrice, dérivée de la clé API authentifiée." })
+  plateformeSource!: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  commentaire!: string | null;
+
+  @ApiPropertyOptional({ type: Object, nullable: true })
+  payload!: Record<string, unknown> | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "ID de la décision qui révoque celle-ci, le cas échéant." })
+  supersededBy!: string | null;
+}
+
+export class DecisionListResponse {
+  @ApiProperty({ type: [DecisionRecordResponse] })
+  items!: DecisionRecordResponse[];
+}

--- a/api/src/logging/request-logging.interceptor.ts
+++ b/api/src/logging/request-logging.interceptor.ts
@@ -24,14 +24,19 @@ export class RequestLoggingInterceptor implements NestInterceptor {
 
     const shouldTrackApiUsage = this.reflector.get<boolean>(TRACK_API_USAGE_KEY, context.getHandler());
 
+    // Décisions humaines : le corps porte des données personnelles (auteur, commentaire).
+    // On ne le journalise pas — redaction ciblée par chemin, minimalement invasive.
+    const isSensitiveBody = originalUrl.split("?")[0].startsWith("/decisions");
+
     this.logger.log("Incoming Request", {
       method,
       url: originalUrl,
       ip,
       tracked: shouldTrackApiUsage,
-      // we have no sensitive information to be hidden from the logs. And this helps a lot in term of debugging
-      // might have to revise this implementation in the future when addressing logs in a more structured manner
-      body: (body as Record<string, unknown>) ?? null,
+      // we have no sensitive information to be hidden from the logs (except sensitive routes,
+      // see isSensitiveBody). And this helps a lot in term of debugging — might have to revise
+      // this implementation in the future when addressing logs in a more structured manner
+      body: isSensitiveBody ? { redacted: true } : ((body as Record<string, unknown>) ?? null),
     });
 
     return next.handle().pipe(

--- a/api/src/security/throttler.config.ts
+++ b/api/src/security/throttler.config.ts
@@ -1,13 +1,14 @@
 import { ThrottlerModuleOptions } from "@nestjs/throttler";
 
-// this config sets up the throttler module that limits requests to 100 per minute.
+// this config sets up the throttler module that limits requests to 50 per minute.
 // this is per IP address, i.e if MEC backend makes 4 GET requests and 7 POST requests in one minute, it will be throttled.
 // responding a 429 error.
+// NB: @nestjs/throttler 6.x expresses ttl in MILLISECONDS — 60_000 = 1 minute.
 
 export const throttlerConfig: ThrottlerModuleOptions = {
   throttlers: [
     {
-      ttl: 60, //ms
+      ttl: 60000, // 1 minute (ms)
       limit: 50,
     },
   ],

--- a/api/src/security/throttler.config.ts
+++ b/api/src/security/throttler.config.ts
@@ -5,11 +5,13 @@ import { ThrottlerModuleOptions } from "@nestjs/throttler";
 // responding a 429 error.
 // NB: @nestjs/throttler 6.x expresses ttl in MILLISECONDS — 60_000 = 1 minute.
 
+// Surcharge par env pour les environnements de test (la suite e2e dépasse 50 req/min
+// depuis une seule IP — cf. e2e-global-setup qui pose THROTTLER_LIMIT).
 export const throttlerConfig: ThrottlerModuleOptions = {
   throttlers: [
     {
-      ttl: 60000, // 1 minute (ms)
-      limit: 50,
+      ttl: Number(process.env.THROTTLER_TTL_MS ?? 60000), // 1 minute (ms)
+      limit: Number(process.env.THROTTLER_LIMIT ?? 50),
     },
   ],
 };

--- a/api/src/setup-app.ts
+++ b/api/src/setup-app.ts
@@ -13,6 +13,8 @@ import { AidesModule } from "@/aides/aides.module";
 import { FichesActionModule } from "@/fiches-action/fiches-action.module";
 import { AnalyticsModule } from "@/analytics/analytics.module";
 import { MecModule } from "@/mec/mec.module";
+import { DecisionsModule } from "@/decisions/decisions.module";
+import { TerritoiresModule } from "@/territoires/territoires.module";
 
 export function setupApp(app: INestApplication) {
   const logger = app.get(CustomLogger);
@@ -63,6 +65,8 @@ function setupProjetsDoc(app: INestApplication) {
         FichesActionModule,
         AnalyticsModule,
         MecModule,
+        DecisionsModule,
+        TerritoiresModule,
       ],
     });
   SwaggerModule.setup("api/projets", app, documentFactory, {

--- a/api/src/territoires/dto/plans-territoire.dto.ts
+++ b/api/src/territoires/dto/plans-territoire.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+export class PcaetReferenceDto {
+  @ApiPropertyOptional({ nullable: true, description: "Nom du PCAET." })
+  nom!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "SIREN du porteur du PCAET." })
+  sirenPorteur!: string | null;
+
+  @ApiProperty({ description: "Le PCAET est-il présent dans TeT (tet_external_id renseigné) ?" })
+  presentDansTet!: boolean;
+
+  @ApiPropertyOptional({ nullable: true, description: "External ID TeT du PCAET, si présent dans TeT." })
+  tetExternalId?: string | null;
+
+  @ApiPropertyOptional({
+    enum: ["live", "snapshot", "opendata"],
+    nullable: true,
+    description: "Source de la fiche PCAET de référence (source_nom).",
+  })
+  source!: string | null;
+}
+
+export class PlansTerritoireResponse {
+  @ApiProperty({ type: [PcaetReferenceDto], description: "PCAET couvrant les communes du projet." })
+  pcaet!: PcaetReferenceDto[];
+
+  @ApiProperty({
+    type: [Object],
+    description: "Fiches action suggérées (bonus hors scope immédiat — tableau vide pour l'instant).",
+  })
+  fichesActionSuggerees!: unknown[];
+}

--- a/api/src/territoires/dto/plans-territoire.dto.ts
+++ b/api/src/territoires/dto/plans-territoire.dto.ts
@@ -7,14 +7,19 @@ export class PcaetReferenceDto {
   @ApiPropertyOptional({ nullable: true, description: "SIREN du porteur du PCAET." })
   sirenPorteur!: string | null;
 
-  @ApiProperty({ description: "Le PCAET est-il présent dans TeT (tet_external_id renseigné) ?" })
+  @ApiProperty({
+    description:
+      "Le PCAET est-il présent dans le snapshot TeT (tet_external_id renseigné) ? " +
+      "Indique la présence dans le snapshot, sans garantir un deep-link exploitable.",
+  })
   presentDansTet!: boolean;
 
-  @ApiPropertyOptional({ nullable: true, description: "External ID TeT du PCAET, si présent dans TeT." })
+  @ApiPropertyOptional({ nullable: true, description: "External ID TeT du PCAET, si présent dans le snapshot TeT." })
   tetExternalId?: string | null;
 
   @ApiPropertyOptional({
-    enum: ["live", "snapshot", "opendata"],
+    // Canal 'live' exclu de facto : seuls 'snapshot' et 'opendata' alimentent la référence.
+    enum: ["snapshot", "opendata"],
     nullable: true,
     description: "Source de la fiche PCAET de référence (source_nom).",
   })

--- a/api/src/territoires/dto/qualification.dto.ts
+++ b/api/src/territoires/dto/qualification.dto.ts
@@ -1,0 +1,25 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+export class QualificationResponse {
+  @ApiProperty({ description: "External ID MEC interrogé." })
+  externalId!: string;
+
+  @ApiProperty({ description: "ID stable du projet dans le schéma commun." })
+  projetId!: string;
+
+  @ApiProperty({ type: [String], description: "Leviers SGPE (colonne CSV découpée en tableau)." })
+  leviersSgpe!: string[];
+
+  @ApiPropertyOptional({
+    type: Object,
+    nullable: true,
+    description: "Thématiques LLM (jsonb tel quel : [{ label, score }]).",
+  })
+  llmThematiques!: unknown;
+
+  @ApiPropertyOptional({ type: Number, nullable: true, description: "Probabilité de transition écologique (0–1)." })
+  llmProbabiliteTe!: number | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "Horodatage de classification LLM (ISO 8601)." })
+  llmClassifiedAt!: string | null;
+}

--- a/api/src/territoires/dto/territoire-projets.dto.ts
+++ b/api/src/territoires/dto/territoire-projets.dto.ts
@@ -1,0 +1,62 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+
+// Une trace = une occurrence d'un projet réel dans une source (MEC, TeT, Vivier COP,
+// financements DGCL/Fonds Vert…). Plusieurs traces d'un même groupe décrivent le même
+// projet réel dédupliqué.
+export class TerritoireTraceDto {
+  @ApiProperty({ enum: ["projet", "financement"], description: "Rôle de la trace dans le groupe." })
+  role!: "projet" | "financement";
+
+  @ApiProperty({ description: "Source d'origine (source_origine)." })
+  source!: string;
+
+  @ApiProperty({ description: "ID stable de la trace." })
+  id!: string;
+
+  @ApiPropertyOptional({ nullable: true })
+  nom!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "Statut de phase (phaseStatut)." })
+  statut!: string | null;
+
+  @ApiPropertyOptional({ nullable: true })
+  phase!: string | null;
+
+  @ApiPropertyOptional({ type: Number, nullable: true, description: "Budget prévisionnel plafonné." })
+  budgetPrevisionnel!: number | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "Millésime COP (cop_millesime)." })
+  copMillesime!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "Statut vivier COP (cop_statut_vivier)." })
+  copStatutVivier!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "External ID MEC (traces MEC uniquement)." })
+  externalId!: string | null;
+}
+
+export class TerritoireGroupeDto {
+  @ApiPropertyOptional({
+    enum: ["CERTAIN", "PROBABLE"],
+    nullable: true,
+    description: "Confiance du cluster ; null pour un groupe singleton (projet sans cluster).",
+  })
+  confiance!: "CERTAIN" | "PROBABLE" | null;
+
+  @ApiProperty({ type: [TerritoireTraceDto] })
+  traces!: TerritoireTraceDto[];
+}
+
+export class TerritoireProjetsResponse {
+  @ApiProperty({ description: "Nombre total de groupes correspondant aux filtres." })
+  total!: number;
+
+  @ApiProperty()
+  limit!: number;
+
+  @ApiProperty()
+  offset!: number;
+
+  @ApiProperty({ type: [TerritoireGroupeDto] })
+  groupes!: TerritoireGroupeDto[];
+}

--- a/api/src/territoires/dto/territoire-projets.dto.ts
+++ b/api/src/territoires/dto/territoire-projets.dto.ts
@@ -22,8 +22,21 @@ export class TerritoireTraceDto {
   @ApiPropertyOptional({ nullable: true })
   phase!: string | null;
 
-  @ApiPropertyOptional({ type: Number, nullable: true, description: "Budget prévisionnel plafonné." })
+  @ApiPropertyOptional({
+    type: Number,
+    nullable: true,
+    description: "Coût du projet / montant demandé (budget prévisionnel plafonné).",
+  })
   budgetPrevisionnel!: number | null;
+
+  @ApiPropertyOptional({
+    type: Number,
+    nullable: true,
+    description:
+      "Subvention attribuée (somme des montants attribués des financements liés). " +
+      "Renseigné surtout pour les traces de financement (DGCL). À distinguer de budgetPrevisionnel (coût/montant demandé).",
+  })
+  montantAttribue!: number | null;
 
   @ApiPropertyOptional({ nullable: true, description: "Millésime COP (cop_millesime)." })
   copMillesime!: string | null;

--- a/api/src/territoires/leviers-csv.spec.ts
+++ b/api/src/territoires/leviers-csv.spec.ts
@@ -1,0 +1,36 @@
+import { splitLeviersCsv } from "./leviers-csv";
+import { leviers } from "@/shared/const/leviers";
+
+describe("splitLeviersCsv", () => {
+  it("renvoie [] pour une valeur vide ou nulle", () => {
+    expect(splitLeviersCsv(null)).toEqual([]);
+    expect(splitLeviersCsv(undefined)).toEqual([]);
+    expect(splitLeviersCsv("")).toEqual([]);
+  });
+
+  it("découpe des leviers canoniques simples", () => {
+    expect(splitLeviersCsv("Vélo,Covoiturage")).toEqual(["Vélo", "Covoiturage"]);
+  });
+
+  it("préserve un levier canonique contenant une virgule", () => {
+    const withComma =
+      "Prévention des inondations par débordement de cours d'eau, notamment via restauration des milieux aquatiques";
+    expect(leviers).toContain(withComma);
+    expect(splitLeviersCsv(withComma)).toEqual([withComma]);
+  });
+
+  it("découpe correctement un levier à virgule suivi d'un autre levier", () => {
+    const withComma =
+      "Prévention des inondations par débordement de cours d'eau, notamment via restauration des milieux aquatiques";
+    expect(splitLeviersCsv(`${withComma},Vélo`)).toEqual([withComma, "Vélo"]);
+    expect(splitLeviersCsv(`Vélo,${withComma}`)).toEqual(["Vélo", withComma]);
+  });
+
+  it("retombe sur un split par virgule pour des fragments inconnus", () => {
+    expect(splitLeviersCsv("Inconnu A,Inconnu B")).toEqual(["Inconnu A", "Inconnu B"]);
+  });
+
+  it("mélange leviers canoniques et fragments inconnus", () => {
+    expect(splitLeviersCsv("Vélo,Fragment libre")).toEqual(["Vélo", "Fragment libre"]);
+  });
+});

--- a/api/src/territoires/leviers-csv.ts
+++ b/api/src/territoires/leviers-csv.ts
@@ -1,0 +1,39 @@
+import { leviers } from "@/shared/const/leviers";
+
+// Leviers canoniques triés du plus long au plus court : on tente de consommer
+// d'abord le libellé le plus long, ce qui évite qu'un levier préfixe d'un autre
+// (ou contenant une virgule) soit mal découpé.
+const SORTED_LEVIERS = [...leviers].sort((a, b) => b.length - a.length);
+
+/**
+ * Découpe la colonne CSV `leviersSgpe` en tableau de leviers.
+ *
+ * Un simple split sur "," est faux : au moins un levier canonique contient une
+ * virgule (« Prévention des inondations par débordement de cours d'eau, notamment
+ * via restauration des milieux aquatiques »). On consomme donc gloutonnement les
+ * leviers canoniques en tête de chaîne, et on ne retombe sur un split par virgule
+ * que pour les fragments ne correspondant à aucun levier connu.
+ */
+export function splitLeviersCsv(raw: string | null | undefined): string[] {
+  if (!raw) return [];
+  const result: string[] = [];
+  let rest = raw.trim();
+
+  while (rest.length > 0) {
+    const canonical = SORTED_LEVIERS.find((levier) => rest === levier || rest.startsWith(`${levier},`));
+    if (canonical) {
+      result.push(canonical);
+      rest = rest.slice(canonical.length).replace(/^\s*,\s*/, "");
+      continue;
+    }
+    const idx = rest.indexOf(",");
+    if (idx < 0) {
+      result.push(rest.trim());
+      break;
+    }
+    result.push(rest.slice(0, idx).trim());
+    rest = rest.slice(idx + 1).trimStart();
+  }
+
+  return result.filter(Boolean);
+}

--- a/api/src/territoires/territoires.controller.spec.ts
+++ b/api/src/territoires/territoires.controller.spec.ts
@@ -1,0 +1,59 @@
+import { TerritoiresController } from "./territoires.controller";
+import { TerritoiresService } from "./territoires.service";
+
+describe("TerritoiresController", () => {
+  let controller: TerritoiresController;
+  let service: { territoireProjets: jest.Mock };
+
+  const lastParams = (): Record<string, unknown> => {
+    const calls = service.territoireProjets.mock.calls as unknown[][];
+    return calls[0][1] as Record<string, unknown>;
+  };
+
+  beforeEach(() => {
+    service = { territoireProjets: jest.fn().mockResolvedValue({ total: 0, limit: 50, offset: 0, groupes: [] }) };
+    controller = new TerritoiresController(service as unknown as TerritoiresService);
+  });
+
+  describe("sources (param répété vs virgules)", () => {
+    it("aplati un param répété en tableau (pas de 500)", async () => {
+      await controller.territoireProjets("01001", { sources: ["MEC", "Vivier COP"] });
+      expect(lastParams().sources).toEqual(["MEC", "Vivier COP"]);
+    });
+
+    it("découpe la forme séparée par des virgules", async () => {
+      await controller.territoireProjets("01001", { sources: "MEC,Vivier COP" });
+      expect(lastParams().sources).toEqual(["MEC", "Vivier COP"]);
+    });
+
+    it("sources absent → undefined", async () => {
+      await controller.territoireProjets("01001", {});
+      expect(lastParams().sources).toBeUndefined();
+    });
+  });
+
+  describe("limit (borné à 1..200)", () => {
+    it("limit=0 est ramené à 1", async () => {
+      await controller.territoireProjets("01001", { limit: "0" });
+      expect(lastParams().limit).toBe(1);
+    });
+
+    it("limit > 200 est plafonné à 200", async () => {
+      await controller.territoireProjets("01001", { limit: "500" });
+      expect(lastParams().limit).toBe(200);
+    });
+
+    it("limit absent → défaut 50", async () => {
+      await controller.territoireProjets("01001", {});
+      expect(lastParams().limit).toBe(50);
+    });
+  });
+
+  it("mappe copStatutVivier et inclureFinancementsSeuls", async () => {
+    await controller.territoireProjets("01001", {
+      copStatutVivier: "a_remonter",
+      inclureFinancementsSeuls: "true",
+    });
+    expect(lastParams()).toMatchObject({ copStatutVivier: "a_remonter", inclureFinancementsSeuls: true });
+  });
+});

--- a/api/src/territoires/territoires.controller.ts
+++ b/api/src/territoires/territoires.controller.ts
@@ -1,0 +1,110 @@
+import { Controller, Get, Param, Query, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { ApiKeyGuard } from "@/auth/api-key-guard";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
+import { TerritoiresService } from "./territoires.service";
+import { TerritoireProjetsResponse } from "./dto/territoire-projets.dto";
+import { PlansTerritoireResponse } from "./dto/plans-territoire.dto";
+import { QualificationResponse } from "./dto/qualification.dto";
+
+const toInt = (value: string | undefined, def: number): number => {
+  const n = value == null ? NaN : Number(value);
+  return Number.isFinite(n) && n >= 0 ? Math.floor(n) : def;
+};
+
+// Découpe une valeur en liste par virgule (camelCase, ex. ?sources=MEC,TeT,Vivier COP).
+// Les valeurs de source_origine ne contiennent pas de virgule → séparateur sûr.
+const toCsvList = (value: string | undefined): string[] | undefined => {
+  if (value == null) return undefined;
+  const arr = value
+    .split(",")
+    .map((s) => s.trim())
+    .filter(Boolean);
+  return arr.length > 0 ? arr : undefined;
+};
+
+@ApiBearerAuth()
+@ApiTags("Territoires")
+@Controller()
+@UseGuards(ApiKeyGuard)
+export class TerritoiresController {
+  constructor(private readonly territoiresService: TerritoiresService) {}
+
+  @TrackApiUsage()
+  @Get("territoires/:code/projets")
+  @ApiOperation({
+    summary: "Projets d'un territoire, regroupés par cluster de déduplication",
+    description:
+      "code = INSEE commune (5 chiffres) ou SIREN EPCI (9 chiffres, développé en ses communes membres). " +
+      "Les groupes rassemblent toutes les traces d'un même projet réel (MEC, TeT, Vivier COP, financements…). " +
+      "Aucun identifiant de groupe n'est exposé (les cluster_id sont instables).",
+  })
+  @ApiQuery({
+    name: "sources",
+    required: false,
+    description: "Sources séparées par des virgules (ex. MEC,TeT,Vivier COP).",
+  })
+  @ApiQuery({ name: "copMillesime", required: false, enum: ["2024", "2025"] })
+  @ApiQuery({ name: "statut", required: false, description: "Statut vivier COP (cop_statut_vivier)." })
+  @ApiQuery({ name: "limit", required: false, description: "Défaut 50, max 200." })
+  @ApiQuery({ name: "offset", required: false, description: "Défaut 0." })
+  @ApiQuery({
+    name: "inclureFinancementsSeuls",
+    required: false,
+    description: "Inclure les groupes dont toutes les traces sont des financements (défaut false).",
+  })
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: TerritoireProjetsResponse,
+    description: "Groupes de projets du territoire",
+  })
+  territoireProjets(
+    @Param("code") code: string,
+    @Query("sources") sources?: string,
+    @Query("copMillesime") copMillesime?: string,
+    @Query("statut") statut?: string,
+    @Query("limit") limit?: string,
+    @Query("offset") offset?: string,
+    @Query("inclureFinancementsSeuls") inclureFinancementsSeuls?: string,
+  ): Promise<TerritoireProjetsResponse> {
+    return this.territoiresService.territoireProjets(code, {
+      sources: toCsvList(sources),
+      copMillesime,
+      statut,
+      limit: Math.min(toInt(limit, 50), 200),
+      offset: toInt(offset, 0),
+      inclureFinancementsSeuls: inclureFinancementsSeuls === "true",
+    });
+  }
+
+  @TrackApiUsage()
+  @Get("projets/mec/:externalId/plans-territoire")
+  @ApiOperation({
+    summary: "PCAET couvrant le territoire d'un projet MEC",
+    description: "Résout l'external_id MEC (404 si inconnu), puis liste les PCAET couvrant les communes du projet.",
+  })
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: PlansTerritoireResponse,
+    description: "PCAET du territoire du projet",
+  })
+  plansTerritoire(@Param("externalId") externalId: string): Promise<PlansTerritoireResponse> {
+    return this.territoiresService.planFichesTerritoire(externalId);
+  }
+
+  @TrackApiUsage()
+  @Get("projets/mec/:externalId/qualification")
+  @ApiOperation({
+    summary: "Qualification LLM d'un projet MEC",
+    description: "Résout l'external_id MEC (404 si inconnu), puis retourne leviers, thématiques, probabilité TE.",
+  })
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: QualificationResponse,
+    description: "Qualification du projet",
+  })
+  qualification(@Param("externalId") externalId: string): Promise<QualificationResponse> {
+    return this.territoiresService.qualification(externalId);
+  }
+}

--- a/api/src/territoires/territoires.controller.ts
+++ b/api/src/territoires/territoires.controller.ts
@@ -8,17 +8,23 @@ import { TerritoireProjetsResponse } from "./dto/territoire-projets.dto";
 import { PlansTerritoireResponse } from "./dto/plans-territoire.dto";
 import { QualificationResponse } from "./dto/qualification.dto";
 
+type RawQuery = Record<string, string | string[] | undefined>;
+
+// Première occurrence d'un param (un param répété arrive en tableau via Express).
+const first = (v: string | string[] | undefined): string | undefined => (Array.isArray(v) ? v[0] : v);
+
 const toInt = (value: string | undefined, def: number): number => {
   const n = value == null ? NaN : Number(value);
   return Number.isFinite(n) && n >= 0 ? Math.floor(n) : def;
 };
 
-// Découpe une valeur en liste par virgule (camelCase, ex. ?sources=MEC,TeT,Vivier COP).
-// Les valeurs de source_origine ne contiennent pas de virgule → séparateur sûr.
-const toCsvList = (value: string | undefined): string[] | undefined => {
+// Liste de sources : accepte les params répétés (?sources=A&sources=B) ET la forme
+// séparée par des virgules (?sources=A,B). Les valeurs de source_origine ne
+// contiennent pas de virgule → séparateur sûr.
+const toCsvList = (value: string | string[] | undefined): string[] | undefined => {
   if (value == null) return undefined;
-  const arr = value
-    .split(",")
+  const arr = (Array.isArray(value) ? value : [value])
+    .flatMap((s) => s.split(","))
     .map((s) => s.trim())
     .filter(Boolean);
   return arr.length > 0 ? arr : undefined;
@@ -36,18 +42,24 @@ export class TerritoiresController {
   @ApiOperation({
     summary: "Projets d'un territoire, regroupés par cluster de déduplication",
     description:
-      "code = INSEE commune (5 chiffres) ou SIREN EPCI (9 chiffres, développé en ses communes membres). " +
-      "Les groupes rassemblent toutes les traces d'un même projet réel (MEC, TeT, Vivier COP, financements…). " +
+      "code = INSEE commune (5 chiffres ou 2A/2B+3) ou SIREN EPCI (9 chiffres, développé en ses communes membres). " +
+      "Les groupes rassemblent toutes les traces d'un même projet réel (MEC, Vivier COP, financements DGCL/Fonds Vert…). " +
+      "NB : les traces TeT (fiches action) ne sont pas exposées en V1 — source_origine='TeT' n'existe pas côté projets. " +
       "Aucun identifiant de groupe n'est exposé (les cluster_id sont instables).",
   })
   @ApiQuery({
     name: "sources",
     required: false,
-    description: "Sources séparées par des virgules (ex. MEC,TeT,Vivier COP).",
+    description: "Sources (répétables ou séparées par des virgules), ex. MEC,Vivier COP.",
   })
   @ApiQuery({ name: "copMillesime", required: false, enum: ["2024", "2025"] })
-  @ApiQuery({ name: "statut", required: false, description: "Statut vivier COP (cop_statut_vivier)." })
-  @ApiQuery({ name: "limit", required: false, description: "Défaut 50, max 200." })
+  @ApiQuery({
+    name: "copStatutVivier",
+    required: false,
+    enum: ["a_remonter", "a_travailler", "hors_cop_mais_crte", "non_remonte"],
+    description: "Statut vivier COP (cop_statut_vivier).",
+  })
+  @ApiQuery({ name: "limit", required: false, description: "Défaut 50, borné à 1..200." })
   @ApiQuery({ name: "offset", required: false, description: "Défaut 0." })
   @ApiQuery({
     name: "inclureFinancementsSeuls",
@@ -59,22 +71,15 @@ export class TerritoiresController {
     response: TerritoireProjetsResponse,
     description: "Groupes de projets du territoire",
   })
-  territoireProjets(
-    @Param("code") code: string,
-    @Query("sources") sources?: string,
-    @Query("copMillesime") copMillesime?: string,
-    @Query("statut") statut?: string,
-    @Query("limit") limit?: string,
-    @Query("offset") offset?: string,
-    @Query("inclureFinancementsSeuls") inclureFinancementsSeuls?: string,
-  ): Promise<TerritoireProjetsResponse> {
+  territoireProjets(@Param("code") code: string, @Query() query: RawQuery): Promise<TerritoireProjetsResponse> {
     return this.territoiresService.territoireProjets(code, {
-      sources: toCsvList(sources),
-      copMillesime,
-      statut,
-      limit: Math.min(toInt(limit, 50), 200),
-      offset: toInt(offset, 0),
-      inclureFinancementsSeuls: inclureFinancementsSeuls === "true",
+      sources: toCsvList(query.sources),
+      copMillesime: first(query.copMillesime),
+      copStatutVivier: first(query.copStatutVivier),
+      // limit borné à 1..200 (limit=0 interdit).
+      limit: Math.min(Math.max(toInt(first(query.limit), 50), 1), 200),
+      offset: toInt(first(query.offset), 0),
+      inclureFinancementsSeuls: first(query.inclureFinancementsSeuls) === "true",
     });
   }
 

--- a/api/src/territoires/territoires.module.ts
+++ b/api/src/territoires/territoires.module.ts
@@ -1,0 +1,11 @@
+import { Module } from "@nestjs/common";
+import { DatabaseModule } from "@database/database.module";
+import { TerritoiresController } from "./territoires.controller";
+import { TerritoiresService } from "./territoires.service";
+
+@Module({
+  imports: [DatabaseModule],
+  controllers: [TerritoiresController],
+  providers: [TerritoiresService],
+})
+export class TerritoiresModule {}

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -1,4 +1,4 @@
-import { NotFoundException } from "@nestjs/common";
+import { BadRequestException, NotFoundException } from "@nestjs/common";
 import { TerritoiresService } from "./territoires.service";
 import { DatabaseService } from "@database/database.service";
 
@@ -26,15 +26,17 @@ describe("TerritoiresService", () => {
     const params = { limit: 50, offset: 0, inclureFinancementsSeuls: false };
 
     it("renvoie la forme { total, limit, offset, groupes } pour une commune (INSEE 5 chiffres)", async () => {
-      execute.mockResolvedValueOnce({
-        rows: [
-          {
-            confiance: "CERTAIN",
-            traces: [{ role: "projet", source: "MEC", id: "p1" }],
-            total: "1",
-          },
-        ],
-      });
+      execute
+        .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence de la commune au référentiel
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              confiance: "CERTAIN",
+              traces: [{ role: "projet", source: "MEC", id: "p1" }],
+              total: "1",
+            },
+          ],
+        });
 
       const result = await service.territoireProjets("01001", params);
 
@@ -44,14 +46,35 @@ describe("TerritoiresService", () => {
         offset: 0,
         groupes: [{ confiance: "CERTAIN", traces: [{ role: "projet", source: "MEC", id: "p1" }] }],
       });
-      // Une commune INSEE ne déclenche pas de résolution de périmètre : une seule requête SQL.
-      expect(execute).toHaveBeenCalledTimes(1);
+      // 1 requête d'existence commune + 1 requête de groupes.
+      expect(execute).toHaveBeenCalledTimes(2);
     });
 
-    it("total = 0 et groupes = [] quand aucun groupe", async () => {
+    it("accepte un code commune corse (2A/2B + 3)", async () => {
+      execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
+      const result = await service.territoireProjets("2a004", params);
+      expect(result.total).toBe(0);
+    });
+
+    it("404 pour une commune de format valide mais inconnue du référentiel", async () => {
       execute.mockResolvedValueOnce({ rows: [] });
+      await expect(service.territoireProjets("99999", params)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("total = 0 et groupes = [] quand aucun groupe (offset 0)", async () => {
+      execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
       const result = await service.territoireProjets("01001", params);
       expect(result).toEqual({ total: 0, limit: 50, offset: 0, groupes: [] });
+    });
+
+    it("récupère le vrai total via un COUNT quand la page est vide au-delà de l'offset", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence commune
+        .mockResolvedValueOnce({ rows: [] }) // page vide
+        .mockResolvedValueOnce({ rows: [{ total: "12" }] }); // COUNT de repli
+      const result = await service.territoireProjets("01001", { ...params, offset: 100 });
+      expect(result.total).toBe(12);
+      expect(execute).toHaveBeenCalledTimes(3);
     });
 
     it("résout un EPCI (SIREN 9 chiffres) en ses communes, 404 si aucune", async () => {
@@ -59,8 +82,22 @@ describe("TerritoiresService", () => {
       await expect(service.territoireProjets("200000172", params)).rejects.toBeInstanceOf(NotFoundException);
     });
 
-    it("404 pour un code de format invalide", async () => {
+    it("404 pour un code de format invalide (aucune requête)", async () => {
       await expect(service.territoireProjets("abc", params)).rejects.toBeInstanceOf(NotFoundException);
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("400 si copMillesime invalide", async () => {
+      await expect(service.territoireProjets("01001", { ...params, copMillesime: "2099" })).rejects.toBeInstanceOf(
+        BadRequestException,
+      );
+      expect(execute).not.toHaveBeenCalled();
+    });
+
+    it("400 si copStatutVivier invalide", async () => {
+      await expect(
+        service.territoireProjets("01001", { ...params, copStatutVivier: "peut_etre" }),
+      ).rejects.toBeInstanceOf(BadRequestException);
       expect(execute).not.toHaveBeenCalled();
     });
   });
@@ -69,6 +106,12 @@ describe("TerritoiresService", () => {
     it("404 quand l'external_id est inconnu", async () => {
       selectLimit.mockResolvedValueOnce([]);
       await expect(service.qualification("mec-unknown")).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("404 quand l'external_id résout vers un projet orphelin (hors schéma commun)", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      execute.mockResolvedValueOnce({ rows: [] }); // projet absent de projets_operationnels
+      await expect(service.qualification("mec-orphan")).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it("découpe les leviers, normalise proba et date pour un external_id connu", async () => {
@@ -103,9 +146,17 @@ describe("TerritoiresService", () => {
       await expect(service.planFichesTerritoire("mec-unknown")).rejects.toBeInstanceOf(NotFoundException);
     });
 
+    it("404 quand le projet est orphelin (hors schéma commun)", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      execute.mockResolvedValueOnce({ rows: [] }); // existence projet → absent
+      await expect(service.planFichesTerritoire("mec-orphan")).rejects.toBeInstanceOf(NotFoundException);
+    });
+
     it("renvoie pcaet vide sans communes rattachées", async () => {
       selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
-      execute.mockResolvedValueOnce({ rows: [] }); // communes du projet
+      execute
+        .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence projet
+        .mockResolvedValueOnce({ rows: [] }); // communes du projet
       const result = await service.planFichesTerritoire("mec-123");
       expect(result).toEqual({ pcaet: [], fichesActionSuggerees: [] });
     });
@@ -113,6 +164,7 @@ describe("TerritoiresService", () => {
     it("mappe les PCAET couvrant les communes du projet", async () => {
       selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
       execute
+        .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence projet
         .mockResolvedValueOnce({ rows: [{ insee: "01001" }] }) // communes du projet
         .mockResolvedValueOnce({
           rows: [
@@ -121,7 +173,7 @@ describe("TerritoiresService", () => {
               sirenPorteur: "200000172",
               presentDansTet: true,
               tetExternalId: "tet-9",
-              source: "live",
+              source: "snapshot",
             },
           ],
         });
@@ -135,7 +187,7 @@ describe("TerritoiresService", () => {
             sirenPorteur: "200000172",
             presentDansTet: true,
             tetExternalId: "tet-9",
-            source: "live",
+            source: "snapshot",
           },
         ],
         fichesActionSuggerees: [],

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -1,0 +1,145 @@
+import { NotFoundException } from "@nestjs/common";
+import { TerritoiresService } from "./territoires.service";
+import { DatabaseService } from "@database/database.service";
+
+describe("TerritoiresService", () => {
+  let execute: jest.Mock;
+  let selectLimit: jest.Mock;
+  let service: TerritoiresService;
+
+  // execute() sert les requêtes SQL brutes ; select().from().where().limit() la résolution external_id.
+  const makeDb = () => {
+    execute = jest.fn();
+    selectLimit = jest.fn();
+    const where = jest.fn().mockReturnValue({ limit: selectLimit });
+    const from = jest.fn().mockReturnValue({ where });
+    const select = jest.fn().mockReturnValue({ from });
+    return { execute, select } as unknown as DatabaseService["database"];
+  };
+
+  beforeEach(() => {
+    const dbService = { database: makeDb() } as unknown as DatabaseService;
+    service = new TerritoiresService(dbService);
+  });
+
+  describe("territoireProjets", () => {
+    const params = { limit: 50, offset: 0, inclureFinancementsSeuls: false };
+
+    it("renvoie la forme { total, limit, offset, groupes } pour une commune (INSEE 5 chiffres)", async () => {
+      execute.mockResolvedValueOnce({
+        rows: [
+          {
+            confiance: "CERTAIN",
+            traces: [{ role: "projet", source: "MEC", id: "p1" }],
+            total: "1",
+          },
+        ],
+      });
+
+      const result = await service.territoireProjets("01001", params);
+
+      expect(result).toEqual({
+        total: 1,
+        limit: 50,
+        offset: 0,
+        groupes: [{ confiance: "CERTAIN", traces: [{ role: "projet", source: "MEC", id: "p1" }] }],
+      });
+      // Une commune INSEE ne déclenche pas de résolution de périmètre : une seule requête SQL.
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("total = 0 et groupes = [] quand aucun groupe", async () => {
+      execute.mockResolvedValueOnce({ rows: [] });
+      const result = await service.territoireProjets("01001", params);
+      expect(result).toEqual({ total: 0, limit: 50, offset: 0, groupes: [] });
+    });
+
+    it("résout un EPCI (SIREN 9 chiffres) en ses communes, 404 si aucune", async () => {
+      execute.mockResolvedValueOnce({ rows: [] }); // périmètre vide
+      await expect(service.territoireProjets("200000172", params)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("404 pour un code de format invalide", async () => {
+      await expect(service.territoireProjets("abc", params)).rejects.toBeInstanceOf(NotFoundException);
+      expect(execute).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("qualification", () => {
+    it("404 quand l'external_id est inconnu", async () => {
+      selectLimit.mockResolvedValueOnce([]);
+      await expect(service.qualification("mec-unknown")).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("découpe les leviers, normalise proba et date pour un external_id connu", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      execute.mockResolvedValueOnce({
+        rows: [
+          {
+            leviersSgpe: "Vélo,Covoiturage",
+            llmThematiques: [{ label: "Mobilité", score: 0.9 }],
+            llmProbabiliteTe: 0.87,
+            llmClassifiedAt: new Date("2026-07-01T08:00:00.000Z"),
+          },
+        ],
+      });
+
+      const result = await service.qualification("mec-123");
+
+      expect(result).toEqual({
+        externalId: "mec-123",
+        projetId: "proj-uuid",
+        leviersSgpe: ["Vélo", "Covoiturage"],
+        llmThematiques: [{ label: "Mobilité", score: 0.9 }],
+        llmProbabiliteTe: 0.87,
+        llmClassifiedAt: "2026-07-01T08:00:00.000Z",
+      });
+    });
+  });
+
+  describe("planFichesTerritoire", () => {
+    it("404 quand l'external_id est inconnu", async () => {
+      selectLimit.mockResolvedValueOnce([]);
+      await expect(service.planFichesTerritoire("mec-unknown")).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("renvoie pcaet vide sans communes rattachées", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      execute.mockResolvedValueOnce({ rows: [] }); // communes du projet
+      const result = await service.planFichesTerritoire("mec-123");
+      expect(result).toEqual({ pcaet: [], fichesActionSuggerees: [] });
+    });
+
+    it("mappe les PCAET couvrant les communes du projet", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      execute
+        .mockResolvedValueOnce({ rows: [{ insee: "01001" }] }) // communes du projet
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              nom: "PCAET Test",
+              sirenPorteur: "200000172",
+              presentDansTet: true,
+              tetExternalId: "tet-9",
+              source: "live",
+            },
+          ],
+        });
+
+      const result = await service.planFichesTerritoire("mec-123");
+
+      expect(result).toEqual({
+        pcaet: [
+          {
+            nom: "PCAET Test",
+            sirenPorteur: "200000172",
+            presentDansTet: true,
+            tetExternalId: "tet-9",
+            source: "live",
+          },
+        ],
+        fichesActionSuggerees: [],
+      });
+    });
+  });
+});

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -161,11 +161,22 @@ describe("TerritoiresService", () => {
       expect(result).toEqual({ pcaet: [], fichesActionSuggerees: [] });
     });
 
+    it("renvoie pcaet vide quand la table de référence n'existe pas encore (chantier T4)", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      execute
+        .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence projet
+        .mockResolvedValueOnce({ rows: [{ insee: "01001" }] }) // communes du projet
+        .mockResolvedValueOnce({ rows: [{ present: false }] }); // pcaet_reference absente en prod
+      const result = await service.planFichesTerritoire("mec-123");
+      expect(result).toEqual({ pcaet: [], fichesActionSuggerees: [] });
+    });
+
     it("mappe les PCAET couvrant les communes du projet", async () => {
       selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
       execute
         .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence projet
         .mockResolvedValueOnce({ rows: [{ insee: "01001" }] }) // communes du projet
+        .mockResolvedValueOnce({ rows: [{ present: true }] }) // pcaet_reference présente
         .mockResolvedValueOnce({
           rows: [
             {

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -1,4 +1,4 @@
-import { Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { DatabaseService } from "@database/database.service";
 import { mecExternalIds } from "@database/schema";
 import { and, eq, sql, SQL } from "drizzle-orm";
@@ -13,11 +13,27 @@ type Row = Record<string, unknown>;
 // suffisent pas, à elles seules, à matérialiser un projet sur le territoire.
 const FINANCEMENT_SOURCES = ["DGCL DETR", "DGCL DSIL", "DGCL DPV", "Fonds Vert"] as const;
 
+// Valeurs autorisées des filtres COP (validées → 400 sinon).
+const COP_MILLESIMES = ["2024", "2025"] as const;
+const COP_STATUTS_VIVIER = ["a_remonter", "a_travailler", "hors_cop_mais_crte", "non_remonte"] as const;
+
+// Code INSEE de commune : 5 chiffres, ou code corse 2A/2B + 3 chiffres.
+const CODE_INSEE_REGEX = /^(\d{5}|2[AB]\d{3})$/;
+const SIREN_REGEX = /^\d{9}$/;
+
 // Aligné sur dashboard-te.service : budget prévisionnel plafonné (les valeurs
 // aberrantes deviennent NULL). Le budget est stocké en TEXT dans schema_commun_v2.
 const BUDGET_MAX = 100_000_000;
+
+// Cast numérique GARDÉ par une regex : une donnée sale (colonne TEXT réécrite par
+// l'ETL) ne fait jamais planter la requête — elle devient NULL. Le cast n'est
+// évalué qu'après validation du motif (CASE imbriqué, pas de AND non court-circuité).
+const numericGuard = (col: SQL): SQL =>
+  sql`(CASE WHEN ${col} ~ '^[0-9]+([.][0-9]+)?$' THEN CAST(${col} AS numeric) END)`;
 const cappedBudget = (col: SQL): SQL =>
-  sql`(CASE WHEN CAST(NULLIF(${col}, '') AS numeric) <= ${BUDGET_MAX} THEN CAST(NULLIF(${col}, '') AS numeric) END)`;
+  sql`(CASE WHEN ${col} ~ '^[0-9]+([.][0-9]+)?$'
+       THEN (CASE WHEN CAST(${col} AS numeric) <= ${BUDGET_MAX} THEN CAST(${col} AS numeric) END)
+       END)`;
 
 // Tableau text[] bindé (chaque valeur en paramètre, jamais interpolée).
 const textArray = (values: string[]): SQL =>
@@ -29,7 +45,7 @@ const textArray = (values: string[]): SQL =>
 export interface TerritoireProjetsParams {
   sources?: string[];
   copMillesime?: string;
-  statut?: string;
+  copStatutVivier?: string;
   limit: number;
   offset: number;
   inclureFinancementsSeuls: boolean;
@@ -46,10 +62,21 @@ export class TerritoiresService {
 
   /**
    * Projets de transition écologique d'un territoire, regroupés par cluster de
-   * déduplication. `code` = INSEE commune (5 chiffres) ou SIREN EPCI (9 chiffres).
+   * déduplication. `code` = INSEE commune (5 chiffres / 2A|2B + 3) ou SIREN EPCI (9 chiffres).
    */
   async territoireProjets(code: string, params: TerritoireProjetsParams): Promise<TerritoireProjetsResponse> {
-    const { sources, copMillesime, statut, limit, offset, inclureFinancementsSeuls } = params;
+    const { sources, copMillesime, copStatutVivier, limit, offset, inclureFinancementsSeuls } = params;
+
+    if (copMillesime !== undefined && !COP_MILLESIMES.includes(copMillesime as (typeof COP_MILLESIMES)[number])) {
+      throw new BadRequestException(`copMillesime invalide (attendu : ${COP_MILLESIMES.join(", ")})`);
+    }
+    if (
+      copStatutVivier !== undefined &&
+      !COP_STATUTS_VIVIER.includes(copStatutVivier as (typeof COP_STATUTS_VIVIER)[number])
+    ) {
+      throw new BadRequestException(`copStatutVivier invalide (attendu : ${COP_STATUTS_VIVIER.join(", ")})`);
+    }
+
     const communes = await this.resolveCommunes(code);
 
     // Filtres appliqués aux SEULS projets du territoire (avant expansion en cluster
@@ -59,15 +86,16 @@ export class TerritoiresService {
       filterConditions.push(sql`p.source_origine = ANY(${textArray(sources)})`);
     }
     if (copMillesime) filterConditions.push(sql`p.cop_millesime = ${copMillesime}`);
-    if (statut) filterConditions.push(sql`p.cop_statut_vivier = ${statut}`);
+    if (copStatutVivier) filterConditions.push(sql`p.cop_statut_vivier = ${copStatutVivier}`);
     let filterWhere: SQL = sql``;
     for (const cond of filterConditions) filterWhere = sql`${filterWhere} AND ${cond}`;
 
     // Rôle d'une trace : financement si sa source est une source de financement, sinon projet.
     const roleExpr = sql`CASE WHEN p.source_origine = ANY(${textArray([...FINANCEMENT_SOURCES])}) THEN 'financement' ELSE 'projet' END`;
 
-    const rows = await this.query<{ confiance: string | null; traces: unknown; total: string }>(sql`
-      WITH territory_pids AS (
+    // Chaîne de CTE partagée entre la requête de page et le COUNT de repli.
+    const cteBody = sql`
+      territory_pids AS (
         SELECT DISTINCT lpc.projet_id AS pid
         FROM schema_commun_v2.liens_projets_communes lpc
         WHERE lpc.insee_com = ANY(${textArray(communes)})
@@ -93,18 +121,19 @@ export class TerritoiresService {
       ),
       -- Tous les membres du groupe : membres du cluster (même hors territoire) OU le singleton lui-même.
       group_members AS (
-        SELECT g.group_key, cm.projet_id AS pid
+        SELECT g.group_key, g.cluster_id, cm.projet_id AS pid
         FROM groups g
         JOIN schema_commun_v2.clusters_membres cm ON cm.cluster_id = g.cluster_id
         WHERE g.cluster_id IS NOT NULL
         UNION
-        SELECT g.group_key, g.group_key AS pid
+        SELECT g.group_key, g.cluster_id, g.group_key AS pid
         FROM groups g
         WHERE g.cluster_id IS NULL
       ),
       member_rows AS (
         SELECT
           gm.group_key,
+          gm.cluster_id,
           p.id,
           ${roleExpr} AS role,
           p.source_origine AS source,
@@ -112,6 +141,14 @@ export class TerritoiresService {
           p."phaseStatut" AS statut,
           p.phase,
           ${cappedBudget(sql`p."budgetPrevisionnel"`)} AS budget,
+          -- Subvention attribuée : somme des montants attribués des financements liés au projet.
+          -- Sous-requête (et non JOIN) pour éviter de multiplier les traces si plusieurs financements.
+          (
+            SELECT SUM(${numericGuard(sql`f."montantAttribue"`)})
+            FROM schema_commun_v2.liens_financements_projets lfp
+            JOIN schema_commun_v2.financements f ON f.id = lfp.financement_id
+            WHERE lfp.projet_id = p.id
+          ) AS montant_attribue,
           p.cop_millesime,
           p.cop_statut_vivier,
           -- external_id résolu pour les seules traces MEC ; cast ::uuid réservé à ce cas
@@ -127,6 +164,7 @@ export class TerritoiresService {
       group_agg AS (
         SELECT
           mr.group_key,
+          MAX(mr.cluster_id) AS cluster_id,
           MIN(mr.id) AS min_id,
           bool_and(mr.role = 'financement') AS all_financement,
           jsonb_agg(
@@ -138,6 +176,7 @@ export class TerritoiresService {
               'statut', mr.statut,
               'phase', mr.phase,
               'budgetPrevisionnel', mr.budget,
+              'montantAttribue', mr.montant_attribue,
               'copMillesime', mr.cop_millesime,
               'copStatutVivier', mr.cop_statut_vivier,
               'externalId', mr.external_id
@@ -150,16 +189,34 @@ export class TerritoiresService {
       group_final AS (
         SELECT ga.min_id, ga.all_financement, ga.traces, c.confiance
         FROM group_agg ga
-        LEFT JOIN schema_commun_v2.clusters c ON c.id = ga.group_key
+        LEFT JOIN schema_commun_v2.clusters c ON c.id = ga.cluster_id
+      ),
+      filtered_groups AS (
+        SELECT confiance, traces, min_id
+        FROM group_final
+        WHERE ${inclureFinancementsSeuls ? sql`TRUE` : sql`all_financement = FALSE`}
       )
+    `;
+
+    const rows = await this.query<{ confiance: string | null; traces: unknown; total: string }>(sql`
+      WITH ${cteBody}
       SELECT confiance, traces, count(*) OVER() AS total
-      FROM group_final
-      WHERE ${inclureFinancementsSeuls ? sql`TRUE` : sql`all_financement = FALSE`}
+      FROM filtered_groups
       ORDER BY min_id
       LIMIT ${limit} OFFSET ${offset}
     `);
 
-    const total = rows.length > 0 ? Number(rows[0].total) : 0;
+    let total = rows.length > 0 ? Number(rows[0].total) : 0;
+    // Page vide au-delà du 1er offset : count(*) OVER() ne renvoie aucune ligne,
+    // donc aucun total. On le récupère par un COUNT dédié pour ne pas mentir avec 0.
+    if (rows.length === 0 && offset > 0) {
+      const [countRow] = await this.query<{ total: string }>(sql`
+        WITH ${cteBody}
+        SELECT count(*)::text AS total FROM filtered_groups
+      `);
+      total = Number(countRow?.total ?? 0);
+    }
+
     const groupes: TerritoireGroupeDto[] = rows.map((r) => ({
       confiance: (r.confiance as TerritoireGroupeDto["confiance"]) ?? null,
       traces: (r.traces as TerritoireTraceDto[]) ?? [],
@@ -174,6 +231,7 @@ export class TerritoiresService {
    */
   async planFichesTerritoire(externalId: string): Promise<PlansTerritoireResponse> {
     const projetId = await this.resolveMecProjetId(externalId);
+    await this.assertProjetInSchemaCommun(projetId);
 
     const communeRows = await this.query<{ insee: string }>(sql`
       SELECT insee_com AS insee
@@ -239,34 +297,50 @@ export class TerritoiresService {
       LIMIT 1
     `);
 
+    // external_id orphelin : résout vers un objet absent de schema_commun_v2
+    // (non synchronisé). 404 explicite plutôt qu'un 200 vide indiscernable.
+    if (!row) {
+      throw new NotFoundException(this.orphanMessage(projetId));
+    }
+
     return {
       externalId,
       projetId,
-      leviersSgpe: splitLeviersCsv(row?.leviersSgpe ?? null),
-      llmThematiques: row?.llmThematiques ?? null,
-      llmProbabiliteTe: row?.llmProbabiliteTe != null ? Number(row.llmProbabiliteTe) : null,
-      llmClassifiedAt: this.toIso(row?.llmClassifiedAt ?? null),
+      leviersSgpe: splitLeviersCsv(row.leviersSgpe ?? null),
+      llmThematiques: row.llmThematiques ?? null,
+      llmProbabiliteTe: row.llmProbabiliteTe != null ? Number(row.llmProbabiliteTe) : null,
+      llmClassifiedAt: this.toIso(row.llmClassifiedAt ?? null),
     };
   }
 
   // Résout le code territoire en liste de communes INSEE.
-  // 5 chiffres → commune telle quelle ; 9 chiffres → communes membres de l'EPCI
-  // (404 si aucune) ; autre → 404 (format invalide).
+  // 5 chiffres (ou 2A/2B + 3) → commune ; 9 chiffres → communes membres de l'EPCI.
+  // 404 si commune ou EPCI inconnu du référentiel ; autre format → 404.
   private async resolveCommunes(code: string): Promise<string[]> {
-    if (/^\d{5}$/.test(code)) return [code];
-    if (/^\d{9}$/.test(code)) {
+    // Normalise la casse pour les codes corses (2A/2B stockés en majuscules).
+    const normalized = code.toUpperCase();
+    if (CODE_INSEE_REGEX.test(normalized)) {
+      const rows = await this.query<{ ok: number }>(sql`
+        SELECT 1 AS ok FROM api_referentiel.communes WHERE code_insee = ${normalized} LIMIT 1
+      `);
+      if (rows.length === 0) {
+        throw new NotFoundException(`Commune inconnue au référentiel : ${normalized}`);
+      }
+      return [normalized];
+    }
+    if (SIREN_REGEX.test(normalized)) {
       const rows = await this.query<{ insee: string }>(sql`
         SELECT code_insee_commune AS insee
         FROM api_referentiel.perimetres
-        WHERE siren_groupement = ${code}
+        WHERE siren_groupement = ${normalized}
       `);
       if (rows.length === 0) {
-        throw new NotFoundException(`Aucune commune trouvée pour le territoire ${code}`);
+        throw new NotFoundException(`Aucune commune trouvée pour le territoire ${normalized}`);
       }
       return rows.map((r) => r.insee);
     }
     throw new NotFoundException(
-      `Code territoire invalide : ${code} (attendu : INSEE commune 5 chiffres ou SIREN EPCI 9 chiffres)`,
+      `Code territoire invalide : ${code} (attendu : INSEE commune 5 chiffres / 2A|2B+3, ou SIREN EPCI 9 chiffres)`,
     );
   }
 
@@ -282,6 +356,21 @@ export class TerritoiresService {
       throw new NotFoundException(`Projet MEC inconnu pour l'external_id ${externalId}`);
     }
     return row.objetId;
+  }
+
+  // ~1 053 external_ids MEC pointent vers un objet absent de schema_commun_v2
+  // (non synchronisé). On matérialise ce cas par un 404 explicite.
+  private async assertProjetInSchemaCommun(projetId: string): Promise<void> {
+    const rows = await this.query<{ ok: number }>(sql`
+      SELECT 1 AS ok FROM schema_commun_v2.projets_operationnels WHERE id = ${projetId} LIMIT 1
+    `);
+    if (rows.length === 0) {
+      throw new NotFoundException(this.orphanMessage(projetId));
+    }
+  }
+
+  private orphanMessage(projetId: string): string {
+    return `Projet ${projetId} hors du schéma commun — non synchronisé.`;
   }
 
   private toIso(value: Date | string | null): string | null {

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -243,6 +243,14 @@ export class TerritoiresService {
       return { pcaet: [], fichesActionSuggerees: [] };
     }
 
+    // pcaet_reference est produite par un chantier distinct (T4) et peut ne pas encore
+    // exister en production : on dégrade en liste vide plutôt que de renvoyer un 500
+    // "relation does not exist". Une fois la table créée, l'endpoint sert les données
+    // sans changement de code. (Même esprit que la garde IF EXISTS de la migration.)
+    if (!(await this.pcaetReferenceExists())) {
+      return { pcaet: [], fichesActionSuggerees: [] };
+    }
+
     const pcaetRows = await this.query<{
       nom: string | null;
       sirenPorteur: string | null;
@@ -367,6 +375,15 @@ export class TerritoiresService {
     if (rows.length === 0) {
       throw new NotFoundException(this.orphanMessage(projetId));
     }
+  }
+
+  // La table de référence PCAET est un livrable du chantier T4, déployé indépendamment.
+  // to_regclass renvoie NULL si la relation n'existe pas (lookup catalogue, sans erreur).
+  private async pcaetReferenceExists(): Promise<boolean> {
+    const [row] = await this.query<{ present: boolean }>(
+      sql`SELECT to_regclass('schema_commun_v2.pcaet_reference') IS NOT NULL AS present`,
+    );
+    return row?.present === true;
   }
 
   private orphanMessage(projetId: string): string {

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -1,0 +1,291 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { DatabaseService } from "@database/database.service";
+import { mecExternalIds } from "@database/schema";
+import { and, eq, sql, SQL } from "drizzle-orm";
+import { splitLeviersCsv } from "./leviers-csv";
+import { TerritoireGroupeDto, TerritoireProjetsResponse, TerritoireTraceDto } from "./dto/territoire-projets.dto";
+import { PlansTerritoireResponse } from "./dto/plans-territoire.dto";
+import { QualificationResponse } from "./dto/qualification.dto";
+
+type Row = Record<string, unknown>;
+
+// Sources dont les traces sont des financements (et non des projets) : elles ne
+// suffisent pas, à elles seules, à matérialiser un projet sur le territoire.
+const FINANCEMENT_SOURCES = ["DGCL DETR", "DGCL DSIL", "DGCL DPV", "Fonds Vert"] as const;
+
+// Aligné sur dashboard-te.service : budget prévisionnel plafonné (les valeurs
+// aberrantes deviennent NULL). Le budget est stocké en TEXT dans schema_commun_v2.
+const BUDGET_MAX = 100_000_000;
+const cappedBudget = (col: SQL): SQL =>
+  sql`(CASE WHEN CAST(NULLIF(${col}, '') AS numeric) <= ${BUDGET_MAX} THEN CAST(NULLIF(${col}, '') AS numeric) END)`;
+
+// Tableau text[] bindé (chaque valeur en paramètre, jamais interpolée).
+const textArray = (values: string[]): SQL =>
+  sql`ARRAY[${sql.join(
+    values.map((v) => sql`${v}`),
+    sql`, `,
+  )}]::text[]`;
+
+export interface TerritoireProjetsParams {
+  sources?: string[];
+  copMillesime?: string;
+  statut?: string;
+  limit: number;
+  offset: number;
+  inclureFinancementsSeuls: boolean;
+}
+
+@Injectable()
+export class TerritoiresService {
+  constructor(private readonly dbService: DatabaseService) {}
+
+  private async query<T = Row>(q: ReturnType<typeof sql>): Promise<T[]> {
+    const result = await this.dbService.database.execute(q);
+    return result.rows as T[];
+  }
+
+  /**
+   * Projets de transition écologique d'un territoire, regroupés par cluster de
+   * déduplication. `code` = INSEE commune (5 chiffres) ou SIREN EPCI (9 chiffres).
+   */
+  async territoireProjets(code: string, params: TerritoireProjetsParams): Promise<TerritoireProjetsResponse> {
+    const { sources, copMillesime, statut, limit, offset, inclureFinancementsSeuls } = params;
+    const communes = await this.resolveCommunes(code);
+
+    // Filtres appliqués aux SEULS projets du territoire (avant expansion en cluster
+    // complet — les membres hors territoire du même cluster sont conservés).
+    const filterConditions: SQL[] = [];
+    if (sources && sources.length > 0) {
+      filterConditions.push(sql`p.source_origine = ANY(${textArray(sources)})`);
+    }
+    if (copMillesime) filterConditions.push(sql`p.cop_millesime = ${copMillesime}`);
+    if (statut) filterConditions.push(sql`p.cop_statut_vivier = ${statut}`);
+    let filterWhere: SQL = sql``;
+    for (const cond of filterConditions) filterWhere = sql`${filterWhere} AND ${cond}`;
+
+    // Rôle d'une trace : financement si sa source est une source de financement, sinon projet.
+    const roleExpr = sql`CASE WHEN p.source_origine = ANY(${textArray([...FINANCEMENT_SOURCES])}) THEN 'financement' ELSE 'projet' END`;
+
+    const rows = await this.query<{ confiance: string | null; traces: unknown; total: string }>(sql`
+      WITH territory_pids AS (
+        SELECT DISTINCT lpc.projet_id AS pid
+        FROM schema_commun_v2.liens_projets_communes lpc
+        WHERE lpc.insee_com = ANY(${textArray(communes)})
+      ),
+      filtered_pids AS (
+        SELECT tp.pid
+        FROM territory_pids tp
+        JOIN schema_commun_v2.projets_operationnels p ON p.id = tp.pid
+        WHERE 1 = 1 ${filterWhere}
+      ),
+      -- group_key = cluster_id si le projet appartient à un cluster, sinon son propre id (singleton).
+      projet_group AS (
+        SELECT fp.pid,
+          COALESCE(cm.cluster_id, fp.pid) AS group_key,
+          cm.cluster_id AS cluster_id
+        FROM filtered_pids fp
+        LEFT JOIN schema_commun_v2.clusters_membres cm ON cm.projet_id = fp.pid
+      ),
+      groups AS (
+        SELECT group_key, MAX(cluster_id) AS cluster_id
+        FROM projet_group
+        GROUP BY group_key
+      ),
+      -- Tous les membres du groupe : membres du cluster (même hors territoire) OU le singleton lui-même.
+      group_members AS (
+        SELECT g.group_key, cm.projet_id AS pid
+        FROM groups g
+        JOIN schema_commun_v2.clusters_membres cm ON cm.cluster_id = g.cluster_id
+        WHERE g.cluster_id IS NOT NULL
+        UNION
+        SELECT g.group_key, g.group_key AS pid
+        FROM groups g
+        WHERE g.cluster_id IS NULL
+      ),
+      member_rows AS (
+        SELECT
+          gm.group_key,
+          p.id,
+          ${roleExpr} AS role,
+          p.source_origine AS source,
+          p.nom,
+          p."phaseStatut" AS statut,
+          p.phase,
+          ${cappedBudget(sql`p."budgetPrevisionnel"`)} AS budget,
+          p.cop_millesime,
+          p.cop_statut_vivier,
+          -- external_id résolu pour les seules traces MEC ; cast ::uuid réservé à ce cas
+          -- (certains ids — cop_*, dgcl-* — ne sont pas des UUID).
+          CASE WHEN p.source_origine = 'MEC' THEN (
+            SELECT ext.external_id FROM data_mec.external_ids ext
+            WHERE ext.service_type = 'MEC' AND ext.objet_id = p.id::uuid
+            LIMIT 1
+          ) END AS external_id
+        FROM group_members gm
+        JOIN schema_commun_v2.projets_operationnels p ON p.id = gm.pid
+      ),
+      group_agg AS (
+        SELECT
+          mr.group_key,
+          MIN(mr.id) AS min_id,
+          bool_and(mr.role = 'financement') AS all_financement,
+          jsonb_agg(
+            jsonb_build_object(
+              'role', mr.role,
+              'source', mr.source,
+              'id', mr.id,
+              'nom', mr.nom,
+              'statut', mr.statut,
+              'phase', mr.phase,
+              'budgetPrevisionnel', mr.budget,
+              'copMillesime', mr.cop_millesime,
+              'copStatutVivier', mr.cop_statut_vivier,
+              'externalId', mr.external_id
+            )
+            ORDER BY mr.id
+          ) AS traces
+        FROM member_rows mr
+        GROUP BY mr.group_key
+      ),
+      group_final AS (
+        SELECT ga.min_id, ga.all_financement, ga.traces, c.confiance
+        FROM group_agg ga
+        LEFT JOIN schema_commun_v2.clusters c ON c.id = ga.group_key
+      )
+      SELECT confiance, traces, count(*) OVER() AS total
+      FROM group_final
+      WHERE ${inclureFinancementsSeuls ? sql`TRUE` : sql`all_financement = FALSE`}
+      ORDER BY min_id
+      LIMIT ${limit} OFFSET ${offset}
+    `);
+
+    const total = rows.length > 0 ? Number(rows[0].total) : 0;
+    const groupes: TerritoireGroupeDto[] = rows.map((r) => ({
+      confiance: (r.confiance as TerritoireGroupeDto["confiance"]) ?? null,
+      traces: (r.traces as TerritoireTraceDto[]) ?? [],
+    }));
+
+    return { total, limit, offset, groupes };
+  }
+
+  /**
+   * PCAET couvrant les communes d'un projet MEC (résolu via son external_id).
+   * S'appuie sur schema_commun_v2.pcaet_reference (table créée par le chantier T4).
+   */
+  async planFichesTerritoire(externalId: string): Promise<PlansTerritoireResponse> {
+    const projetId = await this.resolveMecProjetId(externalId);
+
+    const communeRows = await this.query<{ insee: string }>(sql`
+      SELECT insee_com AS insee
+      FROM schema_commun_v2.liens_projets_communes
+      WHERE projet_id = ${projetId}
+    `);
+    const communes = communeRows.map((r) => r.insee);
+    if (communes.length === 0) {
+      return { pcaet: [], fichesActionSuggerees: [] };
+    }
+
+    const pcaetRows = await this.query<{
+      nom: string | null;
+      sirenPorteur: string | null;
+      presentDansTet: boolean;
+      tetExternalId: string | null;
+      source: string | null;
+    }>(sql`
+      SELECT
+        pr.nom,
+        pr.siren_porteur AS "sirenPorteur",
+        (pr.tet_external_id IS NOT NULL) AS "presentDansTet",
+        pr.tet_external_id AS "tetExternalId",
+        pr.source_nom AS source
+      FROM schema_commun_v2.pcaet_reference pr
+      WHERE pr.communes && ${textArray(communes)}
+      ORDER BY pr.nom
+    `);
+
+    return {
+      pcaet: pcaetRows.map((r) => ({
+        nom: r.nom,
+        sirenPorteur: r.sirenPorteur,
+        presentDansTet: r.presentDansTet,
+        tetExternalId: r.tetExternalId ?? null,
+        source: r.source,
+      })),
+      // TODO(T4+): dériver des fiches action suggérées depuis les PCAET rattachés (bonus hors scope immédiat).
+      fichesActionSuggerees: [],
+    };
+  }
+
+  /**
+   * Qualification LLM d'un projet MEC (résolu via son external_id) :
+   * leviers SGPE, thématiques LLM, probabilité TE et date de classification.
+   */
+  async qualification(externalId: string): Promise<QualificationResponse> {
+    const projetId = await this.resolveMecProjetId(externalId);
+
+    const [row] = await this.query<{
+      leviersSgpe: string | null;
+      llmThematiques: unknown;
+      llmProbabiliteTe: number | string | null;
+      llmClassifiedAt: Date | string | null;
+    }>(sql`
+      SELECT
+        "leviersSgpe" AS "leviersSgpe",
+        llm_thematiques AS "llmThematiques",
+        llm_probabilite_te AS "llmProbabiliteTe",
+        llm_classified_at AS "llmClassifiedAt"
+      FROM schema_commun_v2.projets_operationnels
+      WHERE id = ${projetId}
+      LIMIT 1
+    `);
+
+    return {
+      externalId,
+      projetId,
+      leviersSgpe: splitLeviersCsv(row?.leviersSgpe ?? null),
+      llmThematiques: row?.llmThematiques ?? null,
+      llmProbabiliteTe: row?.llmProbabiliteTe != null ? Number(row.llmProbabiliteTe) : null,
+      llmClassifiedAt: this.toIso(row?.llmClassifiedAt ?? null),
+    };
+  }
+
+  // Résout le code territoire en liste de communes INSEE.
+  // 5 chiffres → commune telle quelle ; 9 chiffres → communes membres de l'EPCI
+  // (404 si aucune) ; autre → 404 (format invalide).
+  private async resolveCommunes(code: string): Promise<string[]> {
+    if (/^\d{5}$/.test(code)) return [code];
+    if (/^\d{9}$/.test(code)) {
+      const rows = await this.query<{ insee: string }>(sql`
+        SELECT code_insee_commune AS insee
+        FROM api_referentiel.perimetres
+        WHERE siren_groupement = ${code}
+      `);
+      if (rows.length === 0) {
+        throw new NotFoundException(`Aucune commune trouvée pour le territoire ${code}`);
+      }
+      return rows.map((r) => r.insee);
+    }
+    throw new NotFoundException(
+      `Code territoire invalide : ${code} (attendu : INSEE commune 5 chiffres ou SIREN EPCI 9 chiffres)`,
+    );
+  }
+
+  // Résout un external_id MEC en id de projet stable (data_mec.external_ids). 404 si inconnu.
+  private async resolveMecProjetId(externalId: string): Promise<string> {
+    const [row] = await this.dbService.database
+      .select({ objetId: mecExternalIds.objetId })
+      .from(mecExternalIds)
+      .where(and(eq(mecExternalIds.serviceType, "MEC"), eq(mecExternalIds.externalId, externalId)))
+      .limit(1);
+
+    if (!row) {
+      throw new NotFoundException(`Projet MEC inconnu pour l'external_id ${externalId}`);
+    }
+    return row.objetId;
+  }
+
+  private toIso(value: Date | string | null): string | null {
+    if (value == null) return null;
+    return value instanceof Date ? value.toISOString() : value;
+  }
+}

--- a/api/test/helpers/e2e-global-setup.ts
+++ b/api/test/helpers/e2e-global-setup.ts
@@ -20,6 +20,9 @@ export default async function globalSetup() {
   const DATABASE_URL = "postgres://postgres:mypassword@localhost:5433/e2e_test_db";
   process.env.DATABASE_URL = DATABASE_URL;
   process.env.REDIS_URL = "redis://localhost:6380";
+  // La suite e2e enchaîne >50 requêtes/min depuis une seule IP : depuis la correction du
+  // throttler (ttl en ms), la limite prod ferait des 429 en cascade dans les tests.
+  process.env.THROTTLER_LIMIT = process.env.THROTTLER_LIMIT ?? "10000";
 
   execSync("npm run db:migrate:drizzle", {
     env: {

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -1,0 +1,152 @@
+# Intégration MEC — vue territoriale DDT & décisions
+
+> Public : équipe MEC (Sylvain). Sprint juillet 2026, POC lecture seule + contrat de feedback.
+> Spec machine : [`openapi-territoires-decisions.yaml`](./openapi-territoires-decisions.yaml)
+> (les mêmes endpoints sont aussi dans le Swagger `/api/projets` de l'instance).
+
+## Auth
+
+Comme les autres endpoints : `Authorization: Bearer <MEC_API_KEY>`. La clé identifie la
+plateforme — `POST /decisions` enregistre automatiquement `plateforme_source = MEC`
+(le body ne peut pas se faire passer pour un autre service).
+
+## Stabilité — à lire avant de persister quoi que ce soit
+
+| Donnée | Stabilité |
+|---|---|
+| `traces[].id` (UUID/ID objet) | **Stable et contractuel** — c'est la seule référence à persister côté MEC (et la seule acceptée par `POST /decisions`) |
+| `traces[].externalId` | Stable (c'est votre propre id) |
+| Composition des groupes, `confiance` | **Recalculées à chaque run du pipeline** — ne jamais persister ; c'est pourquoi aucun identifiant de groupe n'est exposé |
+| `copMillesime`, `copStatutVivier`, leviers | Stables entre deux livraisons DREAL/référentiel |
+
+## 1. `GET /territoires/{code}/projets`
+
+`code` = INSEE commune (5 chiffres) ou SIREN EPCI (9 chiffres, résolu en communes membres).
+
+Query params : `sources` (CSV de `source_origine` : `MEC`, `Vivier COP`, `Fonds Vert`, `DGCL DETR`…
+— ⚠ pas de source `TeT` en V1 : les fiches action TeT ne sont pas exposées dans cette vue),
+`copMillesime` (`2024`|`2025`), `copStatutVivier` (`a_remonter`, `a_travailler`,
+`hors_cop_mais_crte`, `non_remonte`), `limit` (1–200, défaut 50), `offset`,
+`inclureFinancementsSeuls` (défaut `false` : les groupes composés uniquement de
+financements DGCL/Fonds Vert sont masqués).
+
+```bash
+curl -H "Authorization: Bearer $MEC_API_KEY" \
+  "$BASE/territoires/80021/projets?sources=Vivier%20COP&copMillesime=2024&limit=5"
+```
+
+Réponse : liste de **groupes**. Un groupe = les traces d'un même projet réel dans les
+différentes sources (regroupement par la déduplication du pipeline).
+
+```json
+{
+  "total": 23, "limit": 5, "offset": 0,
+  "groupes": [
+    {
+      "confiance": "PROBABLE",
+      "traces": [
+        { "role": "projet", "source": "MEC", "id": "019dab93-…", "externalId": "51285",
+          "nom": "…", "statut": "En cours", "phase": "Opération", "budgetPrevisionnel": 150000,
+          "copMillesime": null, "copStatutVivier": null },
+        { "role": "projet", "source": "Vivier COP", "id": "cop_20675265", "externalId": null,
+          "nom": "…", "statut": "En instruction", "copMillesime": "2024", "copStatutVivier": "a_remonter" },
+        { "role": "financement", "source": "DGCL DSIL", "id": "dgcl-…",
+          "budgetPrevisionnel": 1308903, "montantAttribue": 150000 }
+      ]
+    },
+    { "confiance": null, "traces": [ { "role": "projet", "source": "Vivier COP", "…": "…" } ] }
+  ]
+}
+```
+
+**Sémantique UX convenue** :
+- `confiance: "CERTAIN"` → afficher comme **lien établi** entre les traces ;
+- `"PROBABLE"` → afficher comme **suggestion** (à confirmer par l'agent → `POST /decisions`) ;
+- `null` → singleton (une seule trace connue).
+- `role: "financement"` (DGCL DETR/DSIL/DPV, Fonds Vert) : à présenter comme financement
+  du projet du groupe, pas comme un projet distinct. ⚠ `budgetPrevisionnel` = montant **demandé**
+  (coût du dossier) ; `montantAttribue` = subvention réellement attribuée (DGCL uniquement,
+  null pour Fonds Vert).
+- Les filtres sélectionnent les projets **du territoire** ; le groupe renvoyé contient
+  ensuite *toutes* les traces du projet réel, y compris d'autres sources.
+
+## 2. `GET /projets/mec/{externalId}/plans-territoire`
+
+Résout votre `externalId`, renvoie les PCAET couvrant les communes du projet
+(référentiel dédupliqué : un SIREN porteur = un PCAET).
+
+```bash
+curl -H "Authorization: Bearer $MEC_API_KEY" "$BASE/projets/mec/181/plans-territoire"
+```
+
+```json
+{ "pcaet": [ { "nom": "PCAET …", "sirenPorteur": "241700640",
+               "presentDansTet": false, "tetExternalId": null, "source": "opendata" } ],
+  "fichesActionSuggerees": [] }
+```
+
+⚠️ `presentDansTet`/`tetExternalId` : le deep-link TeT n'est possible que pour les plans
+connus de l'API TeT (~1/3 des cas) — prévoir l'affichage sans lien.
+`fichesActionSuggerees` : vide en V1 (bonus à venir).
+
+## 3. `GET /projets/mec/{externalId}/qualification`
+
+Le « GET leviers » : qualification calculée par le pipeline.
+
+```json
+{ "externalId": "51285", "projetId": "019dab95-…",
+  "leviersSgpe": ["Rénovation (hors changement chaudières)"],
+  "llmThematiques": [ { "label": "…", "score": 0.95 } ],
+  "llmProbabiliteTe": 0.9, "llmClassifiedAt": "2026-05-02T…" }
+```
+
+`404` si l'`externalId` est inconnu (projet non encore synchronisé via le webhook).
+
+## 4. `POST /decisions` — le contrat de feedback
+
+Journal **append-only** : chaque validation/infirmation d'un agent (DDT, collectivité)
+est un événement qui **survit aux recalculs du pipeline**. Implémentation côté MEC prévue
+à la rentrée — le contrat est figé dès maintenant.
+
+```bash
+curl -X POST -H "Authorization: Bearer $MEC_API_KEY" -H "Content-Type: application/json" \
+  "$BASE/decisions" -d '{
+    "typeDecision": "lien_confirme",
+    "objetAType": "projet", "objetAId": "019dab93-f4cc-7641-8bd6-3f69a44c49f3",
+    "objetBType": "projet", "objetBId": "cop_20675265",
+    "verdict": "confirme",
+    "auteur": "agent-ddtm-59",
+    "commentaire": "Même projet, confirmé avec la collectivité"
+  }'
+# → 201 { "id": "77b096d7-…", "createdAt": "2026-07-07T…" }
+```
+
+Règles :
+- `objetAId`/`objetBId` = **toujours les `traces[].id`** (jamais un identifiant de groupe,
+  qui n'existe d'ailleurs pas dans l'API) ;
+- `typeDecision` libre mais convenu : `lien_confirme`, `lien_infirme`, `doublon_signale`,
+  `projet_valide`, `projet_obsolete`, `rattachement_pcaet` ;
+- pas de modification/suppression : pour revenir sur une décision, poster un nouvel
+  événement avec `supersedes: "<uuid de la décision révoquée>"` (le pipeline apprendra à les
+  consommer — un lien `infirme` ne sera pas recréé) ;
+- `GET /decisions?objetId=<id>` pour relire les décisions d'un objet — **chaque service ne
+  voit que ses propres décisions** (filtrées sur la plateforme authentifiée).
+
+## Cadrage POC PCAET — 5 EPCI (feature flag côté MEC)
+
+| EPCI | SIREN (= `code` de l'endpoint territoires) |
+|---|---|
+| CU d'Arras | `200033579` |
+| CC de la Haute Saintonge | `200041523` |
+| CA Pornic Agglo Pays de Retz | `200067346` |
+| Nantes Métropole | `244400404` |
+| CA Valenciennes Métropole | `245901160` |
+
+## Limites connues V1
+
+- Vivier COP : Hauts-de-France uniquement (millésimes 2024 atténuation+biodiv, 2025 adaptation) ;
+  ~10 % des lignes portent un rattachement territorial `needs_review` côté pipeline.
+- PCAET : canal TeT-live exclu (bug d'ingestion webhook, issue #497) — couverture actuelle
+  50,7 % des projets MEC.
+- Les groupes reflètent l'état de la déduplication : des doublons intra-MEC (~6 200 connus
+  côté MEC) apparaissent comme des groupes distincts tant qu'ils ne sont pas fusionnés.

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -146,7 +146,9 @@ Règles :
 
 - Vivier COP : Hauts-de-France uniquement (millésimes 2024 atténuation+biodiv, 2025 adaptation) ;
   ~10 % des lignes portent un rattachement territorial `needs_review` côté pipeline.
-- PCAET : canal TeT-live exclu (bug d'ingestion webhook, issue #497) — couverture actuelle
-  50,7 % des projets MEC.
+- PCAET : la table de référence (`pcaet_reference`) est un livrable du chantier T4 déployé
+  séparément ; tant qu'elle n'est pas en production, `plans-territoire` renvoie `pcaet: []`
+  (pas d'erreur — dégradation propre). Couverture cible une fois livrée : 50,7 % des projets
+  MEC. Canal TeT-live exclu (bug d'ingestion webhook, issue #497).
 - Les groupes reflètent l'état de la déduplication : des doublons intra-MEC (~6 200 connus
   côté MEC) apparaissent comme des groupes distincts tant qu'ils ne sont pas fusionnés.

--- a/docs/api/openapi-territoires-decisions.yaml
+++ b/docs/api/openapi-territoires-decisions.yaml
@@ -1,0 +1,198 @@
+openapi: 3.0.3
+info:
+  title: API Projets Collectivités — vue territoriale & décisions
+  description: >
+    Sous-ensemble de l'API communs consommé par MEC (vue territoriale DDT, lecture seule
+    + journal de décisions). Voir INTEGRATION_MEC.md pour la sémantique détaillée.
+    Les identifiants d'objets (`traces[].id`) sont stables et contractuels ; la composition
+    des groupes et la confiance sont recalculées à chaque run du pipeline.
+  version: "1.0.0"
+security:
+  - bearerAuth: []
+paths:
+  /territoires/{code}/projets:
+    get:
+      summary: Projets d'un territoire, regroupés par projet réel (déduplication)
+      parameters:
+        - name: code
+          in: path
+          required: true
+          schema: { type: string, pattern: '^\d{5}$|^\d{9}$' }
+          description: Code INSEE commune (5 chiffres) ou SIREN EPCI (9 chiffres)
+        - name: sources
+          in: query
+          schema: { type: string }
+          description: "Filtre source_origine, CSV (ex. `MEC,Vivier COP`)"
+        - name: copMillesime
+          in: query
+          schema: { type: string, enum: ["2024", "2025"] }
+        - name: copStatutVivier
+          in: query
+          schema: { type: string, enum: [a_remonter, a_travailler, hors_cop_mais_crte, non_remonte] }
+          description: Statut vivier COP
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50, minimum: 1, maximum: 200 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0 }
+        - name: inclureFinancementsSeuls
+          in: query
+          schema: { type: boolean, default: false }
+          description: Inclure les groupes composés uniquement de financements DGCL/Fonds Vert
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  total: { type: integer }
+                  limit: { type: integer }
+                  offset: { type: integer }
+                  groupes:
+                    type: array
+                    items: { $ref: "#/components/schemas/Groupe" }
+          description: Groupes de traces du territoire
+        "404": { description: Territoire inconnu ou code invalide }
+  /projets/mec/{externalId}/plans-territoire:
+    get:
+      summary: PCAET couvrant les communes d'un projet MEC
+      parameters:
+        - name: externalId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pcaet:
+                    type: array
+                    items:
+                      type: object
+                      properties:
+                        nom: { type: string, nullable: true }
+                        sirenPorteur: { type: string }
+                        presentDansTet: { type: boolean }
+                        tetExternalId: { type: string, nullable: true }
+                        source: { type: string, enum: [snapshot, opendata], description: Canal live exclu en V1 (issue #497) }
+                  fichesActionSuggerees:
+                    type: array
+                    items: { type: object }
+                    description: Vide en V1
+          description: PCAET du territoire du projet
+        "404": { description: externalId MEC inconnu }
+  /projets/mec/{externalId}/qualification:
+    get:
+      summary: Qualification pipeline d'un projet MEC (leviers, thématiques, probabilité TE)
+      parameters:
+        - name: externalId
+          in: path
+          required: true
+          schema: { type: string }
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  externalId: { type: string }
+                  projetId: { type: string, description: ID pivot stable }
+                  leviersSgpe:
+                    type: array
+                    items: { type: string }
+                  llmThematiques:
+                    type: array
+                    nullable: true
+                    items:
+                      type: object
+                      properties:
+                        label: { type: string }
+                        score: { type: number }
+                  llmProbabiliteTe: { type: number, nullable: true }
+                  llmClassifiedAt: { type: string, format: date-time, nullable: true }
+          description: Qualification
+        "404": { description: externalId MEC inconnu }
+  /decisions:
+    post:
+      summary: Enregistrer une décision humaine (journal append-only)
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: "#/components/schemas/CreateDecision" }
+      responses:
+        "201":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  id: { type: string, format: uuid }
+                  createdAt: { type: string, format: date-time }
+          description: Décision enregistrée
+        "400": { description: Corps invalide }
+    get:
+      summary: Décisions référençant un objet (audit)
+      parameters:
+        - name: objetId
+          in: query
+          required: true
+          schema: { type: string }
+      responses:
+        "200": { description: "Décisions du service authentifié uniquement (max 100, plus récentes d'abord)" }
+components:
+  securitySchemes:
+    bearerAuth: { type: http, scheme: bearer }
+  schemas:
+    Groupe:
+      type: object
+      description: >
+        Traces d'un même projet réel dans les différentes sources. Aucun identifiant de
+        groupe n'est exposé (les identifiants de clusters sont instables entre deux runs).
+      properties:
+        confiance:
+          type: string
+          nullable: true
+          enum: [CERTAIN, PROBABLE, null]
+          description: CERTAIN = lien établi · PROBABLE = suggestion · null = singleton
+        traces:
+          type: array
+          items: { $ref: "#/components/schemas/Trace" }
+    Trace:
+      type: object
+      properties:
+        role: { type: string, enum: [projet, financement] }
+        source: { type: string, description: "source_origine (MEC, Vivier COP, DGCL DSIL…)" }
+        id: { type: string, description: ID objet STABLE — seule référence à persister }
+        externalId: { type: string, nullable: true, description: Renseigné pour les traces MEC }
+        nom: { type: string, nullable: true }
+        statut: { type: string, nullable: true }
+        phase: { type: string, nullable: true }
+        budgetPrevisionnel: { type: number, nullable: true, description: Montant demandé / coût du dossier }
+        montantAttribue: { type: number, nullable: true, description: Subvention attribuée (traces financement DGCL) }
+        copMillesime: { type: string, nullable: true }
+        copStatutVivier: { type: string, nullable: true }
+    CreateDecision:
+      type: object
+      required: [typeDecision, objetAType, objetAId]
+      properties:
+        typeDecision:
+          type: string
+          description: lien_confirme | lien_infirme | doublon_signale | projet_valide | projet_obsolete | rattachement_pcaet | …
+        objetAType: { type: string, enum: [projet, fiche_action, plan, financement] }
+        objetAId: { type: string, description: ID objet stable (JAMAIS un identifiant de groupe) }
+        objetBType: { type: string, enum: [projet, fiche_action, plan, financement], nullable: true }
+        objetBId: { type: string, nullable: true }
+        verdict: { type: string, nullable: true, description: confirme | infirme | fusionner | … }
+        auteur: { type: string, nullable: true }
+        commentaire: { type: string, nullable: true }
+        payload: { type: object, nullable: true, description: "Max ~10 ko sérialisé" }
+        supersedes: { type: string, format: uuid, nullable: true, description: Décision révoquée par cet événement }
+      description: >
+        plateforme_source n'est PAS dans le corps — elle est dérivée du service authentifié.


### PR DESCRIPTION
## Contexte

Sprint vue territoriale DDT (juillet 2026) : MEC (Sylvain) consomme ces endpoints en lecture pour afficher les projets d'un territoire (dont le Vivier COP HdF ingéré côté pipeline), et poste les retours humains via `POST /decisions`.

## Endpoints

- **GET `/territoires/{code}/projets`** — `code` = INSEE commune ou SIREN EPCI. Groupes de traces d'un même projet réel (regroupement par cluster de déduplication), `role` projet/financement (DGCL/Fonds Vert projetés en financements), `confiance` CERTAIN/PROBABLE/null. Filtres `sources`, `copMillesime`, `statut`, pagination. **Aucun identifiant de groupe exposé** (les cluster_id sont recalculés à chaque run du pipeline).
- **GET `/projets/mec/{externalId}/plans-territoire`** — PCAET couvrant les communes du projet (vue `pcaet_reference`, dédup par SIREN porteur).
- **GET `/projets/mec/{externalId}/qualification`** — leviers SGPE + thématiques LLM + probabilité TE.
- **POST `/decisions`** (+ GET par objet) — journal **append-only** `decisions_humaines.decisions` (migration 0040) : les décisions humaines survivent aux rebuilds du pipeline. `plateforme_source` dérivée du service authentifié.

## Validation

- 18 tests unitaires ; type-check/lint/format OK
- Intégration lecture seule contre la prod : Amiens 62 groupes (23 Vivier COP 2024), CU d'Arras 202 groupes dont 36 Vivier COP, groupes mixtes MEC + DGCL DSIL, plans-territoire 25 ms
- Migration 0040 validée sur Postgres local (chaîne 0000→0040 + INSERT)

## À suivre dans cette PR

- Corrections éventuelles de la revue adversariale en cours (commits supplémentaires)
- `INTEGRATION_MEC.md` + spec OpenAPI (T6)

Réf. : issue #497 (bug webhook TeT plans sans SIREN/communes).