### PR TITLE
test: désactiver le test e2e qualification cassé en CI (#500)

### DIFF
--- a/api/test/qualification.e2e-spec.ts
+++ b/api/test/qualification.e2e-spec.ts
@@ -17,7 +17,10 @@ describe("Qualification (e2e)", () => {
   });
 
   describe("POST /qualification/competences", () => {
-    it("should qualify competences for a valid project", async () => {
+    // TODO(#500) : test cassé — appel LLM réel dans la CI, échoue systématiquement
+    // (6 runs consécutifs le 7/7, y compris sur main pur — canari #499) alors que
+    // l'endpoint répond correctement sur staging. Réactiver après mock/assouplissement.
+    it.skip("should qualify competences for a valid project", async () => {
       const requestBody = {
         nom: "Rénovation énergétique",
         description: "Rénovation du chauffage d'une école primaire avec isolation thermique",


### PR DESCRIPTION
Le test `qualification/competences › should qualify competences for a valid project` échoue systématiquement en CI (6 runs consécutifs le 7/7, **y compris sur main pur** — canari #499) alors que l'endpoint répond correctement sur staging (vérifié par appel direct). Cause environnementale : appel LLM réel dans la CI.

Impact : **bloque tous les déploiements staging** (le job lint-test-typecheck gate le deploy).

Ce PR pose un `it.skip` avec référence à #500 (mock ou assouplissement à faire proprement). Réactivation suivie dans #500.