### PR TITLE
fix: neutraliser l'AssertionError undici de fond au bootstrap prod (#507)

### DIFF
--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -11,7 +11,7 @@ import { setupOpendataDoc } from "@/plans-fiches/opendata-doc.setup";
 import { setupDashboardTeDoc } from "@/dashboard-te/dashboard-te-doc.setup";
 import { setupSwaggerHub } from "@/swagger-hub";
 import { serveLandingPages } from "@/landing/landing-pages";
-import { installUncaughtErrorHandlers } from "@/shared/process/uncaught-error-handlers";
+import { handleFatalError, installUncaughtErrorHandlers } from "@/shared/process/uncaught-error-handlers";
 
 async function bootstrap() {
   // Initialize Sentry - this not following their doc here : https://docs.sentry.io/platforms/javascript/guides/nestjs/
@@ -23,8 +23,10 @@ async function bootstrap() {
   });
 
   // Neutralise l'AssertionError node:assert de fond d'undici (issue #507) sans
-  // crasher le process ; laisse crasher tout le reste. À installer après l'init
-  // Sentry pour que la remontée fonctionne.
+  // crasher le process ; toute autre uncaughtException reste fatale (log + flush
+  // Sentry puis exit). À installer après l'init Sentry pour que la remontée
+  // fonctionne. On ne touche PAS aux unhandledRejection (couvertes par le mode
+  // 'warn' de Sentry, comportement prod inchangé).
   installUncaughtErrorHandlers();
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
@@ -42,4 +44,9 @@ async function bootstrap() {
   await app.listen(process.env.PORT ?? 3000);
 }
 
-void bootstrap();
+// Un échec au démarrage ne doit pas laisser un process zombie : on journalise,
+// on flushe Sentry, puis on quitte (fail-fast ciblé sur le boot, sans politique
+// globale sur les rejections).
+bootstrap().catch((error) => {
+  void handleFatalError("bootstrap", error);
+});

--- a/api/src/main.ts
+++ b/api/src/main.ts
@@ -11,6 +11,7 @@ import { setupOpendataDoc } from "@/plans-fiches/opendata-doc.setup";
 import { setupDashboardTeDoc } from "@/dashboard-te/dashboard-te-doc.setup";
 import { setupSwaggerHub } from "@/swagger-hub";
 import { serveLandingPages } from "@/landing/landing-pages";
+import { installUncaughtErrorHandlers } from "@/shared/process/uncaught-error-handlers";
 
 async function bootstrap() {
   // Initialize Sentry - this not following their doc here : https://docs.sentry.io/platforms/javascript/guides/nestjs/
@@ -20,6 +21,11 @@ async function bootstrap() {
     tracesSampleRate: 0.25,
     environment: process.env.SCALINGO_ENV,
   });
+
+  // Neutralise l'AssertionError node:assert de fond d'undici (issue #507) sans
+  // crasher le process ; laisse crasher tout le reste. À installer après l'init
+  // Sentry pour que la remontée fonctionne.
+  installUncaughtErrorHandlers();
 
   const app = await NestFactory.create<NestExpressApplication>(AppModule);
 

