### PR TITLE
fix: surcharge throttler 500/min sur les routes d'ingestion partenaires

### DIFF
--- a/api/src/fiches-action/fiches-action.controller.ts
+++ b/api/src/fiches-action/fiches-action.controller.ts
@@ -1,3 +1,4 @@
+import { Throttle } from "@nestjs/throttler";
 import { Body, Controller, Get, Param, Patch, Post, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ApiKeyGuard } from "@/auth/api-key-guard";
@@ -8,6 +9,9 @@ import { FichesActionService } from "./fiches-action.service";
 
 @ApiBearerAuth()
 @ApiTags("TeT")
+// Routes d'ingestion partenaires (webhooks MEC/TeT) : les resyncs dépassent largement
+// la limite globale 50/min — surcharge à 500/min (absorbe le burst observé).
+@Throttle({ default: { limit: 500, ttl: 60000 } })
 @Controller("tet/v1/actions")
 @UseGuards(ApiKeyGuard)
 export class FichesActionController {

--- a/api/src/mec/mec.controller.ts
+++ b/api/src/mec/mec.controller.ts
@@ -1,3 +1,4 @@
+import { Throttle } from "@nestjs/throttler";
 import { Body, Controller, Get, Param, Patch, Post, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ApiKeyGuard } from "@/auth/api-key-guard";
@@ -14,6 +15,9 @@ import { MecService } from "./mec.service";
 
 @ApiBearerAuth()
 @ApiTags("MEC")
+// Routes d'ingestion partenaires (webhooks MEC/TeT) : les resyncs dépassent largement
+// la limite globale 50/min — surcharge à 500/min (absorbe le burst observé).
+@Throttle({ default: { limit: 500, ttl: 60000 } })
 @Controller("mec/v1/projets")
 @UseGuards(ApiKeyGuard)
 export class MecController {

--- a/api/src/projets/projets.controller.ts
+++ b/api/src/projets/projets.controller.ts
@@ -1,3 +1,4 @@
+import { Throttle } from "@nestjs/throttler";
 import { Body, Controller, Get, Param, Patch, Post, Query, Req, UseGuards } from "@nestjs/common";
 import { CreateOrUpdateProjetResponse, CreateProjetRequest } from "./dto/create-projet.dto";
 import { UpdateProjetRequest } from "./dto/update-projet.dto";
@@ -21,6 +22,9 @@ import { ProjectId, ProjectIdType } from "@/shared/decorator/projetId-decorator"
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
 
 @ApiBearerAuth()
+// Routes d'ingestion partenaires (webhooks MEC/TeT) : les resyncs dépassent largement
+// la limite globale 50/min — surcharge à 500/min (absorbe le burst observé).
+@Throttle({ default: { limit: 500, ttl: 60000 } })
 @Controller("projets")
 @UseGuards(ApiKeyGuard)
 export class ProjetsController {


### PR DESCRIPTION
Préalable au déploiement prod : depuis la réparation du throttler (#498 — ttl en ms, la limite 50 req/min/IP est désormais réellement appliquée), les webhooks entrants MEC/TeT passaient sous la limite globale — un resync bulk se ferait étrangler en 429.

Surcharge `@Throttle({ default: { limit: 500, ttl: 60000 } })` au niveau des 3 controllers d'ingestion : `mec/v1/projets`, `projets` (legacy MEC/TeT), `fiches-action`. 500/min absorbe le burst observé. Les autres routes restent à 50/min.