### PR TITLE
fix: poser THROTTLER_LIMIT avant l'évaluation des imports e2e

### DIFF
--- a/api/test/helpers/e2e-env.ts
+++ b/api/test/helpers/e2e-env.ts
@@ -1,0 +1,5 @@
+// Doit être importé EN PREMIER par e2e-global-setup : les variables d'environnement
+// lues à l'import des modules applicatifs (ex. throttler.config.ts) doivent être posées
+// avant que la chaîne d'imports d'AppModule ne s'évalue. Un simple `process.env.X = …`
+// dans le corps de globalSetup arrive trop tard (hoisting des imports).
+process.env.THROTTLER_LIMIT = process.env.THROTTLER_LIMIT ?? "10000";

--- a/api/test/helpers/e2e-global-setup.ts
+++ b/api/test/helpers/e2e-global-setup.ts
@@ -1,4 +1,5 @@
 import "tsconfig-paths/register";
+import "./e2e-env";
 
 import { Test, TestingModule } from "@nestjs/testing";
 import { INestApplication } from "@nestjs/common";
@@ -20,9 +21,6 @@ export default async function globalSetup() {
   const DATABASE_URL = "postgres://postgres:mypassword@localhost:5433/e2e_test_db";
   process.env.DATABASE_URL = DATABASE_URL;
   process.env.REDIS_URL = "redis://localhost:6380";
-  // La suite e2e enchaîne >50 requêtes/min depuis une seule IP : depuis la correction du
-  // throttler (ttl en ms), la limite prod ferait des 429 en cascade dans les tests.
-  process.env.THROTTLER_LIMIT = process.env.THROTTLER_LIMIT ?? "10000";
 
   execSync("npm run db:migrate:drizzle", {
     env: {


### PR DESCRIPTION
Cause racine des échecs e2e mouvants (#498 → #501 → #502 : qualification/competences, puis le test 401, puis analytics) : depuis la correction du throttler (ttl en ms réellement appliqué, 50 req/min), la suite e2e dépasse la limite ~60 s après le boot — le test en cours à ce moment-là prend un 429, quel que soit le fichier.

Le `THROTTLER_LIMIT=10000` posé dans le corps de globalSetup (#498) était inopérant : `throttlerConfig` est un const évalué **à l'import** d'AppModule, avant le corps de la fonction (hoisting des imports). Fix : module `e2e-env` importé en premier.

NB : la suite qualification reste skippée (#500) — l'échec du canari #499 sur main pur (throttler alors inopérant) montre qu'elle a aussi une fragilité LLM propre.