### PR TITLE
feat: contrat de décisions v2 (taxonomie fermée + effets référentiel)

### DIFF
--- a/api/src/decisions/active-decisions.ts
+++ b/api/src/decisions/active-decisions.ts
@@ -1,0 +1,27 @@
+import { sql, SQL } from "drizzle-orm";
+
+// ============================================================
+// Helper SQL réutilisable : « décision active »
+// ============================================================
+//
+// Une décision est ACTIVE tant qu'AUCUNE autre décision ne la supersède (la chaîne
+// de révocation est append-only : le nouvel événement pointe vers l'ancien via
+// `supersedes`, aucune ligne n'est jamais mutée).
+//
+// En cas de décisions actives CONTRADICTOIRES sur les mêmes objets (deux verdicts
+// concurrents non reliés par `supersedes`), la résolution « la plus récente prime »
+// se fait au point d'appel via `DISTINCT ON (<clé>) ... ORDER BY <clé>, created_at DESC`.
+// Ce prédicat ne tranche PAS les contradictions : il ne fait qu'exclure les décisions révoquées.
+
+/**
+ * Prédicat SQL à injecter dans un WHERE de requête raw : vrai si la décision d'alias
+ * `alias` n'est supersédée par aucune autre. `alias` est un identifiant SQL interne
+ * (jamais une entrée utilisateur).
+ *
+ * Exemple : `WHERE d.type_decision = 'projet_statut' AND ${activeDecisionPredicate("d")}`.
+ */
+export const activeDecisionPredicate = (alias = "d"): SQL =>
+  sql`NOT EXISTS (
+    SELECT 1 FROM decisions_humaines.decisions sup
+    WHERE sup.supersedes = ${sql.raw(alias)}.id
+  )`;

--- a/api/src/decisions/decision-contract.spec.ts
+++ b/api/src/decisions/decision-contract.spec.ts
@@ -1,0 +1,165 @@
+import { BadRequestException } from "@nestjs/common";
+import { DecisionContractInput, validateDecisionContract } from "./decision-contract";
+
+// Validation croisée par type. Convention des messages : chaque erreur nomme le champ
+// fautif ET le type concerné, pour un 400 exploitable côté partenaire.
+const ok = (input: DecisionContractInput) => () => validateDecisionContract(input);
+
+const expectRejects = (input: DecisionContractInput, message: RegExp) => {
+  expect(ok(input)).toThrow(BadRequestException);
+  expect(ok(input)).toThrow(message);
+};
+
+describe("validateDecisionContract", () => {
+  it("rejette un type hors du vocabulaire fermé", () => {
+    expectRejects({ typeDecision: "lien_confirme", objetAType: "projet", objetAId: "a" }, /hors du vocabulaire fermé/);
+  });
+
+  describe.each(["doublon_signale", "doublon_confirme", "doublon_infirme"])("%s", (type) => {
+    const base: DecisionContractInput = {
+      typeDecision: type,
+      objetAType: "projet",
+      objetAId: "proj-a",
+      objetBType: "projet",
+      objetBId: "proj-b",
+    };
+
+    it("accepte projet↔projet et fiche_action↔fiche_action", () => {
+      expect(ok(base)).not.toThrow();
+      expect(ok({ ...base, objetAType: "fiche_action", objetBType: "fiche_action" })).not.toThrow();
+    });
+
+    it("400 si objetAType n'est ni projet ni fiche_action", () => {
+      expectRejects({ ...base, objetAType: "plan" }, /objetAType.*invalide/);
+    });
+
+    it("400 si objetB manquant (requis)", () => {
+      expectRejects({ ...base, objetBType: undefined, objetBId: undefined }, /objetBType et objetBId requis/);
+    });
+
+    it("400 si objetBType hors projet|fiche_action", () => {
+      expectRejects({ ...base, objetBType: "plan" }, /objetBType.*invalide/);
+    });
+
+    it("400 si verdict fourni (interdit)", () => {
+      expectRejects({ ...base, verdict: "confirme" }, /verdict interdit/);
+    });
+  });
+
+  describe("rattachement_pcaet", () => {
+    const base: DecisionContractInput = {
+      typeDecision: "rattachement_pcaet",
+      objetAType: "projet",
+      objetAId: "proj-a",
+      objetBType: "pcaet",
+      objetBId: "200000172",
+      verdict: "confirme",
+    };
+
+    it("accepte projet + pcaet(SIREN) + verdict confirme|infirme", () => {
+      expect(ok(base)).not.toThrow();
+      expect(ok({ ...base, verdict: "infirme" })).not.toThrow();
+    });
+
+    it("400 si objetAType n'est pas projet", () => {
+      expectRejects({ ...base, objetAType: "fiche_action" }, /objetAType.*invalide/);
+    });
+
+    it("400 si objetBType n'est pas pcaet", () => {
+      expectRejects({ ...base, objetBType: "projet" }, /objetBType.*invalide/);
+    });
+
+    it("400 si objetBId n'est pas un SIREN de 9 chiffres", () => {
+      expectRejects({ ...base, objetBId: "12345" }, /SIREN de 9 chiffres/);
+      expectRejects({ ...base, objetBId: "abcdefghi" }, /SIREN de 9 chiffres/);
+    });
+
+    it("400 si objetB manquant", () => {
+      expectRejects({ ...base, objetBType: undefined, objetBId: undefined }, /objetBType et objetBId requis/);
+    });
+
+    it("400 si verdict manquant", () => {
+      expectRejects({ ...base, verdict: undefined }, /verdict requis/);
+    });
+
+    it("400 si verdict hors confirme|infirme", () => {
+      expectRejects({ ...base, verdict: "valide" }, /verdict.*invalide/);
+    });
+  });
+
+  describe("projet_statut", () => {
+    const base: DecisionContractInput = {
+      typeDecision: "projet_statut",
+      objetAType: "projet",
+      objetAId: "proj-a",
+      verdict: "valide",
+    };
+
+    it("accepte projet + verdict valide|obsolete|termine, sans objetB", () => {
+      for (const verdict of ["valide", "obsolete", "termine"]) {
+        expect(ok({ ...base, verdict })).not.toThrow();
+      }
+    });
+
+    it("400 si objetAType n'est pas projet", () => {
+      expectRejects({ ...base, objetAType: "financement" }, /objetAType.*invalide/);
+    });
+
+    it("400 si objetB fourni (interdit)", () => {
+      expectRejects({ ...base, objetBType: "projet", objetBId: "proj-b" }, /objetBType\/objetBId interdits/);
+    });
+
+    it("400 si verdict manquant", () => {
+      expectRejects({ ...base, verdict: undefined }, /verdict requis/);
+    });
+
+    it("400 si verdict hors valide|obsolete|termine", () => {
+      expectRejects({ ...base, verdict: "confirme" }, /verdict.*invalide/);
+    });
+  });
+
+  describe("correction_signalee", () => {
+    const base: DecisionContractInput = {
+      typeDecision: "correction_signalee",
+      objetAType: "projet",
+      objetAId: "proj-a",
+      payload: { champ: "budgetPrevisionnel", valeurProposee: "150000" },
+    };
+
+    it("accepte tout type d'objet A avec payload { champ, valeurProposee }", () => {
+      for (const objetAType of ["projet", "fiche_action", "plan", "financement"]) {
+        expect(ok({ ...base, objetAType })).not.toThrow();
+      }
+    });
+
+    it("accepte une source optionnelle", () => {
+      expect(ok({ ...base, payload: { ...base.payload, source: "délibération 2026-03" } })).not.toThrow();
+    });
+
+    it("400 si objetB fourni (interdit)", () => {
+      expectRejects({ ...base, objetBType: "projet", objetBId: "proj-b" }, /objetBType\/objetBId interdits/);
+    });
+
+    it("400 si verdict fourni (interdit)", () => {
+      expectRejects({ ...base, verdict: "valide" }, /verdict interdit/);
+    });
+
+    it("400 si payload manquant", () => {
+      expectRejects({ ...base, payload: undefined }, /payload requis/);
+    });
+
+    it("400 si payload.champ manquant ou vide", () => {
+      expectRejects({ ...base, payload: { valeurProposee: "x" } }, /payload\.champ requis/);
+      expectRejects({ ...base, payload: { champ: "  ", valeurProposee: "x" } }, /payload\.champ requis/);
+    });
+
+    it("400 si payload.valeurProposee manquant ou non-chaîne", () => {
+      expectRejects({ ...base, payload: { champ: "nom" } }, /payload\.valeurProposee requis/);
+      expectRejects({ ...base, payload: { champ: "nom", valeurProposee: 42 } }, /payload\.valeurProposee requis/);
+    });
+
+    it("400 si payload.source fourni mais non-chaîne", () => {
+      expectRejects({ ...base, payload: { champ: "nom", valeurProposee: "x", source: 12 } }, /payload\.source/);
+    });
+  });
+});

--- a/api/src/decisions/decision-contract.ts
+++ b/api/src/decisions/decision-contract.ts
@@ -1,0 +1,202 @@
+import { BadRequestException } from "@nestjs/common";
+
+// ============================================================
+// Contrat de taxonomie des décisions humaines (V2)
+// ============================================================
+//
+// `typeDecision` est une ENUM FERMÉE : toute valeur hors liste est rejetée (400).
+// Chaque type impose ses propres contraintes croisées (objet A/B, verdict, payload),
+// vérifiées par `validateDecisionContract` avec un message explicite indiquant le
+// champ fautif ET le type concerné. Le contrat est décrit en clair dans
+// docs/api/GUIDE_DECISIONS.md.
+
+// Types d'objets référençables par une décision. Les IDs pointés doivent TOUJOURS
+// être des IDs objets stables (traces[].id : UUID sources, ids cop_*…), jamais un cluster_id.
+export const OBJET_TYPES = ["projet", "fiche_action", "plan", "financement"] as const;
+export type ObjetType = (typeof OBJET_TYPES)[number];
+
+// L'objet B peut EN PLUS désigner un PCAET (rattachement_pcaet). Un PCAET n'a pas
+// d'id de trace stable propre : les plan_id ont trois canaux (snapshot/opendata/live)
+// dont la couverture bouge d'un run à l'autre. On le référence donc par le SIREN de
+// son porteur, clé stable de schema_commun_v2.pcaet_reference. 'pcaet' n'est jamais
+// un type d'objet A.
+export const OBJET_B_TYPES = [...OBJET_TYPES, "pcaet"] as const;
+export type ObjetBType = (typeof OBJET_B_TYPES)[number];
+
+// Vocabulaire fermé des types de décision.
+export const DECISION_TYPES = [
+  "doublon_signale",
+  "doublon_confirme",
+  "doublon_infirme",
+  "rattachement_pcaet",
+  "projet_statut",
+  "correction_signalee",
+] as const;
+export type DecisionType = (typeof DECISION_TYPES)[number];
+
+// SIREN du porteur PCAET : 9 chiffres.
+const SIREN_REGEX = /^\d{9}$/;
+
+// Les signalements/confirmations de doublon lient deux objets « projet » ou « fiche_action ».
+const DOUBLON_OBJET_TYPES = ["projet", "fiche_action"] as const;
+
+type ObjetBRule =
+  // interdit : objetBType ET objetBId doivent être absents.
+  | { required: false }
+  // requis : type dans `types`, id éventuellement contraint par un motif.
+  | { required: true; types: readonly ObjetBType[]; idPattern?: RegExp; idPatternLabel?: string };
+
+type VerdictRule =
+  // interdit : verdict doit être absent.
+  | { required: false }
+  // requis : verdict dans `values`.
+  | { required: true; values: readonly string[] };
+
+// free : payload libre (borné en octets par le DTO). correction : forme imposée.
+type PayloadRule = "free" | "correction";
+
+interface DecisionSpec {
+  objetATypes: readonly ObjetType[];
+  objetB: ObjetBRule;
+  verdict: VerdictRule;
+  payload: PayloadRule;
+}
+
+// Contrat figé — voir le tableau récapitulatif de docs/api/GUIDE_DECISIONS.md.
+const CONTRACT: Record<DecisionType, DecisionSpec> = {
+  doublon_signale: {
+    objetATypes: DOUBLON_OBJET_TYPES,
+    objetB: { required: true, types: DOUBLON_OBJET_TYPES },
+    verdict: { required: false },
+    payload: "free",
+  },
+  doublon_confirme: {
+    objetATypes: DOUBLON_OBJET_TYPES,
+    objetB: { required: true, types: DOUBLON_OBJET_TYPES },
+    verdict: { required: false },
+    payload: "free",
+  },
+  doublon_infirme: {
+    objetATypes: DOUBLON_OBJET_TYPES,
+    objetB: { required: true, types: DOUBLON_OBJET_TYPES },
+    verdict: { required: false },
+    payload: "free",
+  },
+  rattachement_pcaet: {
+    objetATypes: ["projet"],
+    objetB: {
+      required: true,
+      types: ["pcaet"],
+      idPattern: SIREN_REGEX,
+      idPatternLabel: "un SIREN de 9 chiffres (porteur du PCAET)",
+    },
+    verdict: { required: true, values: ["confirme", "infirme"] },
+    payload: "free",
+  },
+  projet_statut: {
+    objetATypes: ["projet"],
+    objetB: { required: false },
+    verdict: { required: true, values: ["valide", "obsolete", "termine"] },
+    payload: "free",
+  },
+  correction_signalee: {
+    objetATypes: OBJET_TYPES,
+    objetB: { required: false },
+    verdict: { required: false },
+    payload: "correction",
+  },
+};
+
+// Sous-ensemble du DTO nécessaire à la validation croisée (découplé de la classe).
+export interface DecisionContractInput {
+  typeDecision: string;
+  objetAType: string;
+  objetAId: string;
+  objetBType?: string | null;
+  objetBId?: string | null;
+  verdict?: string | null;
+  payload?: Record<string, unknown> | null;
+}
+
+/**
+ * Valide les contraintes CROISÉES propres à chaque type de décision. Lève une
+ * BadRequestException (400) au premier écart, avec un message nommant le champ
+ * fautif et le type concerné. À appeler après la validation class-validator du DTO
+ * (qui garantit déjà : typeDecision dans l'enum, objetAId non vide, types dans OBJET_TYPES…).
+ */
+export function validateDecisionContract(dto: DecisionContractInput): void {
+  const spec = CONTRACT[dto.typeDecision as DecisionType];
+  // Filet de sécurité : le DTO (@IsIn) rejette déjà les types hors enum en amont.
+  if (!spec) {
+    throw new BadRequestException(
+      `typeDecision "${dto.typeDecision}" hors du vocabulaire fermé (attendu : ${DECISION_TYPES.join(", ")})`,
+    );
+  }
+
+  const forType = `pour le type "${dto.typeDecision}"`;
+
+  // Objet A : toujours requis (objetAId garanti non vide par le DTO), type contraint.
+  if (!spec.objetATypes.includes(dto.objetAType as ObjetType)) {
+    throw new BadRequestException(
+      `objetAType "${dto.objetAType}" invalide ${forType} (attendu : ${spec.objetATypes.join(", ")})`,
+    );
+  }
+
+  // Objet B : requis (avec type/motif) ou interdit selon le type.
+  const hasObjetB = dto.objetBType != null || dto.objetBId != null;
+  if (spec.objetB.required) {
+    if (dto.objetBType == null || dto.objetBId == null) {
+      throw new BadRequestException(`objetBType et objetBId requis ${forType}`);
+    }
+    if (!spec.objetB.types.includes(dto.objetBType as ObjetBType)) {
+      throw new BadRequestException(
+        `objetBType "${dto.objetBType}" invalide ${forType} (attendu : ${spec.objetB.types.join(", ")})`,
+      );
+    }
+    if (spec.objetB.idPattern && !spec.objetB.idPattern.test(dto.objetBId)) {
+      throw new BadRequestException(`objetBId doit être ${spec.objetB.idPatternLabel} ${forType}`);
+    }
+  } else if (hasObjetB) {
+    throw new BadRequestException(`objetBType/objetBId interdits ${forType}`);
+  }
+
+  // Verdict : requis (valeur contrainte) ou interdit selon le type.
+  if (spec.verdict.required) {
+    if (dto.verdict == null) {
+      throw new BadRequestException(`verdict requis ${forType} (attendu : ${spec.verdict.values.join(", ")})`);
+    }
+    if (!spec.verdict.values.includes(dto.verdict)) {
+      throw new BadRequestException(
+        `verdict "${dto.verdict}" invalide ${forType} (attendu : ${spec.verdict.values.join(", ")})`,
+      );
+    }
+  } else if (dto.verdict != null) {
+    throw new BadRequestException(`verdict interdit ${forType}`);
+  }
+
+  // Payload : forme imposée pour correction_signalee, libre sinon.
+  if (spec.payload === "correction") {
+    validateCorrectionPayload(dto.payload ?? null, forType);
+  }
+}
+
+// correction_signalee exige un payload { champ, valeurProposee, source? }.
+function validateCorrectionPayload(payload: Record<string, unknown> | null, forType: string): void {
+  if (payload == null) {
+    throw new BadRequestException(`payload requis ${forType} : { champ, valeurProposee, source? }`);
+  }
+  const { champ, valeurProposee, source } = payload as {
+    champ?: unknown;
+    valeurProposee?: unknown;
+    source?: unknown;
+  };
+  if (typeof champ !== "string" || champ.trim() === "") {
+    throw new BadRequestException(`payload.champ requis (chaîne non vide) ${forType}`);
+  }
+  if (typeof valeurProposee !== "string") {
+    throw new BadRequestException(`payload.valeurProposee requis (chaîne) ${forType}`);
+  }
+  if (source !== undefined && typeof source !== "string") {
+    throw new BadRequestException(`payload.source, s'il est fourni, doit être une chaîne ${forType}`);
+  }
+}

