### PR TITLE
docs: ids des traces DGCL non contractuels (intégration MEC)

### DIFF
--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -14,7 +14,7 @@ plateforme — `POST /decisions` enregistre automatiquement `plateforme_source =
 
 | Donnée | Stabilité |
 |---|---|
-| `traces[].id` (UUID/ID objet) | **Stable et contractuel** — c'est la seule référence à persister côté MEC (et la seule acceptée par `POST /decisions`) |
+| `traces[].id` (UUID/ID objet) | **Stable et contractuel** — c'est la seule référence à persister côté MEC (et la seule acceptée par `POST /decisions`). **Exception : les ids des traces DGCL** (`role: "financement"`, sources `DGCL *`) ne sont **pas contractuels** — ne jamais les persister ni les référencer dans une décision (une partie changera au prochain recalcul du pipeline ; réévaluation à la rentrée selon le deal DGCL) |
 | `traces[].externalId` | Stable (c'est votre propre id) |
 | Composition des groupes, `confiance` | **Recalculées à chaque run du pipeline** — ne jamais persister ; c'est pourquoi aucun identifiant de groupe n'est exposé |
 | `copMillesime`, `copStatutVivier`, leviers | Stables entre deux livraisons DREAL/référentiel |


### PR DESCRIPTION
Complément au contrat de stabilité de `INTEGRATION_MEC.md` : les ids des traces DGCL (`role: financement`) ne sont pas contractuels — une partie changera au prochain rebuild du pipeline (récupération UUID partielle sur le snapshot DGCL, documentée côté pipeline dans `IMPORT_DGCL.md` §4bis). À ne jamais persister ni référencer dans `POST /decisions`. Réévaluation à la rentrée selon le deal DGCL.