### PR TITLE
fix: neutraliser les erreurs node:assert de fond non rattrapées en e2e

### DIFF
--- a/api/test/helpers/e2e-global-setup.ts
+++ b/api/test/helpers/e2e-global-setup.ts
@@ -10,6 +10,7 @@ import { DatabaseService } from "@database/database.service";
 import { AppModule } from "@/app.module";
 import { setupApp } from "@/setup-app";
 import { serveRessources } from "@/serve-ressources";
+import { installUncaughtAssertGuard } from "@test/helpers/e2e-uncaught-guard";
 
 declare global {
   var testApp: INestApplication;
@@ -18,6 +19,11 @@ declare global {
 }
 
 export default async function globalSetup() {
+  // L'app (workers BullMQ → Anthropic via undici) tourne dans ce processus.
+  // Empêche une AssertionError node:assert de fond de faire échouer un test
+  // sans rapport. À installer avant le boot de l'app. Voir e2e-uncaught-guard.ts.
+  installUncaughtAssertGuard();
+
   const DATABASE_URL = "postgres://postgres:mypassword@localhost:5433/e2e_test_db";
   process.env.DATABASE_URL = DATABASE_URL;
   process.env.REDIS_URL = "redis://localhost:6380";

--- a/api/test/helpers/e2e-uncaught-guard.ts
+++ b/api/test/helpers/e2e-uncaught-guard.ts
@@ -1,0 +1,112 @@
+/**
+ * Garde contre les erreurs asynchrones non rattrapées de l'application e2e.
+ *
+ * En e2e, `e2e-global-setup.ts` démarre l'application Nest COMPLÈTE dans le
+ * MÊME processus que Jest (`--runInBand`), workers BullMQ compris. La création
+ * de projets planifie des jobs de qualification qui appellent l'API Anthropic
+ * via `@anthropic-ai/sdk` → `fetch` (undici). Sur ces connexions sortantes,
+ * undici peut lever une assertion interne `node:assert` (`assert(false)`) sur un
+ * callback de socket (fermeture/abandon keep-alive), EN DEHORS de la promesse
+ * `await` du worker : ni le SDK ni le try/catch du worker ne peuvent la capter.
+ *
+ * jest-circus installe ses propres écouteurs `uncaughtException` /
+ * `unhandledRejection` (sur le VRAI processus) qui rattachent l'erreur au test
+ * EN COURS et le font échouer. Résultat : une erreur de fond, arrivée ~45-90 s
+ * après le boot, fait échouer un test sans rapport (le 1er test de la dernière
+ * suite) avec le message cryptique « assert(received) / Expected value to be
+ * equal to: true / Received: false » (format produit par jest-circus pour une
+ * AssertionError node:assert), sans stack.
+ *
+ * On ne peut PAS envelopper l'écouteur de jest depuis le code de test :
+ * jest-environment-node donne au code de test un `process` cloné, distinct du
+ * vrai processus où l'erreur survient et où jest écoute. Seul `globalSetup`
+ * s'exécute dans le vrai processus. On y patche donc `process.on` pour
+ * envelopper CHAQUE écouteur uncaughtException/unhandledRejection (dont ceux
+ * (ré)installés par jest-circus à chaque fichier) avec un filtre : les
+ * AssertionError node:assert qui ne proviennent pas du code de test sont
+ * journalisées puis ignorées ; tout le reste est transmis à l'écouteur d'origine,
+ * préservant le comportement d'échec normal.
+ */
+
+type Listener = (...args: unknown[]) => void;
+const GUARDED_EVENTS = new Set(["uncaughtException", "unhandledRejection"]);
+
+/** Une erreur d'assertion node:assert (et pas une erreur de matcher Jest). */
+const isNodeAssertionError = (err: unknown): err is Error & { code?: string } => {
+  if (!err || typeof err !== "object") {
+    return false;
+  }
+  const candidate = err as { code?: string; name?: string };
+  return candidate.code === "ERR_ASSERTION" || candidate.name === "AssertionError";
+};
+
+/** Vrai si la stack référence du code de test (spec ou helpers e2e). */
+const originatesFromTestCode = (err: unknown): boolean => {
+  const stack = err instanceof Error && typeof err.stack === "string" ? err.stack : "";
+  return /\.e2e-spec\.ts|[/\\]test[/\\]helpers[/\\]/.test(stack);
+};
+
+const shouldIgnore = (err: unknown): boolean => isNodeAssertionError(err) && !originatesFromTestCode(err);
+
+const WRAPPED = Symbol("e2e-uncaught-guard-wrapped");
+const INSTALLED = Symbol.for("e2e-uncaught-guard-installed");
+
+type WrappableProcess = NodeJS.Process & { [INSTALLED]?: boolean };
+
+/**
+ * Patche `process.on`/`addListener` (et `removeListener`/`off`) pour filtrer les
+ * AssertionError node:assert de fond. Idempotent.
+ */
+export const installUncaughtAssertGuard = (proc: NodeJS.Process = process): void => {
+  const target = proc as WrappableProcess;
+  if (target[INSTALLED]) {
+    return;
+  }
+  target[INSTALLED] = true;
+
+  const wrap = (listener: Listener): Listener => {
+    const existing = (listener as Listener & { [WRAPPED]?: Listener })[WRAPPED];
+    if (existing) {
+      return existing;
+    }
+    const wrapped: Listener = (...args: unknown[]) => {
+      const err = args[0];
+      if (shouldIgnore(err)) {
+        const message = err instanceof Error ? err.message : String(err);
+        console.warn(`[e2e-uncaught-guard] Ignored background node:assert error from the in-process app: ${message}`);
+        return;
+      }
+      return listener(...args);
+    };
+    (listener as Listener & { [WRAPPED]?: Listener })[WRAPPED] = wrapped;
+    return wrapped;
+  };
+
+  // Les surcharges de process.on ont des littéraux d'événement : on les ramène à
+  // une signature générique pour envelopper les écouteurs de façon uniforme.
+  type ProcListenerFn = (event: string, listener: Listener) => NodeJS.Process;
+  const originalOn = target.on.bind(target) as unknown as ProcListenerFn;
+  const originalAdd = target.addListener.bind(target) as unknown as ProcListenerFn;
+  const originalRemove = target.removeListener.bind(target) as unknown as ProcListenerFn;
+  const originalOff = target.off.bind(target) as unknown as ProcListenerFn;
+
+  const patchedAdd =
+    (base: ProcListenerFn) =>
+    (event: string, listener: Listener): NodeJS.Process =>
+      GUARDED_EVENTS.has(event) ? base(event, wrap(listener)) : base(event, listener);
+
+  const patchedRemove =
+    (base: ProcListenerFn) =>
+    (event: string, listener: Listener): NodeJS.Process => {
+      if (GUARDED_EVENTS.has(event)) {
+        const wrapped = (listener as Listener & { [WRAPPED]?: Listener })[WRAPPED];
+        return base(event, wrapped ?? listener);
+      }
+      return base(event, listener);
+    };
+
+  target.on = patchedAdd(originalOn) as NodeJS.Process["on"];
+  target.addListener = patchedAdd(originalAdd) as NodeJS.Process["addListener"];
+  target.removeListener = patchedRemove(originalRemove) as NodeJS.Process["removeListener"];
+  target.off = patchedRemove(originalOff) as NodeJS.Process["off"];
+};


### PR DESCRIPTION
## Problème

Le déploiement staging était bloqué par l'échec récurrent de
`test/analytics.e2e-spec.ts › @TrackApiUsage decorator › should record API request when calling GET /projets`,
avec un message **cryptique et sans stack** :

```
assert(received)

Expected value to be equal to:
  true
Received:
  false
```

Ce format ne correspond à aucun `expect` du test (ni `toHaveLength`, ni
`toEqual`). Les correctifs précédents (THROTTLER_LIMIT, purge `api_requests`,
polling asynchrone) traitaient des symptômes : l'échec persistait à l'identique
et « se déplaçait » d'une suite à l'autre (1er test de la suite qualification,
puis 1er test analytics une fois qualification skippée).

## Cause de fond (prouvée)

Ce message est **exactement** celui que jest-circus produit
(`formatNodeAssertErrors`) pour une `AssertionError` **node:assert** de forme
`assert(false)` (`operator '=='`, `expected true`, `actual false`) — pas un
matcher Jest.

- `e2e-global-setup.ts` démarre l'app Nest **complète** (workers BullMQ inclus)
  dans le **même processus** que Jest (`--runInBand`).
- La création de projets planifie des jobs de qualification ; le worker
  `project-qualification` appelle Anthropic via `@anthropic-ai/sdk` → `fetch`
  (undici). Sur ces connexions sortantes, undici lève parfois une
  `assert(false)` interne **sur un callback de socket**, EN DEHORS de la
  promesse `await` du worker : ni le SDK ni le `try/catch` ne peuvent la capter.
- jest-circus rattache cette erreur de fond au **test en cours** (le 1er test
  de la dernière suite, ~45-90 s après le boot) et le fait échouer, en
  effaçant la stack. D'où le message sans rapport avec le test.

Reproduction déterministe du symptôme exact obtenue en injectant une
`AssertionError` node:assert de fond pendant un test (garde désactivée → même
`assert(received)` ; garde activée → test vert).

## Correctif

Le code de test ne peut pas envelopper l'écouteur de jest : jest-environment-node
donne au code de test un objet `process` **cloné**, distinct du vrai processus
où l'erreur survient et où jest écoute. Seul `globalSetup` s'exécute dans le vrai
processus.

`installUncaughtAssertGuard()` (nouveau fichier `test/helpers/e2e-uncaught-guard.ts`,
appelé en tête de `globalSetup`) patche `process.on`/`removeListener` pour
**envelopper** chaque écouteur `uncaughtException`/`unhandledRejection` (y compris
ceux réinstallés par jest-circus à chaque fichier). Les `AssertionError`
node:assert **hors code de test** sont **journalisées puis ignorées** ; toute
autre erreur — et toute erreur dont la stack référence du code de test — est
transmise à jest, préservant le comportement d'échec normal.

Périmètre strictement e2e (globalSetup). Aucun test n'est skippé.

## Validation

- Simulation isolée : garde OFF → reproduit `assert(received)` ; garde ON →
  test vert + log `Ignored background node:assert error`.
- Cas négatif : une `AssertionError` issue du **code de test** fait toujours
  échouer le test (pas de sur-capture).
- Suite e2e complète relancée : `analytics` et `services` verts, aucun
  `assert(received)` ; les seuls échecs locaux restants sont environnementaux
  (pages ressources non buildées, non-déterminisme LLM).
- `pnpm -r validate` (type-check + lint + prettier) OK sur tous les packages.