--- a/api/src/decisions/decisions.controller.spec.ts
+++ b/api/src/decisions/decisions.controller.spec.ts
@@ -6,19 +6,19 @@ import { CreateDecisionDto } from "./dto/create-decision.dto";
 
 describe("DecisionsController", () => {
   let controller: DecisionsController;
-  let service: { create: jest.Mock; findByObjet: jest.Mock };
+  let service: { create: jest.Mock; find: jest.Mock };
 
   const mockRequest = (serviceType: string) => ({ serviceType }) as unknown as Request;
 
   beforeEach(() => {
-    service = { create: jest.fn(), findByObjet: jest.fn() };
+    service = { create: jest.fn(), find: jest.fn() };
     controller = new DecisionsController(service as unknown as DecisionsService);
   });
 
   describe("create", () => {
     it("dérive plateformeSource de request.serviceType (jamais du body)", async () => {
       service.create.mockResolvedValue({ id: "dec-1", createdAt: "2026-07-07T10:00:00.000Z" });
-      const dto = { typeDecision: "lien_confirme", objetAType: "projet", objetAId: "p1" } as CreateDecisionDto;
+      const dto = { typeDecision: "projet_statut", objetAType: "projet", objetAId: "p1" } as CreateDecisionDto;
 
       await controller.create(mockRequest("MEC"), dto);
 
@@ -26,18 +26,31 @@ describe("DecisionsController", () => {
     });
   });
 
-  describe("findByObjet", () => {
-    it("transmet la plateforme appelante au service (cloisonnement)", async () => {
-      service.findByObjet.mockResolvedValue({ items: [] });
+  describe("find", () => {
+    it("transmet objetId et la plateforme appelante au service (cloisonnement)", async () => {
+      service.find.mockResolvedValue({ items: [] });
 
-      await controller.findByObjet(mockRequest("TeT"), "p1");
+      await controller.find(mockRequest("TeT"), "p1");
 
-      expect(service.findByObjet).toHaveBeenCalledWith("p1", "TeT");
+      expect(service.find).toHaveBeenCalledWith({ objetId: "p1", type: undefined }, "TeT");
     });
 
-    it("400 si objetId manquant", () => {
-      expect(() => controller.findByObjet(mockRequest("MEC"), undefined)).toThrow(BadRequestException);
-      expect(service.findByObjet).not.toHaveBeenCalled();
+    it("accepte un filtre par type seul", async () => {
+      service.find.mockResolvedValue({ items: [] });
+
+      await controller.find(mockRequest("MEC"), undefined, "projet_statut");
+
+      expect(service.find).toHaveBeenCalledWith({ objetId: undefined, type: "projet_statut" }, "MEC");
+    });
+
+    it("400 si ni objetId ni type", () => {
+      expect(() => controller.find(mockRequest("MEC"), undefined, undefined)).toThrow(BadRequestException);
+      expect(service.find).not.toHaveBeenCalled();
+    });
+
+    it("400 si type hors du vocabulaire fermé", () => {
+      expect(() => controller.find(mockRequest("MEC"), undefined, "lien_confirme")).toThrow(BadRequestException);
+      expect(service.find).not.toHaveBeenCalled();
     });
   });
 });

--- a/api/src/decisions/decisions.controller.ts
+++ b/api/src/decisions/decisions.controller.ts
@@ -6,6 +6,7 @@ import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator"
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
 import { DecisionsService } from "./decisions.service";
 import { CreateDecisionDto, DecisionCreatedResponse, DecisionListResponse } from "./dto/create-decision.dto";
+import { DECISION_TYPES, type DecisionType } from "./decision-contract";
 
 @ApiBearerAuth()
 @ApiTags("Décisions")
@@ -35,21 +36,31 @@ export class DecisionsController {
   @TrackApiUsage()
   @Get()
   @ApiOperation({
-    summary: "Lister les décisions portant sur un objet",
+    summary: "Lister les décisions par objet et/ou par type",
     description:
-      "Retourne les décisions référençant l'objet (en A ou en B), triées anté-chronologiquement (max 100). " +
+      "Retourne les décisions filtrées par objetId (référencé en A ou en B) ET/OU par type, " +
+      "triées anté-chronologiquement (max 100). Au moins un des deux filtres est requis. " +
       "Cloisonnement : chaque plateforme ne voit QUE ses propres décisions (celles émises avec sa clé API).",
   })
-  @ApiQuery({ name: "objetId", required: true, description: "ID stable de l'objet à inspecter." })
+  @ApiQuery({ name: "objetId", required: false, description: "ID stable de l'objet à inspecter." })
+  @ApiQuery({
+    name: "type",
+    required: false,
+    enum: DECISION_TYPES,
+    description: "Type de décision à filtrer (vocabulaire fermé).",
+  })
   @ApiEndpointResponses({
     successStatus: 200,
     response: DecisionListResponse,
-    description: "Décisions portant sur l'objet",
+    description: "Décisions correspondant aux filtres",
   })
-  findByObjet(@Req() request: Request, @Query("objetId") objetId?: string) {
-    if (!objetId) {
-      throw new BadRequestException("objetId requis");
+  find(@Req() request: Request, @Query("objetId") objetId?: string, @Query("type") type?: string) {
+    if (!objetId && !type) {
+      throw new BadRequestException("Au moins un filtre requis : objetId et/ou type");
     }
-    return this.decisionsService.findByObjet(objetId, request.serviceType!);
+    if (type && !DECISION_TYPES.includes(type as DecisionType)) {
+      throw new BadRequestException(`type invalide (attendu : ${DECISION_TYPES.join(", ")})`);
+    }
+    return this.decisionsService.find({ objetId, type }, request.serviceType!);
   }
 }

--- a/api/src/decisions/decisions.service.spec.ts
+++ b/api/src/decisions/decisions.service.spec.ts
@@ -1,3 +1,4 @@
+import { BadRequestException } from "@nestjs/common";
 import { DecisionsService } from "./decisions.service";
 import { DatabaseService } from "@database/database.service";
 import { CreateDecisionDto } from "./dto/create-decision.dto";
@@ -41,12 +42,14 @@ describe("DecisionsService", () => {
   });
 
   describe("create", () => {
+    // rattachement_pcaet : porte à la fois objetB (pcaet + SIREN) et verdict → couvre
+    // la persistance de tous les champs binaires.
     const dto: CreateDecisionDto = {
-      typeDecision: "lien_confirme",
+      typeDecision: "rattachement_pcaet",
       objetAType: "projet",
       objetAId: "proj-a",
-      objetBType: "projet",
-      objetBId: "proj-b",
+      objetBType: "pcaet",
+      objetBId: "200000172",
       verdict: "confirme",
     };
 
@@ -57,14 +60,24 @@ describe("DecisionsService", () => {
 
       expect(result).toEqual({ id: "dec-1", createdAt: "2026-07-07T10:00:00.000Z" });
       expect(insertedValues).toMatchObject({
-        typeDecision: "lien_confirme",
+        typeDecision: "rattachement_pcaet",
         objetAType: "projet",
         objetAId: "proj-a",
-        objetBType: "projet",
-        objetBId: "proj-b",
+        objetBType: "pcaet",
+        objetBId: "200000172",
         verdict: "confirme",
         plateformeSource: "MEC",
       });
+    });
+
+    it("valide le contrat AVANT d'insérer : 400 et aucune insertion si le type est violé", async () => {
+      service = buildService({ returning: [{ id: "dec-x", createdAt }] });
+
+      // doublon_confirme sans objetB → interdit par le contrat.
+      await expect(
+        service.create({ typeDecision: "doublon_confirme", objetAType: "projet", objetAId: "proj-a" }, "MEC"),
+      ).rejects.toBeInstanceOf(BadRequestException);
+      expect(insertedValues).toBeUndefined();
     });
 
     it("persiste supersedes quand fourni (chaîne de révocation)", async () => {
@@ -78,12 +91,14 @@ describe("DecisionsService", () => {
     it("normalise les champs optionnels absents en null (dont supersedes)", async () => {
       service = buildService({ returning: [{ id: "dec-2", createdAt }] });
 
-      await service.create({ typeDecision: "projet_valide", objetAType: "projet", objetAId: "proj-a" }, "TeT");
+      await service.create(
+        { typeDecision: "projet_statut", objetAType: "projet", objetAId: "proj-a", verdict: "valide" },
+        "TeT",
+      );
 
       expect(insertedValues).toMatchObject({
         objetBType: null,
         objetBId: null,
-        verdict: null,
         auteur: null,
         commentaire: null,
         payload: null,
@@ -93,15 +108,24 @@ describe("DecisionsService", () => {
     });
   });
 
-  describe("findByObjet", () => {
+  describe("find", () => {
     it("renvoie les décisions trouvées sous forme { items } et applique un filtre WHERE (cloisonnement)", async () => {
       const rows = [{ id: "dec-1" }, { id: "dec-2" }];
       service = buildService({ selectRows: rows });
 
-      const result = await service.findByObjet("proj-a", "MEC");
+      const result = await service.find({ objetId: "proj-a" }, "MEC");
 
       expect(result).toEqual({ items: rows });
       // Le cloisonnement par plateforme est appliqué dans la clause WHERE.
+      expect(whereArg).toBeDefined();
+    });
+
+    it("accepte un filtre par type seul (sans objetId)", async () => {
+      service = buildService({ selectRows: [] });
+
+      const result = await service.find({ type: "projet_statut" }, "TeT");
+
+      expect(result).toEqual({ items: [] });
       expect(whereArg).toBeDefined();
     });
   });

--- a/api/src/decisions/decisions.service.spec.ts
+++ b/api/src/decisions/decisions.service.spec.ts
@@ -10,7 +10,8 @@ describe("DecisionsService", () => {
 
   const createdAt = new Date("2026-07-07T10:00:00.000Z");
 
-  // Chaîne Drizzle : insert().values().returning() et select().from().where().orderBy().limit()
+  // Chaîne Drizzle : insert().values().returning() ; select().from().where().limit()
+  // (lookup supersedes) ET select().from().where().orderBy().limit() (find).
   const makeDb = (opts: { returning?: unknown[]; selectRows?: unknown[] }) => {
     const returning = jest.fn().mockResolvedValue(opts.returning ?? []);
     const values = jest.fn().mockImplementation((v: Record<string, unknown>) => {
@@ -23,7 +24,7 @@ describe("DecisionsService", () => {
     const orderBy = jest.fn().mockReturnValue({ limit });
     const where = jest.fn().mockImplementation((w: unknown) => {
       whereArg = w;
-      return { orderBy };
+      return { orderBy, limit };
     });
     const from = jest.fn().mockReturnValue({ where });
     const select = jest.fn().mockReturnValue({ from });
@@ -80,12 +81,43 @@ describe("DecisionsService", () => {
       expect(insertedValues).toBeUndefined();
     });
 
-    it("persiste supersedes quand fourni (chaîne de révocation)", async () => {
-      service = buildService({ returning: [{ id: "dec-3", createdAt }] });
+    it("persiste supersedes quand la cible est compatible (même plateforme + même type)", async () => {
+      service = buildService({
+        returning: [{ id: "dec-3", createdAt }],
+        // Décision cible chargée par assertSupersedesCompatible.
+        selectRows: [{ plateformeSource: "MEC", typeDecision: "rattachement_pcaet" }],
+      });
 
       await service.create({ ...dto, supersedes: "dec-1" }, "MEC");
 
       expect(insertedValues).toMatchObject({ supersedes: "dec-1" });
+    });
+
+    it("400 si supersedes vise une décision d'une AUTRE plateforme (aucune insertion)", async () => {
+      service = buildService({
+        returning: [{ id: "dec-x", createdAt }],
+        selectRows: [{ plateformeSource: "TeT", typeDecision: "rattachement_pcaet" }],
+      });
+
+      await expect(service.create({ ...dto, supersedes: "dec-1" }, "MEC")).rejects.toBeInstanceOf(BadRequestException);
+      expect(insertedValues).toBeUndefined();
+    });
+
+    it("400 si supersedes vise une décision d'un AUTRE type (aucune insertion)", async () => {
+      service = buildService({
+        returning: [{ id: "dec-x", createdAt }],
+        selectRows: [{ plateformeSource: "MEC", typeDecision: "doublon_infirme" }],
+      });
+
+      await expect(service.create({ ...dto, supersedes: "dec-1" }, "MEC")).rejects.toBeInstanceOf(BadRequestException);
+      expect(insertedValues).toBeUndefined();
+    });
+
+    it("400 si la décision cible de supersedes est introuvable (aucune insertion)", async () => {
+      service = buildService({ returning: [{ id: "dec-x", createdAt }], selectRows: [] });
+
+      await expect(service.create({ ...dto, supersedes: "dec-1" }, "MEC")).rejects.toBeInstanceOf(BadRequestException);
+      expect(insertedValues).toBeUndefined();
     });
 
     it("normalise les champs optionnels absents en null (dont supersedes)", async () => {

--- a/api/src/decisions/decisions.service.ts
+++ b/api/src/decisions/decisions.service.ts
@@ -1,12 +1,13 @@
 import { Injectable } from "@nestjs/common";
 import { DatabaseService } from "@database/database.service";
 import { decisions } from "@database/schema";
-import { and, desc, eq, or } from "drizzle-orm";
+import { and, desc, eq, or, SQL } from "drizzle-orm";
 import { CreateDecisionDto, DecisionCreatedResponse } from "./dto/create-decision.dto";
+import { validateDecisionContract } from "./decision-contract";
 
 // Journal append-only des décisions humaines (schema decisions_humaines).
 // Aucune méthode UPDATE/DELETE : une révocation est un nouvel événement
-// référençant l'ancien via superseded_by (invariant applicatif).
+// référençant l'ancien via `supersedes` (invariant applicatif).
 @Injectable()
 export class DecisionsService {
   constructor(private readonly dbService: DatabaseService) {}
@@ -14,9 +15,12 @@ export class DecisionsService {
   /**
    * Enregistre une décision. `plateformeSource` est DÉRIVÉE du service authentifié
    * (request.serviceType), jamais du corps de requête : un service ne peut pas se
-   * faire passer pour un autre.
+   * faire passer pour un autre. Les contraintes croisées propres au type (objetB,
+   * verdict, payload) sont validées ici — 400 explicite en cas d'écart.
    */
   async create(dto: CreateDecisionDto, plateformeSource: string): Promise<DecisionCreatedResponse> {
+    validateDecisionContract(dto);
+
     const [row] = await this.dbService.database
       .insert(decisions)
       .values({
@@ -38,21 +42,25 @@ export class DecisionsService {
   }
 
   /**
-   * Décisions référençant un objet, en A ou en B. Tri anté-chronologique,
-   * bornée à 100 — vérification/audit d'un objet, pas de pagination.
+   * Décisions filtrées par objet (référencé en A ou en B) ET/OU par type. Tri
+   * anté-chronologique, bornée à 100 — vérification/audit, pas de pagination.
    * Cloisonnement : chaque plateforme ne lit QUE ses propres décisions
-   * (plateformeSource = service authentifié).
+   * (plateformeSource = service authentifié). Au moins un des deux filtres
+   * (objetId, type) est garanti fourni par le contrôleur.
    */
-  async findByObjet(objetId: string, plateformeSource: string) {
+  async find(filters: { objetId?: string; type?: string }, plateformeSource: string) {
+    const conditions: SQL[] = [eq(decisions.plateformeSource, plateformeSource)];
+    if (filters.objetId) {
+      conditions.push(or(eq(decisions.objetAId, filters.objetId), eq(decisions.objetBId, filters.objetId))!);
+    }
+    if (filters.type) {
+      conditions.push(eq(decisions.typeDecision, filters.type));
+    }
+
     const rows = await this.dbService.database
       .select()
       .from(decisions)
-      .where(
-        and(
-          eq(decisions.plateformeSource, plateformeSource),
-          or(eq(decisions.objetAId, objetId), eq(decisions.objetBId, objetId)),
-        ),
-      )
+      .where(and(...conditions))
       .orderBy(desc(decisions.createdAt))
       .limit(100);
 

--- a/api/src/decisions/decisions.service.ts
+++ b/api/src/decisions/decisions.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from "@nestjs/common";
+import { BadRequestException, Injectable } from "@nestjs/common";
 import { DatabaseService } from "@database/database.service";
 import { decisions } from "@database/schema";
 import { and, desc, eq, or, SQL } from "drizzle-orm";
@@ -20,6 +20,9 @@ export class DecisionsService {
    */
   async create(dto: CreateDecisionDto, plateformeSource: string): Promise<DecisionCreatedResponse> {
     validateDecisionContract(dto);
+    if (dto.supersedes) {
+      await this.assertSupersedesCompatible(dto.supersedes, dto.typeDecision, plateformeSource);
+    }
 
     const [row] = await this.dbService.database
       .insert(decisions)
@@ -39,6 +42,41 @@ export class DecisionsService {
       .returning({ id: decisions.id, createdAt: decisions.createdAt });
 
     return { id: row.id, createdAt: row.createdAt.toISOString() };
+  }
+
+  /**
+   * Une révision (`supersedes`) ne peut désactiver qu'une décision COMPATIBLE : même
+   * plateforme émettrice (cloisonnement — on ne révoque pas la décision d'un autre
+   * service) ET même `typeDecision`. Sans ce garde-fou, une décision anodine
+   * (ex. correction_signalee) pourrait désactiver silencieusement un verrou dur d'une
+   * autre plateforme (ex. doublon_infirme), car le prédicat « décision active » est
+   * type-agnostique. 400 explicite sinon.
+   */
+  private async assertSupersedesCompatible(
+    supersedesId: string,
+    typeDecision: string,
+    plateformeSource: string,
+  ): Promise<void> {
+    const [target] = await this.dbService.database
+      .select({ plateformeSource: decisions.plateformeSource, typeDecision: decisions.typeDecision })
+      .from(decisions)
+      .where(eq(decisions.id, supersedesId))
+      .limit(1);
+
+    if (!target) {
+      throw new BadRequestException(`supersedes : décision cible ${supersedesId} introuvable`);
+    }
+    if (target.plateformeSource !== plateformeSource) {
+      throw new BadRequestException(
+        "supersedes : une décision ne peut réviser que les décisions de sa propre plateforme",
+      );
+    }
+    if (target.typeDecision !== typeDecision) {
+      throw new BadRequestException(
+        `supersedes : type incompatible (cible « ${target.typeDecision} », révision « ${typeDecision} ») — ` +
+          "une révision doit être du même type que la décision révoquée",
+      );
+    }
   }
 
   /**

--- a/api/src/decisions/dto/create-decision.dto.spec.ts
+++ b/api/src/decisions/dto/create-decision.dto.spec.ts
@@ -3,8 +3,11 @@ import { plainToInstance } from "class-transformer";
 import { validateSync } from "class-validator";
 import { CreateDecisionDto, PAYLOAD_MAX_BYTES } from "./create-decision.dto";
 
+// Validation au niveau DTO (class-validator) uniquement : enum de typeDecision,
+// types d'objets, longueurs, UUID, taille du payload. Les contraintes CROISÉES par
+// type (objetB/verdict/payload requis vs interdit) sont couvertes dans decision-contract.spec.ts.
 const validBase = {
-  typeDecision: "lien_confirme",
+  typeDecision: "doublon_signale",
   objetAType: "projet",
   objetAId: "proj-a",
 };
@@ -21,12 +24,21 @@ describe("CreateDecisionDto validation", () => {
     expect(validate(validBase)).toHaveLength(0);
   });
 
+  it("rejette typeDecision hors de l'enum fermée", () => {
+    expect(errorsOn({ ...validBase, typeDecision: "lien_confirme" })).toContain("typeDecision");
+    expect(errorsOn({ ...validBase, typeDecision: "doublon_signale" })).not.toContain("typeDecision");
+  });
+
   it("rejette objetAType hors énumération", () => {
     expect(errorsOn({ ...validBase, objetAType: "cluster" })).toContain("objetAType");
   });
 
-  it("applique MaxLength(100) sur typeDecision", () => {
-    expect(errorsOn({ ...validBase, typeDecision: "x".repeat(101) })).toContain("typeDecision");
+  it("accepte objetBType='pcaet' (réservé au rattachement)", () => {
+    expect(errorsOn({ ...validBase, objetBType: "pcaet", objetBId: "200000172" })).not.toContain("objetBType");
+  });
+
+  it("rejette objetBType hors énumération (objetB)", () => {
+    expect(errorsOn({ ...validBase, objetBType: "cluster" })).toContain("objetBType");
   });
 
   it("applique MaxLength(200) sur objetAId", () => {

--- a/api/src/decisions/dto/create-decision.dto.ts
+++ b/api/src/decisions/dto/create-decision.dto.ts
@@ -11,11 +11,7 @@ import {
   ValidationArguments,
   ValidationOptions,
 } from "class-validator";
-
-// Types d'objets référençables. Les IDs pointés doivent TOUJOURS être des IDs
-// objets stables (UUID sources, ids cop_*, dgcl-*…), jamais un cluster_id.
-export const OBJET_TYPES = ["projet", "fiche_action", "plan", "financement"] as const;
-export type ObjetType = (typeof OBJET_TYPES)[number];
+import { DECISION_TYPES, OBJET_B_TYPES, OBJET_TYPES, type ObjetBType, type ObjetType } from "../decision-contract";
 
 // Taille maximale du payload jsonb (protège la base et les logs d'un abus).
 export const PAYLOAD_MAX_BYTES = 10_240;
@@ -47,15 +43,14 @@ function MaxJsonBytes(maxBytes: number, validationOptions?: ValidationOptions) {
 export class CreateDecisionDto {
   @ApiProperty({
     description:
-      "Type de décision. Vocabulaire évolutif, non contraint par une enum stricte " +
-      "(ex. lien_confirme, lien_infirme, doublon_signale, projet_valide, projet_obsolete, rattachement_pcaet).",
-    example: "lien_confirme",
-    maxLength: 100,
+      "Type de décision — ENUM FERMÉE (toute autre valeur est rejetée en 400). " +
+      "Chaque type impose ses contraintes croisées sur objetB, verdict et payload " +
+      "(voir docs/api/GUIDE_DECISIONS.md).",
+    enum: DECISION_TYPES,
+    example: "doublon_signale",
   })
-  @IsString()
-  @IsNotEmpty()
-  @MaxLength(100)
-  typeDecision!: string;
+  @IsIn(DECISION_TYPES)
+  typeDecision!: (typeof DECISION_TYPES)[number];
 
   @ApiProperty({
     description: "Type de l'objet A concerné par la décision.",
@@ -76,15 +71,19 @@ export class CreateDecisionDto {
   objetAId!: string;
 
   @ApiPropertyOptional({
-    description: "Type de l'objet B (décisions binaires, ex. lien entre deux objets).",
-    enum: OBJET_TYPES,
+    description:
+      "Type de l'objet B (décisions binaires). Inclut 'pcaet' : pour rattachement_pcaet, " +
+      "objetB désigne un PCAET par le SIREN de son porteur (objetBId = 9 chiffres).",
+    enum: OBJET_B_TYPES,
   })
   @IsOptional()
-  @IsIn(OBJET_TYPES)
-  objetBType?: ObjetType;
+  @IsIn(OBJET_B_TYPES)
+  objetBType?: ObjetBType;
 
   @ApiPropertyOptional({
-    description: "ID STABLE de l'objet B (mêmes règles que objetAId — jamais un cluster_id).",
+    description:
+      "ID STABLE de l'objet B (mêmes règles que objetAId — jamais un cluster_id). " +
+      "Pour objetBType='pcaet' : SIREN du porteur (9 chiffres).",
     maxLength: 200,
   })
   @IsOptional()
@@ -92,7 +91,12 @@ export class CreateDecisionDto {
   @MaxLength(200)
   objetBId?: string;
 
-  @ApiPropertyOptional({ description: "Verdict associé (ex. confirme, infirme, fusionner).", maxLength: 100 })
+  @ApiPropertyOptional({
+    description:
+      "Verdict associé. Valeurs contraintes par type : confirme|infirme (rattachement_pcaet), " +
+      "valide|obsolete|termine (projet_statut) ; interdit pour les doublons et correction_signalee.",
+    maxLength: 100,
+  })
   @IsOptional()
   @IsString()
   @MaxLength(100)
@@ -121,7 +125,9 @@ export class CreateDecisionDto {
 
   @ApiPropertyOptional({
     type: Object,
-    description: `Charge utile structurée additionnelle propre à la décision (max ${PAYLOAD_MAX_BYTES} octets sérialisés).`,
+    description:
+      `Charge utile structurée additionnelle propre à la décision (max ${PAYLOAD_MAX_BYTES} octets sérialisés). ` +
+      "REQUISE et de forme imposée pour correction_signalee : { champ: string, valeurProposee: string, source?: string }.",
   })
   @IsOptional()
   @IsObject()
@@ -153,7 +159,7 @@ export class DecisionRecordResponse {
   @ApiProperty()
   objetAId!: string;
 
-  @ApiPropertyOptional({ enum: OBJET_TYPES, nullable: true })
+  @ApiPropertyOptional({ enum: OBJET_B_TYPES, nullable: true })
   objetBType!: string | null;
 
   @ApiPropertyOptional({ nullable: true })

--- a/api/src/territoires/dto/plans-territoire.dto.ts
+++ b/api/src/territoires/dto/plans-territoire.dto.ts
@@ -24,6 +24,14 @@ export class PcaetReferenceDto {
     description: "Source de la fiche PCAET de référence (source_nom).",
   })
   source!: string | null;
+
+  @ApiProperty({
+    enum: ["confirme", "infirme", "aucun"],
+    description:
+      "État du rattachement projet ↔ PCAET, dérivé de la décision active rattachement_pcaet la plus récente " +
+      "entre ce projet et ce PCAET (SIREN porteur). 'aucun' si aucune décision active.",
+  })
+  rattachement!: "confirme" | "infirme" | "aucun";
 }
 
 export class PlansTerritoireResponse {

--- a/api/src/territoires/dto/territoire-projets.dto.ts
+++ b/api/src/territoires/dto/territoire-projets.dto.ts
@@ -48,6 +48,35 @@ export class TerritoireTraceDto {
   externalId!: string | null;
 }
 
+// Décision humaine ACTIVE portant sur au moins une trace du groupe. L'agent auteur
+// n'est PAS exposé (PII + cloisonnement inter-plateformes) : on expose la décision,
+// pas qui l'a prise. La `plateforme` émettrice, elle, est exposée.
+export class TerritoireDecisionDto {
+  @ApiProperty({ description: "Type de décision (vocabulaire fermé)." })
+  type!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: "Verdict associé, selon le type." })
+  verdict!: string | null;
+
+  @ApiProperty({ description: "Plateforme émettrice de la décision." })
+  plateforme!: string;
+
+  @ApiProperty({ description: "Horodatage de création (ISO 8601)." })
+  createdAt!: string;
+
+  @ApiProperty({ description: "ID de l'objet A visé par la décision (une trace du groupe, ou son pair)." })
+  objetAId!: string;
+
+  @ApiPropertyOptional({
+    nullable: true,
+    description: "ID de l'objet B (doublons, ou SIREN PCAET pour un rattachement).",
+  })
+  objetBId!: string | null;
+
+  @ApiPropertyOptional({ nullable: true, description: "Commentaire libre attaché à la décision." })
+  commentaire!: string | null;
+}
+
 export class TerritoireGroupeDto {
   @ApiPropertyOptional({
     enum: ["CERTAIN", "PROBABLE"],
@@ -58,6 +87,14 @@ export class TerritoireGroupeDto {
 
   @ApiProperty({ type: [TerritoireTraceDto] })
   traces!: TerritoireTraceDto[];
+
+  @ApiProperty({
+    type: [TerritoireDecisionDto],
+    description:
+      "Décisions humaines ACTIVES portant sur une trace du groupe (toutes plateformes confondues, sans l'auteur). " +
+      "Tableau vide si aucune décision.",
+  })
+  decisions!: TerritoireDecisionDto[];
 }
 
 export class TerritoireProjetsResponse {

--- a/api/src/territoires/territoires.controller.spec.ts
+++ b/api/src/territoires/territoires.controller.spec.ts
@@ -56,4 +56,21 @@ describe("TerritoiresController", () => {
     });
     expect(lastParams()).toMatchObject({ copStatutVivier: "a_remonter", inclureFinancementsSeuls: true });
   });
+
+  describe("masquerObsoletes (défaut false)", () => {
+    it("masquerObsoletes='true' → true", async () => {
+      await controller.territoireProjets("01001", { masquerObsoletes: "true" });
+      expect(lastParams().masquerObsoletes).toBe(true);
+    });
+
+    it("absent → false", async () => {
+      await controller.territoireProjets("01001", {});
+      expect(lastParams().masquerObsoletes).toBe(false);
+    });
+
+    it("valeur autre que 'true' → false", async () => {
+      await controller.territoireProjets("01001", { masquerObsoletes: "1" });
+      expect(lastParams().masquerObsoletes).toBe(false);
+    });
+  });
 });

--- a/api/src/territoires/territoires.controller.ts
+++ b/api/src/territoires/territoires.controller.ts
@@ -66,6 +66,12 @@ export class TerritoiresController {
     required: false,
     description: "Inclure les groupes dont toutes les traces sont des financements (défaut false).",
   })
+  @ApiQuery({
+    name: "masquerObsoletes",
+    required: false,
+    description:
+      "Exclure les groupes dont une trace est marquée obsolète (décision active projet_statut, verdict 'obsolete'). Défaut false.",
+  })
   @ApiEndpointResponses({
     successStatus: 200,
     response: TerritoireProjetsResponse,
@@ -80,6 +86,7 @@ export class TerritoiresController {
       limit: Math.min(Math.max(toInt(first(query.limit), 50), 1), 200),
       offset: toInt(first(query.offset), 0),
       inclureFinancementsSeuls: first(query.inclureFinancementsSeuls) === "true",
+      masquerObsoletes: first(query.masquerObsoletes) === "true",
     });
   }
 

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -103,6 +103,13 @@ describe("TerritoiresService", () => {
       ]);
       // Aucun champ auteur exposé.
       expect(result.groupes[0].decisions[0]).not.toHaveProperty("auteur");
+
+      // La requête d'enrichissement filtre le vocabulaire fermé, borne le résultat
+      // et départage les created_at égaux (id DESC).
+      const decisionsSql = renderSql((execute.mock.calls[2] as unknown[])[0]);
+      expect(decisionsSql).toContain("type_decision = ANY");
+      expect(decisionsSql).toContain("d.id DESC");
+      expect(decisionsSql).toContain("LIMIT");
     });
 
     it("ne lance pas de requête de décisions quand la page est vide", async () => {
@@ -118,6 +125,8 @@ describe("TerritoiresService", () => {
       const pageSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
       expect(pageSql).toContain("obsolete_pids");
       expect(pageSql).toContain("has_obsolete = FALSE");
+      // Départage déterministe des created_at égaux dans obsolete_pids.
+      expect(pageSql).toContain("d.id DESC");
     });
 
     it("masquerObsoletes=false (défaut) n'ajoute pas le filtre has_obsolete", async () => {
@@ -279,6 +288,9 @@ describe("TerritoiresService", () => {
         ],
         fichesActionSuggerees: [],
       });
+      // La requête de rattachement départage les created_at égaux (id DESC).
+      const rattachementSql = renderSql((execute.mock.calls[4] as unknown[])[0]);
+      expect(rattachementSql).toContain("d.id DESC");
     });
 
     it("rattachement='aucun' quand aucune décision active", async () => {

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -1,4 +1,5 @@
 import { BadRequestException, NotFoundException } from "@nestjs/common";
+import { PgDialect } from "drizzle-orm/pg-core";
 import { TerritoiresService } from "./territoires.service";
 import { DatabaseService } from "@database/database.service";
 
@@ -6,6 +7,10 @@ describe("TerritoiresService", () => {
   let execute: jest.Mock;
   let selectLimit: jest.Mock;
   let service: TerritoiresService;
+
+  // Rend le SQL généré en texte : permet d'asserter la présence/absence de clauses
+  // conditionnelles (filtre obsolètes) sans base de données.
+  const renderSql = (q: unknown) => new PgDialect().sqlToQuery(q as never).sql;
 
   // execute() sert les requêtes SQL brutes ; select().from().where().limit() la résolution external_id.
   const makeDb = () => {
@@ -23,9 +28,9 @@ describe("TerritoiresService", () => {
   });
 
   describe("territoireProjets", () => {
-    const params = { limit: 50, offset: 0, inclureFinancementsSeuls: false };
+    const params = { limit: 50, offset: 0, inclureFinancementsSeuls: false, masquerObsoletes: false };
 
-    it("renvoie la forme { total, limit, offset, groupes } pour une commune (INSEE 5 chiffres)", async () => {
+    it("renvoie la forme { total, limit, offset, groupes } (chaque groupe a decisions[])", async () => {
       execute
         .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence de la commune au référentiel
         .mockResolvedValueOnce({
@@ -36,7 +41,8 @@ describe("TerritoiresService", () => {
               total: "1",
             },
           ],
-        });
+        })
+        .mockResolvedValueOnce({ rows: [] }); // décisions actives de la page (aucune)
 
       const result = await service.territoireProjets("01001", params);
 
@@ -44,10 +50,83 @@ describe("TerritoiresService", () => {
         total: 1,
         limit: 50,
         offset: 0,
-        groupes: [{ confiance: "CERTAIN", traces: [{ role: "projet", source: "MEC", id: "p1" }] }],
+        groupes: [{ confiance: "CERTAIN", traces: [{ role: "projet", source: "MEC", id: "p1" }], decisions: [] }],
       });
-      // 1 requête d'existence commune + 1 requête de groupes.
+      // existence commune + groupes + décisions de la page.
+      expect(execute).toHaveBeenCalledTimes(3);
+    });
+
+    it("attache les décisions actives au groupe, sans l'auteur, en une seule requête", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence commune
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              confiance: "PROBABLE",
+              traces: [
+                { role: "projet", source: "MEC", id: "p1" },
+                { role: "projet", source: "Vivier COP", id: "cop_2" },
+              ],
+              total: "1",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              type: "doublon_confirme",
+              verdict: null,
+              plateforme: "MEC",
+              createdAt: new Date("2026-07-01T08:00:00.000Z"),
+              objetAId: "p1",
+              objetBId: "cop_2",
+              commentaire: "même projet",
+            },
+          ],
+        });
+
+      const result = await service.territoireProjets("01001", params);
+
+      // Une seule requête de décisions pour toute la page.
+      expect(execute).toHaveBeenCalledTimes(3);
+      // La décision touche p1 (A) ET cop_2 (B), tous deux dans le groupe → attachée UNE fois.
+      expect(result.groupes[0].decisions).toEqual([
+        {
+          type: "doublon_confirme",
+          verdict: null,
+          plateforme: "MEC",
+          createdAt: "2026-07-01T08:00:00.000Z",
+          objetAId: "p1",
+          objetBId: "cop_2",
+          commentaire: "même projet",
+        },
+      ]);
+      // Aucun champ auteur exposé.
+      expect(result.groupes[0].decisions[0]).not.toHaveProperty("auteur");
+    });
+
+    it("ne lance pas de requête de décisions quand la page est vide", async () => {
+      execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
+      const result = await service.territoireProjets("01001", params);
+      expect(result).toEqual({ total: 0, limit: 50, offset: 0, groupes: [] });
       expect(execute).toHaveBeenCalledTimes(2);
+    });
+
+    it("masquerObsoletes=true ajoute le filtre has_obsolete à la requête de page", async () => {
+      execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
+      await service.territoireProjets("01001", { ...params, masquerObsoletes: true });
+      const pageSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
+      expect(pageSql).toContain("obsolete_pids");
+      expect(pageSql).toContain("has_obsolete = FALSE");
+    });
+
+    it("masquerObsoletes=false (défaut) n'ajoute pas le filtre has_obsolete", async () => {
+      execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
+      await service.territoireProjets("01001", params);
+      const pageSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
+      // obsolete_pids reste calculé, mais le filtre n'est pas appliqué.
+      expect(pageSql).toContain("obsolete_pids");
+      expect(pageSql).not.toContain("has_obsolete = FALSE");
     });
 
     it("accepte un code commune corse (2A/2B + 3)", async () => {
@@ -61,12 +140,6 @@ describe("TerritoiresService", () => {
       await expect(service.territoireProjets("99999", params)).rejects.toBeInstanceOf(NotFoundException);
     });
 
-    it("total = 0 et groupes = [] quand aucun groupe (offset 0)", async () => {
-      execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
-      const result = await service.territoireProjets("01001", params);
-      expect(result).toEqual({ total: 0, limit: 50, offset: 0, groupes: [] });
-    });
-
     it("récupère le vrai total via un COUNT quand la page est vide au-delà de l'offset", async () => {
       execute
         .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence commune
@@ -74,6 +147,7 @@ describe("TerritoiresService", () => {
         .mockResolvedValueOnce({ rows: [{ total: "12" }] }); // COUNT de repli
       const result = await service.territoireProjets("01001", { ...params, offset: 100 });
       expect(result.total).toBe(12);
+      // Page vide → pas de requête de décisions.
       expect(execute).toHaveBeenCalledTimes(3);
     });
 
@@ -171,7 +245,7 @@ describe("TerritoiresService", () => {
       expect(result).toEqual({ pcaet: [], fichesActionSuggerees: [] });
     });
 
-    it("mappe les PCAET couvrant les communes du projet", async () => {
+    it("mappe les PCAET et leur rattachement (décision active la plus récente)", async () => {
       selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
       execute
         .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence projet
@@ -187,7 +261,8 @@ describe("TerritoiresService", () => {
               source: "snapshot",
             },
           ],
-        });
+        })
+        .mockResolvedValueOnce({ rows: [{ siren: "200000172", verdict: "confirme" }] }); // rattachement
 
       const result = await service.planFichesTerritoire("mec-123");
 
@@ -199,10 +274,35 @@ describe("TerritoiresService", () => {
             presentDansTet: true,
             tetExternalId: "tet-9",
             source: "snapshot",
+            rattachement: "confirme",
           },
         ],
         fichesActionSuggerees: [],
       });
+    });
+
+    it("rattachement='aucun' quand aucune décision active", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      execute
+        .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence projet
+        .mockResolvedValueOnce({ rows: [{ insee: "01001" }] }) // communes
+        .mockResolvedValueOnce({ rows: [{ present: true }] }) // pcaet_reference présente
+        .mockResolvedValueOnce({
+          rows: [
+            {
+              nom: "PCAET Sans Décision",
+              sirenPorteur: "244400404",
+              presentDansTet: false,
+              tetExternalId: null,
+              source: "opendata",
+            },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // aucune décision de rattachement
+
+      const result = await service.planFichesTerritoire("mec-123");
+
+      expect(result.pcaet[0].rattachement).toBe("aucun");
     });
   });
 });

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -2,8 +2,14 @@ import { BadRequestException, Injectable, NotFoundException } from "@nestjs/comm
 import { DatabaseService } from "@database/database.service";
 import { mecExternalIds } from "@database/schema";
 import { and, eq, sql, SQL } from "drizzle-orm";
+import { activeDecisionPredicate } from "@/decisions/active-decisions";
 import { splitLeviersCsv } from "./leviers-csv";
-import { TerritoireGroupeDto, TerritoireProjetsResponse, TerritoireTraceDto } from "./dto/territoire-projets.dto";
+import {
+  TerritoireDecisionDto,
+  TerritoireGroupeDto,
+  TerritoireProjetsResponse,
+  TerritoireTraceDto,
+} from "./dto/territoire-projets.dto";
 import { PlansTerritoireResponse } from "./dto/plans-territoire.dto";
 import { QualificationResponse } from "./dto/qualification.dto";
 
@@ -49,6 +55,9 @@ export interface TerritoireProjetsParams {
   limit: number;
   offset: number;
   inclureFinancementsSeuls: boolean;
+  // Exclut les groupes dont une trace est marquée obsolète (décision active
+  // projet_statut, verdict 'obsolete'). Défaut false.
+  masquerObsoletes: boolean;
 }
 
 @Injectable()
@@ -65,7 +74,8 @@ export class TerritoiresService {
    * déduplication. `code` = INSEE commune (5 chiffres / 2A|2B + 3) ou SIREN EPCI (9 chiffres).
    */
   async territoireProjets(code: string, params: TerritoireProjetsParams): Promise<TerritoireProjetsResponse> {
-    const { sources, copMillesime, copStatutVivier, limit, offset, inclureFinancementsSeuls } = params;
+    const { sources, copMillesime, copStatutVivier, limit, offset, inclureFinancementsSeuls, masquerObsoletes } =
+      params;
 
     if (copMillesime !== undefined && !COP_MILLESIMES.includes(copMillesime as (typeof COP_MILLESIMES)[number])) {
       throw new BadRequestException(`copMillesime invalide (attendu : ${COP_MILLESIMES.join(", ")})`);
@@ -93,8 +103,22 @@ export class TerritoiresService {
     // Rôle d'une trace : financement si sa source est une source de financement, sinon projet.
     const roleExpr = sql`CASE WHEN p.source_origine = ANY(${textArray([...FINANCEMENT_SOURCES])}) THEN 'financement' ELSE 'projet' END`;
 
+    // Projets actuellement marqués obsolètes : dernière décision projet_statut ACTIVE
+    // (non supersédée) de verdict 'obsolete' par projet (la plus récente prime). Table
+    // decisions_humaines à l'échelle humaine (faible volume) : toujours calculée, seul
+    // le filtre `masquerObsoletes` la consomme — la vue « vivant/mort » ANCT.
     // Chaîne de CTE partagée entre la requête de page et le COUNT de repli.
     const cteBody = sql`
+      obsolete_pids AS (
+        SELECT s.oid
+        FROM (
+          SELECT DISTINCT ON (d.objet_a_id) d.objet_a_id AS oid, d.verdict
+          FROM decisions_humaines.decisions d
+          WHERE d.type_decision = 'projet_statut' AND ${activeDecisionPredicate("d")}
+          ORDER BY d.objet_a_id, d.created_at DESC
+        ) s
+        WHERE s.verdict = 'obsolete'
+      ),
       territory_pids AS (
         SELECT DISTINCT lpc.projet_id AS pid
         FROM schema_commun_v2.liens_projets_communes lpc
@@ -157,7 +181,9 @@ export class TerritoiresService {
             SELECT ext.external_id FROM data_mec.external_ids ext
             WHERE ext.service_type = 'MEC' AND ext.objet_id = p.id::uuid
             LIMIT 1
-          ) END AS external_id
+          ) END AS external_id,
+          -- La trace porte-t-elle une décision projet_statut active 'obsolete' ?
+          EXISTS (SELECT 1 FROM obsolete_pids op WHERE op.oid = p.id) AS is_obsolete
         FROM group_members gm
         JOIN schema_commun_v2.projets_operationnels p ON p.id = gm.pid
       ),
@@ -167,6 +193,7 @@ export class TerritoiresService {
           MAX(mr.cluster_id) AS cluster_id,
           MIN(mr.id) AS min_id,
           bool_and(mr.role = 'financement') AS all_financement,
+          bool_or(mr.is_obsolete) AS has_obsolete,
           jsonb_agg(
             jsonb_build_object(
               'role', mr.role,
@@ -187,7 +214,7 @@ export class TerritoiresService {
         GROUP BY mr.group_key
       ),
       group_final AS (
-        SELECT ga.min_id, ga.all_financement, ga.traces, c.confiance
+        SELECT ga.min_id, ga.all_financement, ga.has_obsolete, ga.traces, c.confiance
         FROM group_agg ga
         LEFT JOIN schema_commun_v2.clusters c ON c.id = ga.cluster_id
       ),
@@ -195,6 +222,7 @@ export class TerritoiresService {
         SELECT confiance, traces, min_id
         FROM group_final
         WHERE ${inclureFinancementsSeuls ? sql`TRUE` : sql`all_financement = FALSE`}
+          ${masquerObsoletes ? sql`AND has_obsolete = FALSE` : sql``}
       )
     `;
 
@@ -220,9 +248,74 @@ export class TerritoiresService {
     const groupes: TerritoireGroupeDto[] = rows.map((r) => ({
       confiance: (r.confiance as TerritoireGroupeDto["confiance"]) ?? null,
       traces: (r.traces as TerritoireTraceDto[]) ?? [],
+      decisions: [],
     }));
 
+    await this.attachActiveDecisions(groupes);
+
     return { total, limit, offset, groupes };
+  }
+
+  /**
+   * Enrichit chaque groupe de la page avec ses décisions humaines ACTIVES, en UNE seule
+   * requête pour toute la page (pas de N+1 ; jointure sur les index objet_a/b_id). Une
+   * décision est rattachée au groupe dès que son objet A OU son objet B est l'une des
+   * traces du groupe. Toutes plateformes confondues (vue référentiel partagée), mais
+   * l'agent auteur n'est JAMAIS exposé (PII + cloisonnement inter-plateformes).
+   */
+  private async attachActiveDecisions(groupes: TerritoireGroupeDto[]): Promise<void> {
+    // Un id de trace appartient à un seul groupe (un projet est dans un seul cluster).
+    const groupByTraceId = new Map<string, TerritoireGroupeDto>();
+    for (const g of groupes) {
+      for (const t of g.traces) {
+        if (t.id != null) groupByTraceId.set(t.id, g);
+      }
+    }
+    const ids = [...groupByTraceId.keys()];
+    if (ids.length === 0) return;
+
+    const rows = await this.query<{
+      type: string;
+      verdict: string | null;
+      plateforme: string;
+      createdAt: Date | string;
+      objetAId: string;
+      objetBId: string | null;
+      commentaire: string | null;
+    }>(sql`
+      SELECT
+        d.type_decision AS type,
+        d.verdict,
+        d.plateforme_source AS plateforme,
+        d.created_at AS "createdAt",
+        d.objet_a_id AS "objetAId",
+        d.objet_b_id AS "objetBId",
+        d.commentaire
+      FROM decisions_humaines.decisions d
+      WHERE (d.objet_a_id = ANY(${textArray(ids)}) OR d.objet_b_id = ANY(${textArray(ids)}))
+        AND ${activeDecisionPredicate("d")}
+      ORDER BY d.created_at DESC
+    `);
+
+    for (const r of rows) {
+      const decision: TerritoireDecisionDto = {
+        type: r.type,
+        verdict: r.verdict,
+        plateforme: r.plateforme,
+        createdAt: this.toIso(r.createdAt)!,
+        objetAId: r.objetAId,
+        objetBId: r.objetBId,
+        commentaire: r.commentaire,
+      };
+      // Une décision de doublon touche deux traces (A↔B) potentiellement dans deux
+      // groupes distincts : l'attacher à chacun, une seule fois par groupe.
+      const touched = new Set<TerritoireGroupeDto>();
+      const groupA = groupByTraceId.get(r.objetAId);
+      const groupB = r.objetBId != null ? groupByTraceId.get(r.objetBId) : undefined;
+      if (groupA) touched.add(groupA);
+      if (groupB) touched.add(groupB);
+      for (const g of touched) g.decisions.push(decision);
+    }
   }
 
   /**
@@ -269,6 +362,10 @@ export class TerritoiresService {
       ORDER BY pr.nom
     `);
 
+    // Rattachements décidés par la plateforme (décision active la plus récente projet ↔ PCAET).
+    const rattachements =
+      pcaetRows.length > 0 ? await this.rattachementsByPcaet(projetId) : new Map<string, "confirme" | "infirme">();
+
     return {
       pcaet: pcaetRows.map((r) => ({
         nom: r.nom,
@@ -276,10 +373,33 @@ export class TerritoiresService {
         presentDansTet: r.presentDansTet,
         tetExternalId: r.tetExternalId ?? null,
         source: r.source,
+        rattachement: (r.sirenPorteur != null ? rattachements.get(r.sirenPorteur) : undefined) ?? "aucun",
       })),
       // TODO(T4+): dériver des fiches action suggérées depuis les PCAET rattachés (bonus hors scope immédiat).
       fichesActionSuggerees: [],
     };
+  }
+
+  /**
+   * Verdict de rattachement PCAET par SIREN porteur pour un projet : dernière décision
+   * rattachement_pcaet ACTIVE (non supersédée) par PCAET (la plus récente prime en cas
+   * de décisions actives contradictoires). Seuls les verdicts confirme/infirme sont retenus.
+   */
+  private async rattachementsByPcaet(projetId: string): Promise<Map<string, "confirme" | "infirme">> {
+    const rows = await this.query<{ siren: string; verdict: string | null }>(sql`
+      SELECT DISTINCT ON (d.objet_b_id) d.objet_b_id AS siren, d.verdict
+      FROM decisions_humaines.decisions d
+      WHERE d.type_decision = 'rattachement_pcaet'
+        AND d.objet_a_id = ${projetId}
+        AND d.objet_b_type = 'pcaet'
+        AND ${activeDecisionPredicate("d")}
+      ORDER BY d.objet_b_id, d.created_at DESC
+    `);
+    const map = new Map<string, "confirme" | "infirme">();
+    for (const r of rows) {
+      if (r.verdict === "confirme" || r.verdict === "infirme") map.set(r.siren, r.verdict);
+    }
+    return map;
   }
 
   /**

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -3,6 +3,7 @@ import { DatabaseService } from "@database/database.service";
 import { mecExternalIds } from "@database/schema";
 import { and, eq, sql, SQL } from "drizzle-orm";
 import { activeDecisionPredicate } from "@/decisions/active-decisions";
+import { DECISION_TYPES } from "@/decisions/decision-contract";
 import { splitLeviersCsv } from "./leviers-csv";
 import {
   TerritoireDecisionDto,
@@ -26,6 +27,12 @@ const COP_STATUTS_VIVIER = ["a_remonter", "a_travailler", "hors_cop_mais_crte", 
 // Code INSEE de commune : 5 chiffres, ou code corse 2A/2B + 3 chiffres.
 const CODE_INSEE_REGEX = /^(\d{5}|2[AB]\d{3})$/;
 const SIREN_REGEX = /^\d{9}$/;
+
+// Bornes de l'enrichissement decisions[] (journal à l'échelle humaine, mais append-only) :
+// - garde-fou global sur la requête (taille du result-set),
+// - plafond par groupe sur la réponse exposée (les plus récentes d'abord).
+const DECISIONS_QUERY_LIMIT = 2000;
+const DECISIONS_PER_GROUP_CAP = 100;
 
 // Aligné sur dashboard-te.service : budget prévisionnel plafonné (les valeurs
 // aberrantes deviennent NULL). Le budget est stocké en TEXT dans schema_commun_v2.
@@ -115,7 +122,9 @@ export class TerritoiresService {
           SELECT DISTINCT ON (d.objet_a_id) d.objet_a_id AS oid, d.verdict
           FROM decisions_humaines.decisions d
           WHERE d.type_decision = 'projet_statut' AND ${activeDecisionPredicate("d")}
-          ORDER BY d.objet_a_id, d.created_at DESC
+          -- Départage déterministe des created_at égaux (import/backfill en une
+          -- transaction ⇒ now() figé) : id DESC, aligné sur le pipeline.
+          ORDER BY d.objet_a_id, d.created_at DESC, d.id DESC
         ) s
         WHERE s.verdict = 'obsolete'
       ),
@@ -293,8 +302,10 @@ export class TerritoiresService {
         d.commentaire
       FROM decisions_humaines.decisions d
       WHERE (d.objet_a_id = ANY(${textArray(ids)}) OR d.objet_b_id = ANY(${textArray(ids)}))
+        AND d.type_decision = ANY(${textArray([...DECISION_TYPES])})
         AND ${activeDecisionPredicate("d")}
-      ORDER BY d.created_at DESC
+      ORDER BY d.created_at DESC, d.id DESC
+      LIMIT ${DECISIONS_QUERY_LIMIT}
     `);
 
     for (const r of rows) {
@@ -308,13 +319,16 @@ export class TerritoiresService {
         commentaire: r.commentaire,
       };
       // Une décision de doublon touche deux traces (A↔B) potentiellement dans deux
-      // groupes distincts : l'attacher à chacun, une seule fois par groupe.
+      // groupes distincts : l'attacher à chacun, une seule fois par groupe, dans la
+      // limite du plafond par groupe (les plus récentes d'abord, déjà triées).
       const touched = new Set<TerritoireGroupeDto>();
       const groupA = groupByTraceId.get(r.objetAId);
       const groupB = r.objetBId != null ? groupByTraceId.get(r.objetBId) : undefined;
       if (groupA) touched.add(groupA);
       if (groupB) touched.add(groupB);
-      for (const g of touched) g.decisions.push(decision);
+      for (const g of touched) {
+        if (g.decisions.length < DECISIONS_PER_GROUP_CAP) g.decisions.push(decision);
+      }
     }
   }
 
@@ -393,7 +407,8 @@ export class TerritoiresService {
         AND d.objet_a_id = ${projetId}
         AND d.objet_b_type = 'pcaet'
         AND ${activeDecisionPredicate("d")}
-      ORDER BY d.objet_b_id, d.created_at DESC
+      -- id DESC départage les created_at égaux (cf. obsolete_pids), aligné sur le pipeline.
+      ORDER BY d.objet_b_id, d.created_at DESC, d.id DESC
     `);
     const map = new Map<string, "confirme" | "infirme">();
     for (const r of rows) {

--- a/docs/api/GUIDE_DECISIONS.md
+++ b/docs/api/GUIDE_DECISIONS.md
@@ -1,0 +1,262 @@
+# Guide des décisions — API Collectivités
+
+> Public : plateformes partenaires (MEC, TeT, et tout service connecté) qui veulent
+> **agir** sur le référentiel partagé, pas seulement le lire.
+> Spec machine : Swagger de l'instance (`/api`), section « Décisions » et « Territoires ».
+> Contact été : **Jean** (voir §7).
+
+---
+
+## 1. Ce que ça vous apporte
+
+Vos agents voient dans votre interface des rapprochements que l'API a calculés
+(« ces deux projets sont probablement le même », « ce PCAET couvre ce projet ») : les
+**décisions** vous permettent de renvoyer leur jugement au référentiel, une fois pour toutes.
+Une décision est un événement **qui survit à tous les recalculs** du pipeline : ce que votre
+agent confirme aujourd'hui ne sera pas défait par le prochain traitement de nuit. En retour,
+vous lisez les décisions de **toutes** les plateformes sur un même projet, ce qui transforme
+une donnée « probable » en donnée « tranchée par un humain ».
+
+## 2. Le modèle mental
+
+Cinq notions suffisent.
+
+- **Trace** : une occurrence d'un projet réel dans **une** source (MEC, Vivier COP, Fonds Vert,
+  DGCL…). Chaque trace a un `id` stable — c'est **la seule référence à persister** chez vous et
+  la seule qu'une décision accepte.
+- **Groupe** : l'ensemble des traces que le pipeline pense décrire **le même projet réel**.
+  Un groupe n'a **pas** d'identifiant exposé : sa composition est recalculée à chaque run, donc
+  rien qui le désigne n'est stable. On raisonne sur les `id` des traces, jamais sur « le groupe ».
+- **Rôle** : une trace est un `projet` ou un `financement` (DGCL, Fonds Vert). Un financement
+  se rattache au projet du groupe, il n'est pas un projet distinct.
+- **Confiance** : `CERTAIN` (lien établi), `PROBABLE` (suggestion à confirmer), `null` (trace
+  seule). C'est le pipeline qui la calcule ; vos décisions sont ce qui la fait devenir « certaine ».
+- **Décision** : le jugement d'un humain sur une ou deux traces (doublon, statut, rattachement,
+  correction). Append-only : on ne modifie ni ne supprime, on **révoque** en réémettant.
+
+### Un exemple réel — la crèche Pom'Cannelle à Amiens (INSEE `80021`)
+
+Le même projet de rénovation existe dans trois sources. Le pipeline les a regroupés en un
+groupe `PROBABLE` :
+
+| Rôle        | Source     | `id` (trace)                               | Ce qu'en dit la source                                           |
+| ----------- | ---------- | ------------------------------------------ | ---------------------------------------------------------------- |
+| projet      | MEC        | `019dab94-…-a538bdd8` (`externalId` 48345) | « Rénover énergétiquement la crèche Pom'Cannelle »               |
+| financement | Fonds Vert | `12603143`                                 | « Rénovation énergétique de la Crèche Pom Cannelle » — _Accepté_ |
+| projet      | Vivier COP | `cop_20687601`                             | même intitulé — _En instruction_                                 |
+
+Un agent qui reconnaît qu'il s'agit bien du même dossier poste **une** décision
+`doublon_confirme` entre la trace MEC et la trace Vivier COP. Au prochain rebuild, le pipeline
+n'aura plus à « deviner » : le lien est acté. Entre-temps, votre décision est déjà visible de
+tous dans le champ `decisions[]` du groupe (voir §3).
+
+## 3. Démarrer en 10 minutes
+
+Base : `https://api.collectivites.beta.gouv.fr` · En-tête : `Authorization: Bearer <VOTRE_CLÉ>`.
+La clé identifie votre plateforme ; toute décision que vous postez porte automatiquement
+`plateforme_source = <votre plateforme>` (le corps ne peut pas usurper une autre plateforme).
+
+### Lire un territoire et ses décisions
+
+```bash
+curl -H "Authorization: Bearer $CLE" \
+  "https://api.collectivites.beta.gouv.fr/territoires/80021/projets?limit=5"
+```
+
+```jsonc
+{
+  "total": 40,
+  "limit": 5,
+  "offset": 0,
+  "groupes": [
+    {
+      "confiance": "PROBABLE",
+      "traces": [
+        {
+          "role": "projet",
+          "source": "MEC",
+          "id": "019dab94-…",
+          "externalId": "48345",
+          "nom": "Rénover énergétiquement la crèche Pom'Cannelle",
+          "budgetPrevisionnel": 232605,
+        },
+        {
+          "role": "financement",
+          "source": "Fonds Vert",
+          "id": "12603143",
+          "statut": "Accepté",
+          "budgetPrevisionnel": 232604.72,
+        },
+        {
+          "role": "projet",
+          "source": "Vivier COP",
+          "id": "cop_20687601",
+          "statut": "En instruction",
+          "copMillesime": "2024",
+          "copStatutVivier": "a_remonter",
+        },
+      ],
+      // Décisions ACTIVES portant sur une trace du groupe, toutes plateformes confondues.
+      // Vide tant que personne n'a tranché. L'AGENT auteur n'est jamais exposé, seulement
+      // la plateforme émettrice.
+      "decisions": [],
+    },
+  ],
+}
+```
+
+Deux paramètres ajoutés par ce guide :
+
+- `?masquerObsoletes=true` (défaut `false`) : masque les groupes dont une trace a été déclarée
+  obsolète (décision `projet_statut` / `obsolete`) — la vue « projets vivants » de l'ANCT.
+- `decisions[]` est présent sur **chaque** groupe (tableau vide s'il n'y a rien).
+
+### Poster une décision (corps + réponse attendue — **ne pas exécuter ici**)
+
+Confirmer que la trace MEC et la trace Vivier COP sont le même projet :
+
+```jsonc
+// POST /decisions
+{
+  "typeDecision": "doublon_confirme",
+  "objetAType": "projet",
+  "objetAId": "019dab94-c75e-7ef8-b7ec-7971a538bdd8",
+  "objetBType": "projet",
+  "objetBId": "cop_20687601",
+  "commentaire": "Même projet, vérifié avec la collectivité",
+}
+```
+
+```jsonc
+// → 201
+{ "id": "77b096d7-…", "createdAt": "2026-07-08T…Z" }
+```
+
+Relire ce qui a été tranché sur un objet, ou par type :
+
+```bash
+curl -H "Authorization: Bearer $CLE" \
+  "https://api.collectivites.beta.gouv.fr/decisions?objetId=019dab94-c75e-7ef8-b7ec-7971a538bdd8"
+curl -H "Authorization: Bearer $CLE" \
+  "https://api.collectivites.beta.gouv.fr/decisions?type=projet_statut"
+```
+
+`GET /decisions` est **cloisonné** : vous ne relisez que **vos** décisions. À l'inverse,
+`decisions[]` dans la vue territoire agrège **toutes** les plateformes (sans l'auteur).
+
+## 4. Les parcours, un par type de décision
+
+`typeDecision` est un **vocabulaire fermé** : toute autre valeur est refusée (`400`). Chaque
+type impose ses contraintes ; un champ manquant ou interdit donne un `400` nommant le champ.
+
+| `typeDecision`        | objet A                  | objet B                                           | `verdict`                       | `payload`                                         |
+| --------------------- | ------------------------ | ------------------------------------------------- | ------------------------------- | ------------------------------------------------- |
+| `doublon_signale`     | `projet`\|`fiche_action` | `projet`\|`fiche_action` (requis)                 | interdit                        | libre                                             |
+| `doublon_confirme`    | idem                     | requis                                            | interdit                        | libre                                             |
+| `doublon_infirme`     | idem                     | requis                                            | interdit                        | libre                                             |
+| `rattachement_pcaet`  | `projet`                 | `pcaet` + `objetBId` = SIREN porteur (9 chiffres) | `confirme`\|`infirme`           | libre                                             |
+| `projet_statut`       | `projet`                 | interdit                                          | `valide`\|`obsolete`\|`termine` | libre                                             |
+| `correction_signalee` | tout type                | interdit                                          | interdit                        | **requis** : `{ champ, valeurProposee, source? }` |
+
+**Effet immédiat vs effet au rebuild.** Toute décision est **immédiatement** lisible
+(`decisions[]`, `rattachement`, `masquerObsoletes` lisent le journal en direct). En revanche,
+la **composition des groupes** et la **confiance** ne changent qu'au prochain **rebuild** du
+pipeline, qui consomme vos décisions. Autrement dit : le signal est instantané, la refonte du
+regroupement est différée.
+
+- **Doublons** (`doublon_signale` → `_confirme` / `_infirme`). Séquence : votre agent voit un
+  groupe `PROBABLE` (ou soupçonne un rapprochement absent) → il poste la décision entre les deux
+  `traces[].id`. Immédiat : la décision apparaît dans `decisions[]` des deux groupes concernés.
+  Au rebuild : un `_confirme` pousse le pipeline à fusionner, un `_infirme` l'empêche de refusionner.
+
+- **Rattachement PCAET** (`rattachement_pcaet`, `verdict` `confirme`/`infirme`). L'objet B est le
+  PCAET, désigné par le **SIREN de son porteur** (`objetBType: "pcaet"`, `objetBId` = 9 chiffres).
+  Immédiat : `GET /projets/mec/{externalId}/plans-territoire` renvoie sur chaque PCAET un champ
+  `rattachement` = `confirme` | `infirme` | `aucun`, dérivé de votre décision active la plus récente.
+
+- **Statut de projet** (`projet_statut`, `verdict` `valide`/`obsolete`/`termine`). Immédiat :
+  `?masquerObsoletes=true` retire de la liste les groupes dont une trace est `obsolete`. C'est le
+  levier « vivant/mort » : il pilote l'affichage sans rien détruire dans les sources.
+
+- **Correction signalée** (`correction_signalee`). L'agent propose une valeur pour un champ :
+  `payload = { champ: "budgetPrevisionnel", valeurProposee: "150000", source?: "délibération 2026-03" }`.
+  Immédiat : la proposition est journalisée et visible dans `decisions[]`. Au rebuild / en revue :
+  elle alimente l'arbitrage sur la donnée de référence. Elle **ne réécrit pas** la source.
+
+### Revenir sur une décision
+
+On ne modifie ni ne supprime. Pour révoquer, réémettez en pointant l'ancienne via `supersedes` :
+
+```jsonc
+// POST /decisions
+{
+  "typeDecision": "doublon_infirme",
+  "objetAType": "projet",
+  "objetAId": "019dab94-…",
+  "objetBType": "projet",
+  "objetBId": "cop_20687601",
+  "supersedes": "77b096d7-…",
+}
+```
+
+La décision supersédée cesse d'être « active » : elle disparaît de `decisions[]`, du `rattachement`
+et du filtre obsolètes. En cas de décisions actives contradictoires sur les mêmes objets (sans lien
+`supersedes`), **la plus récente prime**.
+
+## 5. Ce qui vous appartient
+
+L'API fournit la mécanique ; l'expérience agent est de votre ressort.
+
+- **Quand proposer.** Sur `confiance: "PROBABLE"`, présentez un rapprochement **suggéré** à
+  confirmer ; sur `"CERTAIN"`, présentez un lien **établi** ; sur `null`, ne suggérez rien. Ne
+  demandez une décision que quand l'agent a la donnée pour trancher (souvent : après échange avec
+  la collectivité).
+- **Wording.** Parlez de « même projet » / « projets distincts » (doublons), de « couvert par le
+  PCAET » (rattachement), de « projet abandonné / terminé » (statut) — pas de « cluster », pas de
+  « verdict », pas d'`id` techniques à l'écran.
+- **Rythme.** Une décision suffit ; inutile de la rejouer. Si l'agent hésite, laissez-le ne rien
+  poster : l'absence de décision est un état valide (le pipeline garde sa suggestion).
+- **Réversibilité.** Offrez un « revenir en arrière » qui réémet avec `supersedes` — l'agent ne
+  doit jamais craindre de casser quelque chose de définitif.
+
+## 6. Garanties et limites
+
+Chaque limite est dite ici **avant** que vous ne la rencontriez.
+
+- **`traces[].id` stables et contractuels** — sauf les traces **DGCL** (`role: "financement"`,
+  sources `DGCL *`) : une partie de ces `id` changera au prochain recalcul. Ne les persistez pas,
+  ne les référencez pas dans une décision.
+- **Groupes et `confiance` recalculés à chaque run** : ne persistez jamais la composition d'un
+  groupe. C'est la raison pour laquelle aucun identifiant de groupe n'est exposé.
+- **Décisions hors du cycle de rebuild** : le journal survit à tous les traitements ; c'est là
+  tout son intérêt. Vos `traces[].id` restent la bonne clé d'une exécution à l'autre.
+- **Consommation au rebuild, pas à chaud.** Vos décisions sont prises en compte par le pipeline
+  **au prochain rebuild**, pas instantanément dans le regroupement. La lecture (`decisions[]`,
+  `rattachement`, obsolètes) est, elle, immédiate. La consommation « à chaud » du regroupement
+  viendra avec l'**immatriculation** des objets (chantier en cours) ; d'ici là, raisonnez « signal
+  immédiat, refonte différée ».
+- **PCAET** : `plans-territoire` s'appuie sur une table de référence livrée par un chantier séparé.
+  Tant qu'elle n'est pas en production, l'endpoint renvoie `pcaet: []` (dégradation propre, pas
+  d'erreur) ; le champ `rattachement` vaudra donc `aucun` par défaut.
+- **Cloisonnement.** `GET /decisions` ne montre que vos décisions. `decisions[]` (vue territoire)
+  montre celles de toutes les plateformes **sans l'auteur** — on partage la décision, jamais l'agent.
+
+## 7. FAQ + contact
+
+**Quelle plateforme dois-je mettre dans le corps ?** Aucune : `plateforme_source` est dérivée de
+votre clé API.
+
+**Puis-je poster une décision sur une trace DGCL ?** Non recommandé — leurs `id` ne sont pas
+stables (voir §6). Attachez la décision à une trace `projet` du groupe.
+
+**Comment corriger une erreur de saisie de mon agent ?** Réémettez avec `supersedes` pointant la
+décision fautive ; la précédente devient inactive.
+
+**Je poste `doublon_confirme` mais le groupe ne fusionne pas tout de suite. Normal ?** Oui : le
+signal est immédiat (`decisions[]`), la fusion se fait au prochain rebuild (§4, §6).
+
+**Une valeur de `typeDecision` est refusée en 400.** Le vocabulaire est fermé ; utilisez un des six
+types du tableau §4. Les anciens libellés libres (`lien_confirme`, `projet_valide`…) ne sont plus acceptés.
+
+**Contact.** Pendant l'été, adressez-vous à **Jean** pour toute question d'intégration ou tout
+comportement inattendu.

--- a/docs/api/GUIDE_DECISIONS.md
+++ b/docs/api/GUIDE_DECISIONS.md
@@ -170,7 +170,8 @@ regroupement est différée.
   Au rebuild : un `_confirme` pousse le pipeline à fusionner, un `_infirme` l'empêche de refusionner.
 
 - **Rattachement PCAET** (`rattachement_pcaet`, `verdict` `confirme`/`infirme`). L'objet B est le
-  PCAET, désigné par le **SIREN de son porteur** (`objetBType: "pcaet"`, `objetBId` = 9 chiffres).
+  PCAET, désigné par le **SIREN de son porteur** (`objetBType: "pcaet"`, `objetBId` = 9 chiffres) —
+  reprenez le `sirenPorteur` de `plans-territoire` **lorsqu'il est un SIREN** (voir la limite PCAET en §6).
   Immédiat : `GET /projets/mec/{externalId}/plans-territoire` renvoie sur chaque PCAET un champ
   `rattachement` = `confirme` | `infirme` | `aucun`, dérivé de votre décision active la plus récente.
 
@@ -202,6 +203,15 @@ On ne modifie ni ne supprime. Pour révoquer, réémettez en pointant l'ancienne
 La décision supersédée cesse d'être « active » : elle disparaît de `decisions[]`, du `rattachement`
 et du filtre obsolètes. En cas de décisions actives contradictoires sur les mêmes objets (sans lien
 `supersedes`), **la plus récente prime**.
+
+Une révision est **contrainte** (400 sinon) : elle doit être de **votre** plateforme (vous ne
+révoquez pas la décision d'un autre service) **et du même `typeDecision`** que la décision visée.
+Ce garde-fou évite qu'une décision anodine désactive silencieusement un verrou d'un autre type.
+
+**Une paire de doublon est NON ordonnée** : `(A, B)` et `(B, A)` désignent **la même** paire pour
+le référentiel (le pipeline la canonicalise). Pour revenir sur un `doublon_confirme(A, B)`, **supersédez-le**
+(même paire, `supersedes`) plutôt que de reposter `doublon_infirme(B, A)` : sans `supersedes`, les deux
+resteraient « actives » et c'est la récence qui trancherait — moins lisible dans `decisions[]`.
 
 ## 5. Ce qui vous appartient
 
@@ -235,11 +245,19 @@ Chaque limite est dite ici **avant** que vous ne la rencontriez.
   `rattachement`, obsolètes) est, elle, immédiate. La consommation « à chaud » du regroupement
   viendra avec l'**immatriculation** des objets (chantier en cours) ; d'ici là, raisonnez « signal
   immédiat, refonte différée ».
-- **PCAET** : `plans-territoire` s'appuie sur une table de référence livrée par un chantier séparé.
-  Tant qu'elle n'est pas en production, l'endpoint renvoie `pcaet: []` (dégradation propre, pas
-  d'erreur) ; le champ `rattachement` vaudra donc `aucun` par défaut.
+- **PCAET / rattachement** : la table de référence PCAET est **en production**. Le `rattachement`
+  s'appuie sur le **SIREN du porteur** (`objetBType: "pcaet"`, `objetBId` = 9 chiffres) : il ne
+  fonctionne donc que pour les PCAET dont le porteur est identifié par un vrai SIREN (aujourd'hui les
+  fiches `source: "opendata"`). Les fiches `source: "snapshot"` exposent encore un identifiant non-SIREN
+  côté `sirenPorteur` — le référentiel PCAET est en cours de normalisation côté pipeline ; d'ici là,
+  `rattachement` reste `aucun` pour ces fiches et une décision `rattachement_pcaet` avec un `objetBId`
+  non-SIREN est refusée (400). Par ailleurs, si la table de référence était absente, `plans-territoire`
+  dégrade proprement en `pcaet: []` (pas d'erreur).
 - **Cloisonnement.** `GET /decisions` ne montre que vos décisions. `decisions[]` (vue territoire)
   montre celles de toutes les plateformes **sans l'auteur** — on partage la décision, jamais l'agent.
+- **`commentaire` traverse la frontière inter-plateformes.** Le `commentaire` d'une décision est exposé
+  dans `decisions[]` à **toutes** les plateformes (contrairement à l'auteur, masqué). N'y mettez **aucune
+  donnée personnelle** (nom, e-mail, téléphone d'un porteur) : réservez-le à une justification factuelle.
 
 ## 7. FAQ + contact
 
@@ -250,7 +268,8 @@ votre clé API.
 stables (voir §6). Attachez la décision à une trace `projet` du groupe.
 
 **Comment corriger une erreur de saisie de mon agent ?** Réémettez avec `supersedes` pointant la
-décision fautive ; la précédente devient inactive.
+décision fautive ; la précédente devient inactive. La révision doit être de **votre** plateforme et
+du **même type** que la décision visée (400 sinon).
 
 **Je poste `doublon_confirme` mais le groupe ne fusionne pas tout de suite. Normal ?** Oui : le
 signal est immédiat (`decisions[]`), la fusion se fait au prochain rebuild (§4, §6).

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -106,15 +106,19 @@ Le « GET leviers » : qualification calculée par le pipeline.
 
 Journal **append-only** : chaque validation/infirmation d'un agent (DDT, collectivité)
 est un événement qui **survit aux recalculs du pipeline**. Implémentation côté MEC prévue
-à la rentrée — le contrat est figé dès maintenant.
+à la rentrée — le contrat est figé dès maintenant. **Détails, parcours et exemples : voir
+[`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md).**
+
+`typeDecision` est désormais un **vocabulaire fermé** (toute autre valeur → `400`), et chaque
+type impose ses contraintes (objetB/verdict/payload requis ou interdits) : `doublon_signale`,
+`doublon_confirme`, `doublon_infirme`, `rattachement_pcaet`, `projet_statut`, `correction_signalee`.
 
 ```bash
 curl -X POST -H "Authorization: Bearer $MEC_API_KEY" -H "Content-Type: application/json" \
   "$BASE/decisions" -d '{
-    "typeDecision": "lien_confirme",
+    "typeDecision": "doublon_confirme",
     "objetAType": "projet", "objetAId": "019dab93-f4cc-7641-8bd6-3f69a44c49f3",
     "objetBType": "projet", "objetBId": "cop_20675265",
-    "verdict": "confirme",
     "auteur": "agent-ddtm-59",
     "commentaire": "Même projet, confirmé avec la collectivité"
   }'
@@ -124,13 +128,14 @@ curl -X POST -H "Authorization: Bearer $MEC_API_KEY" -H "Content-Type: applicati
 Règles :
 - `objetAId`/`objetBId` = **toujours les `traces[].id`** (jamais un identifiant de groupe,
   qui n'existe d'ailleurs pas dans l'API) ;
-- `typeDecision` libre mais convenu : `lien_confirme`, `lien_infirme`, `doublon_signale`,
-  `projet_valide`, `projet_obsolete`, `rattachement_pcaet` ;
+- pour un doublon, `verdict` est **interdit** (le type porte le sens) ; `verdict` n'existe que
+  pour `rattachement_pcaet` (`confirme`|`infirme`) et `projet_statut` (`valide`|`obsolete`|`termine`) ;
 - pas de modification/suppression : pour revenir sur une décision, poster un nouvel
   événement avec `supersedes: "<uuid de la décision révoquée>"` (le pipeline apprendra à les
-  consommer — un lien `infirme` ne sera pas recréé) ;
-- `GET /decisions?objetId=<id>` pour relire les décisions d'un objet — **chaque service ne
-  voit que ses propres décisions** (filtrées sur la plateforme authentifiée).
+  consommer — un doublon `infirme` ne sera pas recréé) ;
+- `GET /decisions?objetId=<id>` (ou `?type=<type>`) pour relire les décisions — **chaque service
+  ne voit que ses propres décisions** (filtrées sur la plateforme authentifiée). En vue territoire,
+  `decisions[]` agrège toutes les plateformes, sans l'auteur.
 
 ## Cadrage POC PCAET — 5 EPCI (feature flag côté MEC)
 

--- a/docs/api/openapi-territoires-decisions.yaml
+++ b/docs/api/openapi-territoires-decisions.yaml
@@ -40,6 +40,10 @@ paths:
           in: query
           schema: { type: boolean, default: false }
           description: Inclure les groupes composés uniquement de financements DGCL/Fonds Vert
+        - name: masquerObsoletes
+          in: query
+          schema: { type: boolean, default: false }
+          description: Exclure les groupes dont une trace porte une décision active projet_statut / obsolete
       responses:
         "200":
           content:
@@ -79,7 +83,13 @@ paths:
                         sirenPorteur: { type: string }
                         presentDansTet: { type: boolean }
                         tetExternalId: { type: string, nullable: true }
-                        source: { type: string, enum: [snapshot, opendata], description: Canal live exclu en V1 (issue #497) }
+                        source: { type: string, enum: [snapshot, opendata], description: "Canal live exclu en V1 (issue #497)" }
+                        rattachement:
+                          type: string
+                          enum: [confirme, infirme, aucun]
+                          description: >
+                            Décision active rattachement_pcaet la plus récente entre ce projet et ce PCAET
+                            (SIREN porteur) ; 'aucun' par défaut.
                   fichesActionSuggerees:
                     type: array
                     items: { type: object }
@@ -138,14 +148,22 @@ paths:
           description: Décision enregistrée
         "400": { description: Corps invalide }
     get:
-      summary: Décisions référençant un objet (audit)
+      summary: Décisions par objet et/ou par type (audit)
+      description: Au moins un filtre requis (objetId et/ou type). Cloisonné au service authentifié.
       parameters:
         - name: objetId
           in: query
-          required: true
+          required: false
           schema: { type: string }
+        - name: type
+          in: query
+          required: false
+          schema:
+            type: string
+            enum: [doublon_signale, doublon_confirme, doublon_infirme, rattachement_pcaet, projet_statut, correction_signalee]
       responses:
         "200": { description: "Décisions du service authentifié uniquement (max 100, plus récentes d'abord)" }
+        "400": { description: "Aucun filtre (ni objetId ni type) ou type hors enum" }
 components:
   securitySchemes:
     bearerAuth: { type: http, scheme: bearer }
@@ -164,6 +182,22 @@ components:
         traces:
           type: array
           items: { $ref: "#/components/schemas/Trace" }
+        decisions:
+          type: array
+          description: >
+            Décisions humaines ACTIVES portant sur une trace du groupe, toutes plateformes
+            confondues, SANS l'agent auteur (PII + cloisonnement inter-plateformes).
+          items: { $ref: "#/components/schemas/Decision" }
+    Decision:
+      type: object
+      properties:
+        type: { type: string, description: Type de décision (vocabulaire fermé) }
+        verdict: { type: string, nullable: true }
+        plateforme: { type: string, description: Plateforme émettrice (jamais l'agent auteur) }
+        createdAt: { type: string, format: date-time }
+        objetAId: { type: string }
+        objetBId: { type: string, nullable: true }
+        commentaire: { type: string, nullable: true }
     Trace:
       type: object
       properties:
@@ -184,15 +218,24 @@ components:
       properties:
         typeDecision:
           type: string
-          description: lien_confirme | lien_infirme | doublon_signale | projet_valide | projet_obsolete | rattachement_pcaet | …
+          enum: [doublon_signale, doublon_confirme, doublon_infirme, rattachement_pcaet, projet_statut, correction_signalee]
+          description: >
+            Vocabulaire FERMÉ (400 sinon). Contraintes croisées par type sur objetB/verdict/payload
+            (voir GUIDE_DECISIONS.md). Ex. : verdict interdit pour les doublons ; requis pour
+            rattachement_pcaet (confirme|infirme) et projet_statut (valide|obsolete|termine) ;
+            payload { champ, valeurProposee, source? } requis pour correction_signalee.
         objetAType: { type: string, enum: [projet, fiche_action, plan, financement] }
         objetAId: { type: string, description: ID objet stable (JAMAIS un identifiant de groupe) }
-        objetBType: { type: string, enum: [projet, fiche_action, plan, financement], nullable: true }
+        objetBType:
+          type: string
+          enum: [projet, fiche_action, plan, financement, pcaet]
+          nullable: true
+          description: "'pcaet' réservé à rattachement_pcaet (objetBId = SIREN porteur, 9 chiffres)"
         objetBId: { type: string, nullable: true }
-        verdict: { type: string, nullable: true, description: confirme | infirme | fusionner | … }
+        verdict: { type: string, nullable: true, description: Valeurs contraintes par type (voir typeDecision) }
         auteur: { type: string, nullable: true }
         commentaire: { type: string, nullable: true }
-        payload: { type: object, nullable: true, description: "Max ~10 ko sérialisé" }
+        payload: { type: object, nullable: true, description: "Max ~10 ko sérialisé ; forme imposée pour correction_signalee" }
         supersedes: { type: string, format: uuid, nullable: true, description: Décision révoquée par cet événement }
       description: >
         plateforme_source n'est PAS dans le corps — elle est dérivée du service authentifié.

--- a/docs/api/openapi-territoires-decisions.yaml
+++ b/docs/api/openapi-territoires-decisions.yaml
@@ -234,8 +234,12 @@ components:
         objetBId: { type: string, nullable: true }
         verdict: { type: string, nullable: true, description: Valeurs contraintes par type (voir typeDecision) }
         auteur: { type: string, nullable: true }
-        commentaire: { type: string, nullable: true }
+        commentaire: { type: string, nullable: true, description: "Exposé cross-plateforme dans decisions[] — pas de PII" }
         payload: { type: object, nullable: true, description: "Max ~10 ko sérialisé ; forme imposée pour correction_signalee" }
-        supersedes: { type: string, format: uuid, nullable: true, description: Décision révoquée par cet événement }
+        supersedes:
+          type: string
+          format: uuid
+          nullable: true
+          description: "Décision révoquée. Doit être de la MÊME plateforme et du MÊME typeDecision (400 sinon)."
       description: >
         plateforme_source n'est PAS dans le corps — elle est dérivée du service authentifié.


### PR DESCRIPTION
## Objectif

Transformer le journal `decisions_humaines` (jusqu'ici un simple log en écriture libre) en
**contrat** exploitable par les plateformes partenaires : une taxonomie fermée en écriture, une
sémantique « décision active » claire, et des **effets immédiats en lecture** sur les endpoints
territoire/PCAET.

Aucune migration DB : la table existe déjà en prod (une seule ligne de recette). Le durcissement
est côté application (validation + lecture).

## Contrat de taxonomie (`typeDecision` = enum FERMÉE, 400 sinon)

| type | objetA | objetB | verdict | payload |
|---|---|---|---|---|
| `doublon_signale` | `projet`\|`fiche_action` | requis, `projet`\|`fiche_action` | interdit | libre ≤10 ko |
| `doublon_confirme` | idem | requis | interdit | libre |
| `doublon_infirme` | idem | requis | interdit | libre |
| `rattachement_pcaet` | `projet` | requis, `pcaet` + SIREN porteur (9 chiffres) | `confirme`\|`infirme` | libre |
| `projet_statut` | `projet` | interdit | `valide`\|`obsolete`\|`termine` | libre |
| `correction_signalee` | tout type | interdit | interdit | **requis** `{champ, valeurProposee, source?}` |

- Validation en deux temps : **class-validator** au niveau DTO (enum, types, longueurs, UUID,
  taille payload) + **validation croisée par type** dans un module dédié
  (`decision-contract.ts`), qui lève un `400` **nommant le champ fautif et le type**.
- Émetteurs : tous les services authentifiés (pas de restriction par type en V1). `plateforme_source`
  reste dérivée du guard (jamais du corps).
- `objetBType='pcaet'` + SIREN : le PCAET n'a pas d'`id` de trace stable propre (les `plan_id` ont
  trois canaux snapshot/opendata/live dont la couverture bouge d'un run à l'autre). Le SIREN du
  porteur est la clé stable de `pcaet_reference` → c'est lui qu'on référence.

## Sémantique « décision active » (helper SQL réutilisable)

`active-decisions.ts` expose `activeDecisionPredicate(alias)` : une décision est **active** tant
qu'aucune autre ne la supersède (chaîne de révocation append-only). En cas de décisions actives
**contradictoires** sur les mêmes objets, **la plus récente prime** (`DISTINCT ON (…) ORDER BY
created_at DESC` au point d'appel). Le prédicat est réutilisé par les trois effets territoire.

## Effets immédiats en lecture

1. **`GET /territoires/:code/projets`** — chaque groupe gagne `decisions[]` : les décisions **actives**
   dont `objet_a_id` OU `objet_b_id` est une trace du groupe, **toutes plateformes confondues, SANS
   l'auteur** (PII + cloisonnement inter-plateformes). Perf : **une seule requête pour toute la page**
   (jointure sur les index `objet_a/b_id`, pas de N+1) puis rattachement en mémoire.
2. **`GET /projets/mec/:externalId/plans-territoire`** — chaque PCAET gagne
   `rattachement`: `confirme` | `infirme` | `aucun`, dérivé de la décision `rattachement_pcaet`
   active la plus récente entre ce projet et ce SIREN PCAET.
3. **`?masquerObsoletes=true`** (défaut `false`) sur l'endpoint territoire — exclut les groupes dont
   une trace porte une décision active `projet_statut`/`obsolete` (le « vivant/mort » ANCT). Filtré
   **dans la requête SQL** (donc `total` et pagination restent justes).
4. **`GET /decisions`** — ajoute le filtre `type=` en plus d'`objetId` ; **au moins un des deux**
   requis (400 sinon), `type` validé contre l'enum. Toujours cloisonné par plateforme, `limit 100`.

## Documentation

- **`docs/api/GUIDE_DECISIONS.md`** (nouveau) — doc humaine, 7 sections, vouvoiement, « groupe »
  (pas « cluster »), aucune date promise. Exemple **réel** : la crèche Pom'Cannelle à Amiens
  (`80021`), 3 sources MEC + Fonds Vert + Vivier COP. Corps `POST` montrés **sans être postés**.
- `INTEGRATION_MEC.md` §4 aligné (l'ancien exemple postait `lien_confirme`, désormais refusé en 400)
  et renvoyant au guide.
- `openapi-territoires-decisions.yaml` mis à jour (enum fermée, `decisions[]`, `rattachement`,
  `masquerObsoletes`, filtre `type`).

## Tests

`pnpm --filter api type-check && lint && format:check` : zéro erreur. Suites décisions + territoires :
**94 tests** (spécifiques via `jest --globalSetup=noop` car le sandbox n'a pas Docker).

- `decision-contract.spec.ts` : par type, cas passant **et** un `400` par champ manquant/interdit.
- `decisions.service` : contrat validé **avant** insertion (aucune écriture si 400) ; `find` par
  objet et/ou type ; cloisonnement.
- `decisions.controller` : `objetId` et/ou `type`, 400 si aucun / type hors enum.
- `territoires.service` : `decisions[]` (une requête, sans auteur, dédup A↔B), `masquerObsoletes`
  (assertion sur le SQL généré via `PgDialect`), `rattachement`, filtres COP, EPCI.

**Validation SQL bout-en-bout contre la prod (lecture seule)** : les requêtes des 4 effets
s'exécutent réellement (Amiens, EPCI Arras, projet MEC Pom'Cannelle) ; sémantiques « matching
A/B », « la plus récente prime » et « supersédée exclue » vérifiées positivement par injection
`VALUES` read-only.

## Hors périmètre / suites

- Consommation « à chaud » du regroupement par le pipeline : viendra avec l'immatriculation
  (aujourd'hui, signal immédiat en lecture, refonte du regroupement au prochain rebuild — documenté).
- `pcaet_reference` : livrable d'un chantier séparé ; tant qu'elle n'est pas en prod,
  `plans-territoire` renvoie `pcaet: []` (dégradation propre) et `rattachement` vaut `aucun`.

**Ne pas merger** : revue adversariale d'abord.


---

## Correctifs post-revue adversariale (commit `fix: durcir décisions v2…`)

Suite à la revue (rapport 2 agents). Les 2 findings **bloquants** sont côté **pipeline
`dashboard-te`** (traités en parallèle : le rebuild injectera les paires `doublon_confirme`, et la
matview PCAET est en cours de normalisation) — ci-dessous les correctifs **côté API/doc** :

- **`supersedes` validé** (finding important) : au `create()`, la décision cible doit exister, être
  de la **même plateforme** (cloisonnement) et du **même `typeDecision`** — `400` explicite sinon.
  Sans ça, une `correction_signalee` anodine pouvait désactiver un `doublon_infirme` d'une autre
  plateforme (prédicat d'activité type-agnostique). Tests : 400 par cas (plateforme, type, introuvable).
- **Départage déterministe** (mineur) : `, d.id DESC` ajouté aux `DISTINCT ON` (`obsolete_pids`,
  `rattachementsByPcaet`). `created_at` (now()) est figé par transaction → égalités réelles ; aligné
  sur le pipeline. Asserté sur le SQL généré.
- **`decisions[]` filtré au vocabulaire fermé** (mineur) : `type_decision = ANY(DECISION_TYPES)` —
  vérifié en prod : la ligne legacy `test_recette_prod` (trace `cop_20675265`) ne remonte plus.
- **`decisions[]` borné** (mineur) : `LIMIT` sur la requête + plafond par groupe.
- **Doc corrigée** (mineur/factuel) : la matview `pcaet_reference` **EST en prod** (922 lignes) —
  l'ancienne mention « tant qu'elle n'est pas en production, `pcaet: []` » était fausse. `rattachement`
  ne s'applique qu'aux PCAET à SIREN (opendata, 558) ; les 364 fiches snapshot portent un id non-SIREN
  (normalisation pipeline en cours) → limite dite explicitement. Paire de doublon **non ordonnée**
  documentée (superséder plutôt que reposter en ordre inverse). PII interdite dans `commentaire`
  (exposé cross-plateforme).

Tests : **97** (94 + 3 supersedes). `type-check`/`lint`/`format:check` verts ; SQL re-validé contre la
prod en lecture seule. **Toujours NE PAS MERGER.**