--- a/api/src/shared/process/uncaught-error-handlers.spec.ts
+++ b/api/src/shared/process/uncaught-error-handlers.spec.ts
@@ -1,0 +1,101 @@
+import assert, { AssertionError } from "node:assert";
+import {
+  handleUncaughtProcessError,
+  installUncaughtErrorHandlers,
+  UncaughtErrorHandlerDeps,
+} from "@/shared/process/uncaught-error-handlers";
+
+const UNDICI_STACK = [
+  "AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:",
+  "    at makeNetworkError (node:internal/deps/undici/undici:9467:35)",
+].join("\n");
+
+const buildUndiciBackgroundError = (): AssertionError => {
+  try {
+    assert(false);
+    throw new Error("unreachable");
+  } catch (err) {
+    const assertionError = err as AssertionError;
+    assertionError.stack = UNDICI_STACK;
+    return assertionError;
+  }
+};
+
+const buildDeps = (): jest.Mocked<UncaughtErrorHandlerDeps> => ({
+  logger: { error: jest.fn() },
+  captureException: jest.fn(),
+  exit: jest.fn(),
+});
+
+describe("handleUncaughtProcessError", () => {
+  it("journalise + remonte à Sentry mais NE quitte PAS sur l'erreur de fond undici", () => {
+    const deps = buildDeps();
+    const error = buildUndiciBackgroundError();
+
+    handleUncaughtProcessError("uncaughtException", error, deps);
+
+    expect(deps.logger.error).toHaveBeenCalledTimes(1);
+    expect(deps.captureException).toHaveBeenCalledWith(error);
+    expect(deps.exit).not.toHaveBeenCalled();
+  });
+
+  it("traite de la même façon une unhandledRejection undici de fond", () => {
+    const deps = buildDeps();
+    const error = buildUndiciBackgroundError();
+
+    handleUncaughtProcessError("unhandledRejection", error, deps);
+
+    expect(deps.exit).not.toHaveBeenCalled();
+    expect(deps.captureException).toHaveBeenCalledWith(error);
+  });
+
+  it("quitte avec exit(1) sur toute autre erreur (comportement par défaut préservé)", () => {
+    const deps = buildDeps();
+    const error = new Error("état corrompu");
+
+    handleUncaughtProcessError("uncaughtException", error, deps);
+
+    expect(deps.logger.error).toHaveBeenCalledTimes(1);
+    expect(deps.captureException).toHaveBeenCalledWith(error);
+    expect(deps.exit).toHaveBeenCalledWith(1);
+  });
+
+  it("quitte aussi sur une valeur rejetée non-Error", () => {
+    const deps = buildDeps();
+
+    handleUncaughtProcessError("unhandledRejection", "boom", deps);
+
+    expect(deps.exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("installUncaughtErrorHandlers", () => {
+  it("enregistre un handler pour uncaughtException et unhandledRejection", () => {
+    const registered = new Map<string | symbol, (...args: unknown[]) => void>();
+    const onSpy = jest
+      .spyOn(process, "on")
+      .mockImplementation((event: string | symbol, listener: (...args: unknown[]) => void) => {
+        registered.set(event, listener);
+        return process;
+      });
+
+    try {
+      const deps = buildDeps();
+      installUncaughtErrorHandlers(deps);
+
+      expect(registered.has("uncaughtException")).toBe(true);
+      expect(registered.has("unhandledRejection")).toBe(true);
+
+      // Le listener enregistré délègue bien au handler (ici : erreur non-undici → exit).
+      registered.get("uncaughtException")?.(new Error("corrompu"));
+      expect(deps.exit).toHaveBeenCalledWith(1);
+
+      // Et ignore l'erreur de fond undici sans quitter.
+      deps.exit.mockClear();
+      registered.get("unhandledRejection")?.(buildUndiciBackgroundError());
+      expect(deps.exit).not.toHaveBeenCalled();
+    } finally {
+      onSpy.mockRestore();
+    }
+  });
+});

--- a/api/src/shared/process/uncaught-error-handlers.spec.ts
+++ b/api/src/shared/process/uncaught-error-handlers.spec.ts
@@ -1,8 +1,10 @@
 import assert, { AssertionError } from "node:assert";
 import {
-  handleUncaughtProcessError,
+  FORCE_EXIT_TIMEOUT_MS,
+  handleUncaughtException,
   installUncaughtErrorHandlers,
-  UncaughtErrorHandlerDeps,
+  reportFatalAndExit,
+  SENTRY_FLUSH_TIMEOUT_MS,
 } from "@/shared/process/uncaught-error-handlers";
 
 const UNDICI_STACK = [
@@ -21,56 +23,140 @@ const buildUndiciBackgroundError = (): AssertionError => {
   }
 };
 
-const buildDeps = (): jest.Mocked<UncaughtErrorHandlerDeps> => ({
+interface MockedDeps {
+  logger: { error: jest.Mock };
+  captureException: jest.Mock;
+  flush: jest.Mock;
+  exit: jest.Mock;
+}
+
+const buildDeps = (): MockedDeps => ({
   logger: { error: jest.fn() },
   captureException: jest.fn(),
+  flush: jest.fn().mockResolvedValue(true),
   exit: jest.fn(),
 });
 
-describe("handleUncaughtProcessError", () => {
-  it("journalise + remonte à Sentry mais NE quitte PAS sur l'erreur de fond undici", () => {
+const INSTALLED = Symbol.for("api.uncaught-error-handlers.installed");
+const resetInstallGuard = (): void => {
+  delete (process as unknown as Record<symbol, unknown>)[INSTALLED];
+};
+
+describe("handleUncaughtException", () => {
+  it("neutralise l'erreur de fond undici : log + Sentry (warning), sans flush ni exit", async () => {
     const deps = buildDeps();
     const error = buildUndiciBackgroundError();
 
-    handleUncaughtProcessError("uncaughtException", error, deps);
+    await handleUncaughtException(error, deps);
 
     expect(deps.logger.error).toHaveBeenCalledTimes(1);
-    expect(deps.captureException).toHaveBeenCalledWith(error);
+    expect(deps.captureException).toHaveBeenCalledWith(error, "warning");
+    expect(deps.flush).not.toHaveBeenCalled();
     expect(deps.exit).not.toHaveBeenCalled();
   });
 
-  it("traite de la même façon une unhandledRejection undici de fond", () => {
+  it("ne crashe JAMAIS sur le chemin neutralisé, même si le logger lève", async () => {
     const deps = buildDeps();
+    deps.logger.error.mockImplementation(() => {
+      throw new Error("logger down");
+    });
     const error = buildUndiciBackgroundError();
 
-    handleUncaughtProcessError("unhandledRejection", error, deps);
-
+    await expect(handleUncaughtException(error, deps)).resolves.toBeUndefined();
     expect(deps.exit).not.toHaveBeenCalled();
-    expect(deps.captureException).toHaveBeenCalledWith(error);
   });
 
-  it("quitte avec exit(1) sur toute autre erreur (comportement par défaut préservé)", () => {
+  it("quitte avec exit(1) sur toute autre erreur (comportement fatal préservé)", async () => {
     const deps = buildDeps();
     const error = new Error("état corrompu");
 
-    handleUncaughtProcessError("uncaughtException", error, deps);
+    await handleUncaughtException(error, deps);
 
     expect(deps.logger.error).toHaveBeenCalledTimes(1);
-    expect(deps.captureException).toHaveBeenCalledWith(error);
+    expect(deps.captureException).toHaveBeenCalledWith(error, "fatal");
+    expect(deps.exit).toHaveBeenCalledWith(1);
+  });
+});
+
+describe("reportFatalAndExit", () => {
+  it("flushe Sentry AVANT de quitter (exit après résolution du flush)", async () => {
+    const deps = buildDeps();
+    let resolveFlush: (value: boolean) => void = () => undefined;
+    deps.flush.mockReturnValue(
+      new Promise<boolean>((resolve) => {
+        resolveFlush = resolve;
+      }),
+    );
+
+    const pending = reportFatalAndExit("uncaughtException", new Error("boom"), deps);
+    await Promise.resolve();
+
+    expect(deps.flush).toHaveBeenCalledWith(SENTRY_FLUSH_TIMEOUT_MS);
+    expect(deps.exit).not.toHaveBeenCalled();
+
+    resolveFlush(true);
+    await pending;
+
+    expect(deps.exit).toHaveBeenCalledTimes(1);
     expect(deps.exit).toHaveBeenCalledWith(1);
   });
 
-  it("quitte aussi sur une valeur rejetée non-Error", () => {
-    const deps = buildDeps();
+  it("force la sortie via le garde-fou si le flush pend indéfiniment", async () => {
+    jest.useFakeTimers();
+    try {
+      const deps = buildDeps();
+      deps.flush.mockReturnValue(new Promise<boolean>(() => undefined));
 
-    handleUncaughtProcessError("unhandledRejection", "boom", deps);
+      void reportFatalAndExit("uncaughtException", new Error("boom"), deps);
+      await Promise.resolve();
+
+      expect(deps.exit).not.toHaveBeenCalled();
+
+      jest.advanceTimersByTime(FORCE_EXIT_TIMEOUT_MS);
+
+      expect(deps.exit).toHaveBeenCalledWith(1);
+    } finally {
+      jest.useRealTimers();
+    }
+  });
+
+  it("quitte même si le flush rejette", async () => {
+    const deps = buildDeps();
+    deps.flush.mockRejectedValue(new Error("transport down"));
+
+    await reportFatalAndExit("uncaughtException", new Error("boom"), deps);
 
     expect(deps.exit).toHaveBeenCalledWith(1);
   });
 });
 
 describe("installUncaughtErrorHandlers", () => {
-  it("enregistre un handler pour uncaughtException et unhandledRejection", () => {
+  beforeEach(resetInstallGuard);
+  afterEach(resetInstallGuard);
+
+  it("enregistre un seul handler uncaughtException, même en cas de double appel (idempotent)", () => {
+    const registered = new Map<string | symbol, (...args: unknown[]) => void>();
+    const onSpy = jest
+      .spyOn(process, "on")
+      .mockImplementation((event: string | symbol, listener: (...args: unknown[]) => void) => {
+        registered.set(event, listener);
+        return process;
+      });
+
+    try {
+      const deps = buildDeps();
+      installUncaughtErrorHandlers(deps);
+      installUncaughtErrorHandlers(deps);
+
+      const uncaughtRegistrations = onSpy.mock.calls.filter(([event]) => event === "uncaughtException");
+      expect(uncaughtRegistrations).toHaveLength(1);
+      expect(registered.has("unhandledRejection")).toBe(false);
+    } finally {
+      onSpy.mockRestore();
+    }
+  });
+
+  it("le listener enregistré délègue au handler (erreur de fond undici → pas d'exit)", async () => {
     const registered = new Map<string | symbol, (...args: unknown[]) => void>();
     const onSpy = jest
       .spyOn(process, "on")
@@ -83,17 +169,14 @@ describe("installUncaughtErrorHandlers", () => {
       const deps = buildDeps();
       installUncaughtErrorHandlers(deps);
 
-      expect(registered.has("uncaughtException")).toBe(true);
-      expect(registered.has("unhandledRejection")).toBe(true);
+      const listener = registered.get("uncaughtException");
+      expect(listener).toBeDefined();
 
-      // Le listener enregistré délègue bien au handler (ici : erreur non-undici → exit).
-      registered.get("uncaughtException")?.(new Error("corrompu"));
-      expect(deps.exit).toHaveBeenCalledWith(1);
+      listener?.(buildUndiciBackgroundError());
+      await Promise.resolve();
 
-      // Et ignore l'erreur de fond undici sans quitter.
-      deps.exit.mockClear();
-      registered.get("unhandledRejection")?.(buildUndiciBackgroundError());
       expect(deps.exit).not.toHaveBeenCalled();
+      expect(deps.captureException).toHaveBeenCalledWith(expect.any(AssertionError), "warning");
     } finally {
       onSpy.mockRestore();
     }

--- a/api/src/shared/process/uncaught-error-handlers.ts
+++ b/api/src/shared/process/uncaught-error-handlers.ts
@@ -1,0 +1,73 @@
+import * as Sentry from "@sentry/node";
+import { CustomLogger } from "@/logging/logger.service";
+import { isBackgroundAssertionError } from "@/shared/utils/is-background-assertion-error";
+
+type ProcessErrorKind = "uncaughtException" | "unhandledRejection";
+
+/**
+ * Dépendances injectables du handler, pour le tester sans toucher au vrai
+ * `process` ni à Sentry.
+ */
+export interface UncaughtErrorHandlerDeps {
+  logger: Pick<CustomLogger, "error">;
+  captureException: (error: unknown) => void;
+  exit: (code: number) => void;
+}
+
+const buildDefaultDeps = (): UncaughtErrorHandlerDeps => ({
+  logger: new CustomLogger(),
+  captureException: (error) => {
+    Sentry.captureException(error);
+  },
+  exit: (code) => {
+    process.exit(code);
+  },
+});
+
+/**
+ * Handler global des erreurs non rattrapées (issue #507).
+ *
+ * SI l'erreur correspond à la signature étroite de l'AssertionError de fond
+ * d'undici (voir {@link isBackgroundAssertionError}) : on la journalise + on la
+ * remonte à Sentry, et on NE crashe PAS — c'est une erreur réseau de fond, sans
+ * lien avec l'état applicatif.
+ *
+ * SINON : on préserve le comportement par défaut de Node (terminaison). Dans un
+ * handler `uncaughtException`, enregistrer un écouteur SUPPRIME l'arrêt
+ * automatique du process ; on le rétablit donc EXPLICITEMENT via `exit(1)`
+ * (après journalisation + Sentry) pour ne jamais transformer silencieusement une
+ * vraie erreur d'état corrompu en process zombie.
+ */
+export const handleUncaughtProcessError = (
+  kind: ProcessErrorKind,
+  error: unknown,
+  deps: UncaughtErrorHandlerDeps,
+): void => {
+  if (isBackgroundAssertionError(error)) {
+    deps.logger.error(`Erreur node:assert de fond undici ignorée (${kind}), le process reste vivant`, {
+      errorName: error.name,
+      errorMessage: error.message,
+    });
+    deps.captureException(error);
+    return;
+  }
+
+  deps.logger.error(`${kind} fatale, arrêt du process`, {
+    error: error instanceof Error ? (error.stack ?? error.message) : String(error),
+  });
+  deps.captureException(error);
+  deps.exit(1);
+};
+
+/**
+ * Enregistre les handlers `uncaughtException` / `unhandledRejection` sur le
+ * process. À appeler une fois au bootstrap, après l'init Sentry.
+ */
+export const installUncaughtErrorHandlers = (deps: UncaughtErrorHandlerDeps = buildDefaultDeps()): void => {
+  process.on("uncaughtException", (error) => {
+    handleUncaughtProcessError("uncaughtException", error, deps);
+  });
+  process.on("unhandledRejection", (reason) => {
+    handleUncaughtProcessError("unhandledRejection", reason, deps);
+  });
+};

--- a/api/src/shared/process/uncaught-error-handlers.ts
+++ b/api/src/shared/process/uncaught-error-handlers.ts
@@ -2,7 +2,13 @@ import * as Sentry from "@sentry/node";
 import { CustomLogger } from "@/logging/logger.service";
 import { isBackgroundAssertionError } from "@/shared/utils/is-background-assertion-error";
 
-type ProcessErrorKind = "uncaughtException" | "unhandledRejection";
+/** Niveau Sentry utilisé selon que l'erreur est neutralisée ou fatale. */
+type CaptureLevel = "fatal" | "warning";
+
+/** Délai laissé au transport Sentry pour partir avant la sortie (ms). */
+export const SENTRY_FLUSH_TIMEOUT_MS = 2000;
+/** Garde-fou : sortie forcée si le flush pend au-delà de ce délai (ms). */
+export const FORCE_EXIT_TIMEOUT_MS = 2500;
 
 /**
  * Dépendances injectables du handler, pour le tester sans toucher au vrai
@@ -10,64 +16,133 @@ type ProcessErrorKind = "uncaughtException" | "unhandledRejection";
  */
 export interface UncaughtErrorHandlerDeps {
   logger: Pick<CustomLogger, "error">;
-  captureException: (error: unknown) => void;
+  captureException: (error: unknown, level: CaptureLevel) => void;
+  flush: (timeoutMs: number) => Promise<boolean>;
   exit: (code: number) => void;
 }
 
 const buildDefaultDeps = (): UncaughtErrorHandlerDeps => ({
   logger: new CustomLogger(),
-  captureException: (error) => {
-    Sentry.captureException(error);
+  captureException: (error, level) => {
+    Sentry.captureException(error, { level });
   },
+  flush: (timeoutMs) => Sentry.flush(timeoutMs),
   exit: (code) => {
     process.exit(code);
   },
 });
 
 /**
- * Handler global des erreurs non rattrapées (issue #507).
- *
- * SI l'erreur correspond à la signature étroite de l'AssertionError de fond
- * d'undici (voir {@link isBackgroundAssertionError}) : on la journalise + on la
- * remonte à Sentry, et on NE crashe PAS — c'est une erreur réseau de fond, sans
- * lien avec l'état applicatif.
- *
- * SINON : on préserve le comportement par défaut de Node (terminaison). Dans un
- * handler `uncaughtException`, enregistrer un écouteur SUPPRIME l'arrêt
- * automatique du process ; on le rétablit donc EXPLICITEMENT via `exit(1)`
- * (après journalisation + Sentry) pour ne jamais transformer silencieusement une
- * vraie erreur d'état corrompu en process zombie.
+ * Journalise + remonte à Sentry l'AssertionError de fond d'undici (issue #507)
+ * SANS crasher. Ne DOIT jamais lever : neutraliser cette erreur de fond ne peut
+ * pas, à son tour, tuer le process (sinon on réintroduit le crash qu'on corrige).
  */
-export const handleUncaughtProcessError = (
-  kind: ProcessErrorKind,
-  error: unknown,
-  deps: UncaughtErrorHandlerDeps,
-): void => {
-  if (isBackgroundAssertionError(error)) {
-    deps.logger.error(`Erreur node:assert de fond undici ignorée (${kind}), le process reste vivant`, {
+const swallowBackgroundAssertion = (error: Error, deps: UncaughtErrorHandlerDeps): void => {
+  try {
+    deps.logger.error("Erreur node:assert de fond undici neutralisée (uncaughtException), process maintenu vivant", {
       errorName: error.name,
       errorMessage: error.message,
+      stack: error.stack,
     });
-    deps.captureException(error);
-    return;
+    deps.captureException(error, "warning");
+  } catch {
+    // Volontairement avalé : la neutralisation ne doit jamais crasher.
   }
-
-  deps.logger.error(`${kind} fatale, arrêt du process`, {
-    error: error instanceof Error ? (error.stack ?? error.message) : String(error),
-  });
-  deps.captureException(error);
-  deps.exit(1);
 };
 
 /**
- * Enregistre les handlers `uncaughtException` / `unhandledRejection` sur le
- * process. À appeler une fois au bootstrap, après l'init Sentry.
+ * Chemin fatal : journalise + remonte à Sentry, PUIS quitte avec `exit(1)` —
+ * mais seulement APRÈS avoir laissé le transport Sentry vider sa file (`flush`),
+ * sinon l'événement du crash est perdu. Un garde-fou force la sortie si le flush
+ * pend, pour ne jamais laisser de process zombie.
+ *
+ * Réutilisé au bootstrap (échec de `bootstrap()`), d'où le paramètre `context`.
+ */
+export const reportFatalAndExit = async (
+  context: string,
+  error: unknown,
+  deps: UncaughtErrorHandlerDeps,
+): Promise<void> => {
+  try {
+    deps.logger.error(`${context} fatale, arrêt du process après flush Sentry`, {
+      error: error instanceof Error ? (error.stack ?? error.message) : String(error),
+    });
+    deps.captureException(error, "fatal");
+  } catch {
+    // Même si la journalisation/remontée échoue, on doit tout de même sortir.
+  }
+
+  let exited = false;
+  const exitOnce = (): void => {
+    if (exited) {
+      return;
+    }
+    exited = true;
+    deps.exit(1);
+  };
+
+  const forceExit = setTimeout(exitOnce, FORCE_EXIT_TIMEOUT_MS);
+  if (typeof forceExit.unref === "function") {
+    forceExit.unref();
+  }
+
+  try {
+    await deps.flush(SENTRY_FLUSH_TIMEOUT_MS);
+  } catch {
+    // Flush en échec : on sort quand même.
+  } finally {
+    clearTimeout(forceExit);
+    exitOnce();
+  }
+};
+
+/**
+ * Handler global des `uncaughtException` (issue #507).
+ *
+ * SI l'erreur est l'AssertionError de fond d'undici → on la neutralise (log +
+ * Sentry), le process reste vivant. SINON → comportement fatal préservé : un
+ * écouteur `uncaughtException` supprime l'arrêt automatique de Node, on le
+ * rétablit EXPLICITEMENT via `reportFatalAndExit` (flush Sentry puis `exit(1)`)
+ * pour ne jamais transformer une vraie erreur d'état corrompu en process zombie.
+ *
+ * On ne gère PAS `unhandledRejection` : l'intégration Sentry (mode 'warn' par
+ * défaut) journalise + capture déjà les rejections sans crasher, et l'assert
+ * undici de #507 remonte par `uncaughtException` (levé hors promesse). Passer
+ * les rejections en `exit(1)` durcirait la politique prod actuelle (warn) et
+ * transformerait un incident transitoire (ex. insert analytics fire-and-forget)
+ * en crash-loop : hors périmètre, à traiter dans une PR dédiée.
+ */
+export const handleUncaughtException = async (error: unknown, deps: UncaughtErrorHandlerDeps): Promise<void> => {
+  if (isBackgroundAssertionError(error)) {
+    swallowBackgroundAssertion(error, deps);
+    return;
+  }
+  await reportFatalAndExit("uncaughtException", error, deps);
+};
+
+const INSTALLED = Symbol.for("api.uncaught-error-handlers.installed");
+type GuardedProcess = NodeJS.Process & { [INSTALLED]?: boolean };
+
+/**
+ * Enregistre le handler `uncaughtException` sur le process. Idempotent. À
+ * appeler une fois au bootstrap, après l'init Sentry.
  */
 export const installUncaughtErrorHandlers = (deps: UncaughtErrorHandlerDeps = buildDefaultDeps()): void => {
+  const target = process as GuardedProcess;
+  if (target[INSTALLED]) {
+    return;
+  }
+  target[INSTALLED] = true;
+
   process.on("uncaughtException", (error) => {
-    handleUncaughtProcessError("uncaughtException", error, deps);
-  });
-  process.on("unhandledRejection", (reason) => {
-    handleUncaughtProcessError("unhandledRejection", reason, deps);
+    void handleUncaughtException(error, deps);
   });
 };
+
+/**
+ * Journalise + flush Sentry + `exit(1)` sur un échec fatal, avec les
+ * dépendances réelles. Utilisé pour l'échec de `bootstrap()` (on ne peut pas
+ * rester en zombie), sans installer de politique globale sur les rejections.
+ */
+export const handleFatalError = (context: string, error: unknown): Promise<void> =>
+  reportFatalAndExit(context, error, buildDefaultDeps());

--- a/api/src/shared/utils/is-background-assertion-error.spec.ts
+++ b/api/src/shared/utils/is-background-assertion-error.spec.ts
@@ -53,6 +53,26 @@ describe("isBackgroundAssertionError", () => {
     expect(isBackgroundAssertionError(testAssertion)).toBe(false);
   });
 
+  it("ne matche PAS un assert(false) levé par du code tiers dont la stack ne TRAVERSE undici qu'après la 1re frame", () => {
+    // Cas d'un subscriber diagnostics_channel (ex. instrumentation fetch Sentry)
+    // qui `assert(false)` : la 1re frame est le subscriber, undici n'apparaît que
+    // dans les frames du publisher plus bas → ne doit PAS être avalé.
+    let subscriberAssertion: AssertionError | undefined;
+    try {
+      assert(false);
+    } catch (err) {
+      subscriberAssertion = err as AssertionError;
+      subscriberAssertion.stack = [
+        "AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:",
+        "    at Object.subscriber (/home/app/instrumentation.js:12:5)",
+        "    at Channel.publish (node:diagnostics_channel:150:12)",
+        "    at Request.onHeaders (node:internal/deps/undici/undici:8123:20)",
+      ].join("\n");
+    }
+
+    expect(isBackgroundAssertionError(subscriberAssertion)).toBe(false);
+  });
+
   it("ne matche PAS un assert(x, message) applicatif (generatedMessage=false)", () => {
     let customMessageError: AssertionError | undefined;
     try {

--- a/api/src/shared/utils/is-background-assertion-error.spec.ts
+++ b/api/src/shared/utils/is-background-assertion-error.spec.ts
@@ -1,0 +1,97 @@
+import assert, { AssertionError } from "node:assert";
+import { isBackgroundAssertionError } from "@/shared/utils/is-background-assertion-error";
+
+const UNDICI_STACK = [
+  "AssertionError [ERR_ASSERTION]: The expression evaluated to a falsy value:",
+  "    at makeNetworkError (node:internal/deps/undici/undici:9467:35)",
+  "    at Object.onConnect (node:internal/deps/undici/undici:10693:20)",
+].join("\n");
+
+/** Reproduit l'erreur réelle : `assert(false)` interne d'undici sur un socket. */
+const buildUndiciBackgroundError = (): AssertionError => {
+  try {
+    assert(false);
+    throw new Error("unreachable");
+  } catch (err) {
+    const assertionError = err as AssertionError;
+    // La vraie erreur est levée dans le code d'undici : on force une stack qui
+    // référence undici (le `fetch` intégré expose ces frames).
+    assertionError.stack = UNDICI_STACK;
+    return assertionError;
+  }
+};
+
+describe("isBackgroundAssertionError", () => {
+  it("matche l'AssertionError node:assert de fond d'undici (signature exacte)", () => {
+    expect(isBackgroundAssertionError(buildUndiciBackgroundError())).toBe(true);
+  });
+
+  it("matche via le repli code+name quand instanceof échoue (undici d'un autre realm)", () => {
+    const crossRealm = {
+      name: "AssertionError",
+      code: "ERR_ASSERTION",
+      operator: "==",
+      expected: true,
+      actual: false,
+      generatedMessage: true,
+      message: "The expression evaluated to a falsy value:",
+      stack: UNDICI_STACK,
+    };
+
+    expect(isBackgroundAssertionError(crossRealm)).toBe(true);
+  });
+
+  it("ne matche PAS une AssertionError node:assert issue du code de test (stack sans undici)", () => {
+    // Un `assert(false)` d'un test a la même signature mais une stack de test.
+    let testAssertion: AssertionError | undefined;
+    try {
+      assert(false);
+    } catch (err) {
+      testAssertion = err as AssertionError;
+    }
+
+    expect(isBackgroundAssertionError(testAssertion)).toBe(false);
+  });
+
+  it("ne matche PAS un assert(x, message) applicatif (generatedMessage=false)", () => {
+    let customMessageError: AssertionError | undefined;
+    try {
+      assert(false, "règle métier violée");
+    } catch (err) {
+      customMessageError = err as AssertionError;
+      customMessageError.stack = UNDICI_STACK;
+    }
+
+    expect(isBackgroundAssertionError(customMessageError)).toBe(false);
+  });
+
+  it("ne matche PAS un assert.strictEqual (operator/expected différents)", () => {
+    let strictEqualError: AssertionError | undefined;
+    try {
+      assert.strictEqual(1, 2);
+    } catch (err) {
+      strictEqualError = err as AssertionError;
+      strictEqualError.stack = UNDICI_STACK;
+    }
+
+    expect(isBackgroundAssertionError(strictEqualError)).toBe(false);
+  });
+
+  it("ne matche PAS une TypeError", () => {
+    const typeError = new TypeError("Cannot read properties of undefined");
+    typeError.stack = UNDICI_STACK;
+
+    expect(isBackgroundAssertionError(typeError)).toBe(false);
+  });
+
+  it("ne matche PAS une Error générique", () => {
+    expect(isBackgroundAssertionError(new Error("boom"))).toBe(false);
+  });
+
+  it("ne matche PAS les valeurs non-Error", () => {
+    expect(isBackgroundAssertionError(null)).toBe(false);
+    expect(isBackgroundAssertionError(undefined)).toBe(false);
+    expect(isBackgroundAssertionError("The expression evaluated to a falsy value")).toBe(false);
+    expect(isBackgroundAssertionError(42)).toBe(false);
+  });
+});

--- a/api/src/shared/utils/is-background-assertion-error.ts
+++ b/api/src/shared/utils/is-background-assertion-error.ts
@@ -1,0 +1,63 @@
+import { AssertionError } from "node:assert";
+
+/**
+ * Discrimine l'AssertionError `node:assert` de fond levée par undici que l'on
+ * peut ignorer sans crasher le process.
+ *
+ * Contexte (issue #507) : les connexions sortantes du SDK Anthropic passent par
+ * le `fetch` intégré de Node (undici). Sur un callback de socket (fermeture /
+ * abandon d'un keep-alive), undici lève parfois une assertion interne
+ * `assert(<falsy>)` EN DEHORS de toute promesse `await` : ni le SDK ni le
+ * try/catch des workers BullMQ ne peuvent la capter, elle remonte donc en
+ * `uncaughtException`.
+ *
+ * Le prédicat est VOLONTAIREMENT ÉTROIT. Il ne matche que la signature exacte de
+ * ce `assert(<falsy>)` auto-généré :
+ *  - instance d'`AssertionError` `node:assert` (avec repli code+name pour couvrir
+ *    un éventuel undici bundlé dans un autre realm où `instanceof` échouerait) ;
+ *  - `operator === "=="` (comparaison implicite d'`assert.ok`) ;
+ *  - `expected === true` (undici teste une condition « vérité ») ;
+ *  - `generatedMessage === true` (message auto-généré, pas un `assert(x, "…")`
+ *    applicatif porteur d'une intention métier) ;
+ *  - stack référençant undici (le `fetch` intégré expose des frames
+ *    `node:internal/deps/undici/undici`), pour cibler spécifiquement l'origine
+ *    réseau et laisser crasher une éventuelle assertion d'un autre code.
+ *
+ * Tout ce qui ne correspond pas EXACTEMENT à cette signature doit continuer à
+ * crasher (état potentiellement corrompu). Le code applicatif de ce dépôt
+ * n'utilise pas `node:assert`, donc une AssertionError node:assert légitime ne
+ * peut venir que d'une dépendance ; on ne neutralise que celle, identifiée,
+ * d'undici.
+ */
+export const isBackgroundAssertionError = (error: unknown): error is AssertionError => {
+  if (!isNodeAssertionError(error)) {
+    return false;
+  }
+
+  const candidate = error as AssertionError & { generatedMessage?: boolean };
+  const hasUndiciAssertSignature =
+    candidate.operator === "==" && candidate.expected === true && candidate.generatedMessage === true;
+
+  return hasUndiciAssertSignature && originatesFromUndici(candidate);
+};
+
+/**
+ * Vrai si l'erreur est une AssertionError `node:assert`. Le repli `code`/`name`
+ * couvre les cas où `instanceof` échoue (undici chargé dans un autre realm).
+ */
+const isNodeAssertionError = (error: unknown): error is AssertionError => {
+  if (error instanceof AssertionError) {
+    return true;
+  }
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+  const candidate = error as { code?: unknown; name?: unknown };
+  return candidate.code === "ERR_ASSERTION" && candidate.name === "AssertionError";
+};
+
+/** Vrai si la stack référence undici (origine réseau du `fetch` intégré). */
+const originatesFromUndici = (error: Error): boolean => {
+  const stack = typeof error.stack === "string" ? error.stack : "";
+  return /undici/i.test(stack);
+};

--- a/api/src/shared/utils/is-background-assertion-error.ts
+++ b/api/src/shared/utils/is-background-assertion-error.ts
@@ -56,8 +56,22 @@ const isNodeAssertionError = (error: unknown): error is AssertionError => {
   return candidate.code === "ERR_ASSERTION" && candidate.name === "AssertionError";
 };
 
-/** Vrai si la stack référence undici (origine réseau du `fetch` intégré). */
+/**
+ * Vrai si l'erreur a été LEVÉE dans undici (le `fetch` intégré de Node, exposé
+ * sous `node:internal/deps/undici`, ou un `node_modules/undici` bundlé).
+ *
+ * On exige que la PREMIÈRE frame d'appel de la stack soit dans undici, et non
+ * une simple présence d'undici n'importe où : sinon un `assert(<falsy>)` levé
+ * par du code tiers abonné aux canaux `diagnostics_channel` d'undici (ex.
+ * l'instrumentation fetch de Sentry) hériterait des frames undici du publisher
+ * et serait avalé à tort. La vraie erreur #507 est levée DANS ces frames, sa
+ * première frame est donc bien undici.
+ */
 const originatesFromUndici = (error: Error): boolean => {
   const stack = typeof error.stack === "string" ? error.stack : "";
-  return /undici/i.test(stack);
+  const firstFrame = stack.split("\n").find((line) => /^\s*at\s/.test(line));
+  if (!firstFrame) {
+    return false;
+  }
+  return /node:internal[/\\]deps[/\\]undici|[/\\]node_modules[/\\]undici[/\\]/.test(firstFrame);
 };

--- a/api/test/helpers/e2e-uncaught-guard.ts
+++ b/api/test/helpers/e2e-uncaught-guard.ts
@@ -23,22 +23,21 @@
  * s'exécute dans le vrai processus. On y patche donc `process.on` pour
  * envelopper CHAQUE écouteur uncaughtException/unhandledRejection (dont ceux
  * (ré)installés par jest-circus à chaque fichier) avec un filtre : les
- * AssertionError node:assert qui ne proviennent pas du code de test sont
- * journalisées puis ignorées ; tout le reste est transmis à l'écouteur d'origine,
- * préservant le comportement d'échec normal.
+ * AssertionError node:assert de fond d'undici (même signature qu'en prod, voir
+ * `isBackgroundAssertionError`) qui ne proviennent pas du code de test sont
+ * journalisées puis ignorées ; tout le reste est transmis à l'écouteur
+ * d'origine, préservant le comportement d'échec normal.
+ *
+ * La signature de l'erreur est définie UNE seule fois, côté application
+ * (`src/shared/utils/is-background-assertion-error.ts`), et partagée ici : le
+ * handler de prod (issue #507) et cette garde e2e reconnaissent exactement la
+ * même erreur.
  */
+
+import { isBackgroundAssertionError } from "@/shared/utils/is-background-assertion-error";
 
 type Listener = (...args: unknown[]) => void;
 const GUARDED_EVENTS = new Set(["uncaughtException", "unhandledRejection"]);
-
-/** Une erreur d'assertion node:assert (et pas une erreur de matcher Jest). */
-const isNodeAssertionError = (err: unknown): err is Error & { code?: string } => {
-  if (!err || typeof err !== "object") {
-    return false;
-  }
-  const candidate = err as { code?: string; name?: string };
-  return candidate.code === "ERR_ASSERTION" || candidate.name === "AssertionError";
-};
 
 /** Vrai si la stack référence du code de test (spec ou helpers e2e). */
 const originatesFromTestCode = (err: unknown): boolean => {
@@ -46,7 +45,7 @@ const originatesFromTestCode = (err: unknown): boolean => {
   return /\.e2e-spec\.ts|[/\\]test[/\\]helpers[/\\]/.test(stack);
 };
 
-const shouldIgnore = (err: unknown): boolean => isNodeAssertionError(err) && !originatesFromTestCode(err);
+const shouldIgnore = (err: unknown): boolean => isBackgroundAssertionError(err) && !originatesFromTestCode(err);
 
 const WRAPPED = Symbol("e2e-uncaught-guard-wrapped");
 const INSTALLED = Symbol.for("e2e-uncaught-guard-installed");


### PR DESCRIPTION
## Contexte

Closes #507. Suite de #506 (qui neutralisait le symptôme côté e2e), on traite ici la cause en **prod**.

Les connexions sortantes du SDK Anthropic passent par le `fetch` intégré de Node (undici). Sur un callback de socket (fermeture / abandon d'un keep-alive), undici lève parfois une assertion interne `assert(<falsy>)` **en dehors de toute promesse `await`** : ni le SDK ni le try/catch des workers BullMQ de qualification ne peuvent la capter. En prod, elle remonte donc en `uncaughtException` **sans handler → crash du process API**.

Signature réelle observée en CI (run 28880861387) : `The expression evaluated to a falsy value:` — c'est-à-dire un `assert(false)` auto-généré, levé DANS les frames undici.

## Ce que fait la PR

- **Prédicat partagé** `src/shared/utils/is-background-assertion-error.ts` : reconnaît **UNIQUEMENT** cette erreur, signature volontairement **étroite** :
  - instance d'`AssertionError` `node:assert` (repli `code === "ERR_ASSERTION"` + `name === "AssertionError"` pour couvrir un undici chargé dans un autre realm) ;
  - `operator === "=="`, `expected === true`, `generatedMessage === true` (le `assert(<falsy>)` auto-généré ; un `assert(x, "message métier")` applicatif est **exclu**) ;
  - **PREMIÈRE frame** de la stack dans undici (`node:internal/deps/undici` ou `node_modules/undici`), et non une simple présence d'undici n'importe où — pour ne pas avaler un `assert` de code tiers abonné aux canaux `diagnostics_channel` d'undici (ex. instrumentation fetch de Sentry) qui hériterait des frames undici du *publisher*. La vraie erreur #507 est levée DANS ces frames, sa première frame est donc bien undici.
- **Handler `uncaughtException`** (`src/main.ts` → `src/shared/process/uncaught-error-handlers.ts`), installé après `Sentry.init`, idempotent :
  - erreur de fond undici → `logger.error` (avec stack) + `Sentry.captureException(level: 'warning')`, **sans crasher** ; corps entouré d'un `try/catch` avale-tout (neutraliser l'assert ne doit jamais, à son tour, crasher) ;
  - toute autre erreur → **fatal** : log + `Sentry.captureException(level: 'fatal')` **puis `flush` Sentry AVANT `exit(1)`** (sinon l'événement du crash est perdu, l'exit synchrone ne laissant aucun tick au transport), avec un **garde-fou** qui force la sortie si le flush pend (jamais de zombie).
- **`unhandledRejection` : aucun listener** (voir décision de revue ci-dessous).
- **Démarrage** : `void bootstrap()` → `bootstrap().catch(...)` (log + flush + `exit(1)`) : fail-fast ciblé sur l'échec de boot, sans politique globale.
- **Une seule définition de signature** : la garde e2e `test/helpers/e2e-uncaught-guard.ts` (posée par #506) importe le prédicat partagé, tout en conservant sa mécanique de wrap des écouteurs jest et son exclusion `originatesFromTestCode`.
- **Tests unitaires** (17 cas) : prédicat (positif undici + repli cross-realm ; négatifs : assert d'un test, subscriber diagnostics_channel traversant undici après la 1re frame, `assert(x, msg)`, `assert.strictEqual`, TypeError, Error, non-Error) ; handler (neutralisation sans flush/exit, non-crashant si le logger lève, chemin fatal, **flush-avant-exit**, **garde-fou timeout**, exit même si flush rejette, idempotence, délégation du listener).

## Décision de revue : politique `unhandledRejection` inchangée dans cette PR

La version initiale ajoutait aussi un handler `unhandledRejection` avec `exit(1)`. La revue adversariale a **prouvé** que c'était un durcissement dangereux, retiré :

- La prod **ne crashe pas aujourd'hui** sur une rejection non gérée : l'intégration Sentry par défaut (`onUnhandledRejection`, **mode `'warn'`**) journalise + capture sans sortir, et sa présence supprime déjà le défaut Node. Passer à `exit(1)` aurait été un **changement** de comportement, pas une préservation.
- Vecteur concret dans le repo : `request-logging.interceptor.ts` fait `void this.apiUsageService.recordRequest(...)` (fire-and-forget, insert DB sans `.catch`), exécuté à chaque requête trackée → un incident DB transitoire serait devenu une `unhandledRejection` → `exit(1)` → **crash-loop** du dyno web unique (qui porte aussi les workers). Une PR « anti-crash » aurait ajouté une classe de crash.
- L'assert undici de #507 remonte par `uncaughtException` (hors promesse), pas par rejection.

Le **fail-fast** éventuel sur les rejections (défendable : défaut Node moderne) est renvoyé à une **PR dédiée** après audit des fire-and-forget (interceptor analytics, jobs) et ajout des `.catch` manquants — de préférence via `onUnhandledRejectionIntegration({ mode: 'strict' })` de Sentry, qui flushe avant de sortir.

## Interaction avec Sentry (vérifiée, @sentry/node-core 10.28.0)

- `onUncaughtExceptionIntegration` : `exitEvenIfOtherHandlersAreRegistered: false` par défaut → ne force la sortie que s'il n'y a aucun autre listener. Notre listener étant présent, Sentry **ne sort pas** : c'est notre handler qui décide.
- **Verrou « première erreur »** de l'intégration : elle ne capture QUE le premier `uncaughtException`. Après un swallow undici, un vrai crash suivant ne serait plus remonté par Sentry → d'où notre `captureException` explicite + flush sur le chemin fatal.
- Résidu mineur assumé : sur le tout premier `uncaughtException` avalé, l'intégration Sentry émet aussi un event `level:'fatal'` (en plus de notre `'warning'`). Bruit d'alerting mineur, tunable en suivi (config d'intégration).

## Validation

- `pnpm validate` (type-check + lint + format:check) : OK sur tout le workspace.
- Tests unitaires ciblés (predicate + handler) : **17/17 verts** (globalSetup no-op, Docker indispo en local ; les suites testcontainers passeront en CI).

⚠️ Ne pas merger : dernière relecture au lead.
