### PR TITLE
feat: verdict 'annule' pour révoquer une décision (complément #511)

### DIFF
--- a/api/src/decisions/active-decisions.ts
+++ b/api/src/decisions/active-decisions.ts
@@ -1,4 +1,5 @@
 import { sql, SQL } from "drizzle-orm";
+import { ANNULE_VERDICT } from "./decision-contract";
 
 // ============================================================
 // Helper SQL réutilisable : « décision active »
@@ -25,3 +26,13 @@ export const activeDecisionPredicate = (alias = "d"): SQL =>
     SELECT 1 FROM decisions_humaines.decisions sup
     WHERE sup.supersedes = ${sql.raw(alias)}.id
   )`;
+
+/**
+ * Prédicat SQL à injecter dans un WHERE : exclut les décisions « pierre tombale »
+ * (verdict='annule'), qui ne servent qu'à révoquer leur cible via `supersedes` et
+ * n'affirment rien. À combiner avec `activeDecisionPredicate` dans tout effet de
+ * lecture (decisions[], rattachement, obsolètes). `IS DISTINCT FROM` conserve les
+ * verdicts NULL (aucun verdict ≠ annule).
+ */
+export const notTombstonePredicate = (alias = "d"): SQL =>
+  sql`${sql.raw(alias)}.verdict IS DISTINCT FROM ${ANNULE_VERDICT}`;

--- a/api/src/decisions/decision-contract.spec.ts
+++ b/api/src/decisions/decision-contract.spec.ts
@@ -162,4 +162,60 @@ describe("validateDecisionContract", () => {
       expectRejects({ ...base, payload: { champ: "nom", valeurProposee: "x", source: 12 } }, /payload\.source/);
     });
   });
+
+  describe("verdict 'annule' (révocation universelle)", () => {
+    const target = "3f2504e0-4f89-41d3-9a0c-0305e82c3301";
+    const doublon = {
+      typeDecision: "doublon_confirme",
+      objetAType: "projet",
+      objetAId: "a",
+      objetBType: "projet",
+      objetBId: "b",
+    };
+    const statut = { typeDecision: "projet_statut", objetAType: "projet", objetAId: "a" };
+    const pcaet = {
+      typeDecision: "rattachement_pcaet",
+      objetAType: "projet",
+      objetAId: "a",
+      objetBType: "pcaet",
+      objetBId: "200000172",
+    };
+    const correction = { typeDecision: "correction_signalee", objetAType: "projet", objetAId: "a" };
+
+    it("400 pour 'annule' sans supersedes, quel que soit le type", () => {
+      expectRejects({ ...doublon, verdict: "annule" }, /annule.*exige supersedes/);
+      expectRejects({ ...statut, verdict: "annule" }, /annule.*exige supersedes/);
+      expectRejects({ ...pcaet, verdict: "annule" }, /annule.*exige supersedes/);
+      // correction_signalee sans payload : 'annule' court-circuite la règle payload → c'est
+      // bien supersedes qui manque (et non le payload) qui est signalé.
+      expectRejects({ ...correction, verdict: "annule" }, /annule.*exige supersedes/);
+    });
+
+    it("accepte 'annule' + supersedes pour tous les types (bypass verdict/payload métier)", () => {
+      expect(ok({ ...doublon, verdict: "annule", supersedes: target })).not.toThrow();
+      expect(ok({ ...statut, verdict: "annule", supersedes: target })).not.toThrow();
+      expect(ok({ ...pcaet, verdict: "annule", supersedes: target })).not.toThrow();
+      // Pas de payload de correction requis pour révoquer une correction_signalee.
+      expect(ok({ ...correction, verdict: "annule", supersedes: target })).not.toThrow();
+    });
+
+    it("conserve les contraintes structurelles d'objet B propres au type", () => {
+      // Un doublon révoqué reste structurellement un doublon : objetB requis.
+      expectRejects(
+        {
+          typeDecision: "doublon_confirme",
+          objetAType: "projet",
+          objetAId: "a",
+          verdict: "annule",
+          supersedes: target,
+        },
+        /objetBType et objetBId requis/,
+      );
+      // projet_statut interdit toujours objetB, même en révocation.
+      expectRejects(
+        { ...statut, objetBType: "projet", objetBId: "b", verdict: "annule", supersedes: target },
+        /objetBType\/objetBId interdits/,
+      );
+    });
+  });
 });

--- a/api/src/decisions/decision-contract.ts
+++ b/api/src/decisions/decision-contract.ts
@@ -34,6 +34,16 @@ export const DECISION_TYPES = [
 ] as const;
 export type DecisionType = (typeof DECISION_TYPES)[number];
 
+// Verdict de RÉVOCATION universel. Valide pour TOUS les types, à la seule condition
+// que `supersedes` désigne la décision cible (400 sinon). Sémantique : retire la cible
+// sans rien affirmer. Les décisions verdict='annule' sont des pierres tombales :
+// exclues de tous les effets de lecture (decisions[], rattachement, obsolètes) — elles
+// ne servent qu'à désactiver leur cible via la chaîne `supersedes`.
+// (Nécessaire car pour les doublons `verdict` est sinon interdit : sans ce mécanisme,
+// la ligne qui supersède serait elle-même une décision active du même type, donc le
+// verrou persisterait — la révocation serait inexprimable.)
+export const ANNULE_VERDICT = "annule";
+
 // SIREN du porteur PCAET : 9 chiffres.
 const SIREN_REGEX = /^\d{9}$/;
 
@@ -116,6 +126,7 @@ export interface DecisionContractInput {
   objetBId?: string | null;
   verdict?: string | null;
   payload?: Record<string, unknown> | null;
+  supersedes?: string | null;
 }
 
 /**
@@ -160,6 +171,21 @@ export function validateDecisionContract(dto: DecisionContractInput): void {
     throw new BadRequestException(`objetBType/objetBId interdits ${forType}`);
   }
 
+  // Révocation universelle : verdict='annule' est valide pour TOUS les types, à la
+  // seule condition qu'une cible soit désignée. Il court-circuite les règles de verdict
+  // ET de payload propres au type (une révocation n'affirme rien : ni verdict métier,
+  // ni charge de correction). La compatibilité de la cible (même plateforme, même type)
+  // est vérifiée côté service via `supersedes`.
+  const isAnnule = dto.verdict === ANNULE_VERDICT;
+  if (isAnnule) {
+    if (dto.supersedes == null || dto.supersedes === "") {
+      throw new BadRequestException(
+        `verdict "${ANNULE_VERDICT}" exige supersedes (décision cible à révoquer) ${forType}`,
+      );
+    }
+    return;
+  }
+
   // Verdict : requis (valeur contrainte) ou interdit selon le type.
   if (spec.verdict.required) {
     if (dto.verdict == null) {
@@ -167,11 +193,13 @@ export function validateDecisionContract(dto: DecisionContractInput): void {
     }
     if (!spec.verdict.values.includes(dto.verdict)) {
       throw new BadRequestException(
-        `verdict "${dto.verdict}" invalide ${forType} (attendu : ${spec.verdict.values.join(", ")})`,
+        `verdict "${dto.verdict}" invalide ${forType} (attendu : ${spec.verdict.values.join(", ")}, ou "${ANNULE_VERDICT}" avec supersedes)`,
       );
     }
   } else if (dto.verdict != null) {
-    throw new BadRequestException(`verdict interdit ${forType}`);
+    throw new BadRequestException(
+      `verdict interdit ${forType} (sauf "${ANNULE_VERDICT}" avec supersedes pour révoquer)`,
+    );
   }
 
   // Payload : forme imposée pour correction_signalee, libre sinon.

--- a/api/src/decisions/decisions.service.spec.ts
+++ b/api/src/decisions/decisions.service.spec.ts
@@ -120,6 +120,28 @@ describe("DecisionsService", () => {
       expect(insertedValues).toBeUndefined();
     });
 
+    it("persiste une révocation verdict='annule' quand la cible est compatible", async () => {
+      service = buildService({
+        returning: [{ id: "dec-9", createdAt }],
+        selectRows: [{ plateformeSource: "MEC", typeDecision: "doublon_confirme" }],
+      });
+
+      await service.create(
+        {
+          typeDecision: "doublon_confirme",
+          objetAType: "projet",
+          objetAId: "a",
+          objetBType: "projet",
+          objetBId: "b",
+          verdict: "annule",
+          supersedes: "dec-1",
+        },
+        "MEC",
+      );
+
+      expect(insertedValues).toMatchObject({ verdict: "annule", supersedes: "dec-1" });
+    });
+
     it("normalise les champs optionnels absents en null (dont supersedes)", async () => {
       service = buildService({ returning: [{ id: "dec-2", createdAt }] });
 

--- a/api/src/decisions/dto/create-decision.dto.ts
+++ b/api/src/decisions/dto/create-decision.dto.ts
@@ -94,7 +94,9 @@ export class CreateDecisionDto {
   @ApiPropertyOptional({
     description:
       "Verdict associé. Valeurs contraintes par type : confirme|infirme (rattachement_pcaet), " +
-      "valide|obsolete|termine (projet_statut) ; interdit pour les doublons et correction_signalee.",
+      "valide|obsolete|termine (projet_statut) ; interdit pour les doublons et correction_signalee. " +
+      "Cas spécial : 'annule' est valide pour TOUS les types si supersedes est fourni (révocation " +
+      "sans rien affirmer ; ces lignes sont exclues des effets de lecture).",
     maxLength: 100,
   })
   @IsOptional()

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -110,6 +110,8 @@ describe("TerritoiresService", () => {
       expect(decisionsSql).toContain("type_decision = ANY");
       expect(decisionsSql).toContain("d.id DESC");
       expect(decisionsSql).toContain("LIMIT");
+      // Les révocations (verdict='annule') sont exclues des décisions exposées.
+      expect(decisionsSql).toContain("verdict IS DISTINCT FROM");
     });
 
     it("ne lance pas de requête de décisions quand la page est vide", async () => {
@@ -127,6 +129,8 @@ describe("TerritoiresService", () => {
       expect(pageSql).toContain("has_obsolete = FALSE");
       // Départage déterministe des created_at égaux dans obsolete_pids.
       expect(pageSql).toContain("d.id DESC");
+      // Les révocations projet_statut (verdict='annule') ne comptent pas comme obsolètes.
+      expect(pageSql).toContain("verdict IS DISTINCT FROM");
     });
 
     it("masquerObsoletes=false (défaut) n'ajoute pas le filtre has_obsolete", async () => {
@@ -288,9 +292,11 @@ describe("TerritoiresService", () => {
         ],
         fichesActionSuggerees: [],
       });
-      // La requête de rattachement départage les created_at égaux (id DESC).
+      // La requête de rattachement départage les created_at égaux (id DESC) et exclut
+      // les révocations (verdict='annule').
       const rattachementSql = renderSql((execute.mock.calls[4] as unknown[])[0]);
       expect(rattachementSql).toContain("d.id DESC");
+      expect(rattachementSql).toContain("verdict IS DISTINCT FROM");
     });
 
     it("rattachement='aucun' quand aucune décision active", async () => {

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -2,7 +2,7 @@ import { BadRequestException, Injectable, NotFoundException } from "@nestjs/comm
 import { DatabaseService } from "@database/database.service";
 import { mecExternalIds } from "@database/schema";
 import { and, eq, sql, SQL } from "drizzle-orm";
-import { activeDecisionPredicate } from "@/decisions/active-decisions";
+import { activeDecisionPredicate, notTombstonePredicate } from "@/decisions/active-decisions";
 import { DECISION_TYPES } from "@/decisions/decision-contract";
 import { splitLeviersCsv } from "./leviers-csv";
 import {
@@ -121,7 +121,11 @@ export class TerritoiresService {
         FROM (
           SELECT DISTINCT ON (d.objet_a_id) d.objet_a_id AS oid, d.verdict
           FROM decisions_humaines.decisions d
-          WHERE d.type_decision = 'projet_statut' AND ${activeDecisionPredicate("d")}
+          WHERE d.type_decision = 'projet_statut'
+            AND ${activeDecisionPredicate("d")}
+            -- Les révocations (verdict='annule') ne participent pas au « plus récent gagne » :
+            -- exclues, sinon une révocation d'une décision sans lien masquerait un obsolète actif.
+            AND ${notTombstonePredicate("d")}
           -- Départage déterministe des created_at égaux (import/backfill en une
           -- transaction ⇒ now() figé) : id DESC, aligné sur le pipeline.
           ORDER BY d.objet_a_id, d.created_at DESC, d.id DESC
@@ -304,6 +308,8 @@ export class TerritoiresService {
       WHERE (d.objet_a_id = ANY(${textArray(ids)}) OR d.objet_b_id = ANY(${textArray(ids)}))
         AND d.type_decision = ANY(${textArray([...DECISION_TYPES])})
         AND ${activeDecisionPredicate("d")}
+        -- Pierres tombales (verdict='annule') exclues : elles ne font que révoquer leur cible.
+        AND ${notTombstonePredicate("d")}
       ORDER BY d.created_at DESC, d.id DESC
       LIMIT ${DECISIONS_QUERY_LIMIT}
     `);
@@ -407,6 +413,8 @@ export class TerritoiresService {
         AND d.objet_a_id = ${projetId}
         AND d.objet_b_type = 'pcaet'
         AND ${activeDecisionPredicate("d")}
+        -- Révocations (verdict='annule') exclues : une décision annulée ne rattache rien.
+        AND ${notTombstonePredicate("d")}
       -- id DESC départage les created_at égaux (cf. obsolete_pids), aligné sur le pipeline.
       ORDER BY d.objet_b_id, d.created_at DESC, d.id DESC
     `);

--- a/docs/api/GUIDE_DECISIONS.md
+++ b/docs/api/GUIDE_DECISIONS.md
@@ -158,6 +158,10 @@ type impose ses contraintes ; un champ manquant ou interdit donne un `400` nomma
 | `projet_statut`       | `projet`                 | interdit                                          | `valide`\|`obsolete`\|`termine` | libre                                             |
 | `correction_signalee` | tout type                | interdit                                          | interdit                        | **requis** : `{ champ, valeurProposee, source? }` |
 
+**Révocation transverse** : quel que soit le type, `verdict: "annule"` **avec** `supersedes` est
+accepté et retire la décision cible sans rien affirmer (voir « Revenir sur une décision » ci-dessous).
+Les lignes `annule` sont exclues de tous les effets de lecture.
+
 **Effet immédiat vs effet au rebuild.** Toute décision est **immédiatement** lisible
 (`decisions[]`, `rattachement`, `masquerObsoletes` lisent le journal en direct). En revanche,
 la **composition des groupes** et la **confiance** ne changent qu'au prochain **rebuild** du
@@ -184,34 +188,39 @@ regroupement est différée.
   Immédiat : la proposition est journalisée et visible dans `decisions[]`. Au rebuild / en revue :
   elle alimente l'arbitrage sur la donnée de référence. Elle **ne réécrit pas** la source.
 
-### Revenir sur une décision
+### Revenir sur une décision — la révocation `annule`
 
-On ne modifie ni ne supprime. Pour révoquer, réémettez en pointant l'ancienne via `supersedes` :
+On ne modifie ni ne supprime. Pour **révoquer** une décision (revenir à « je n'ai rien dit »),
+réémettez-la à l'identique avec **`verdict: "annule"`** et **`supersedes`** pointant la décision à
+retirer :
 
-```jsonc
-// POST /decisions
-{
-  "typeDecision": "doublon_infirme",
-  "objetAType": "projet",
-  "objetAId": "019dab94-…",
-  "objetBType": "projet",
-  "objetBId": "cop_20687601",
-  "supersedes": "77b096d7-…",
-}
+```bash
+curl -X POST -H "Authorization: Bearer $CLE" -H "Content-Type: application/json" \
+  "https://api.collectivites.beta.gouv.fr/decisions" -d '{
+    "typeDecision": "doublon_confirme",
+    "objetAType": "projet", "objetAId": "019dab94-c75e-7ef8-b7ec-7971a538bdd8",
+    "objetBType": "projet", "objetBId": "cop_20687601",
+    "verdict": "annule",
+    "supersedes": "77b096d7-…"
+  }'
+# → 201 { "id": "…", "createdAt": "…" }
 ```
 
-La décision supersédée cesse d'être « active » : elle disparaît de `decisions[]`, du `rattachement`
-et du filtre obsolètes. En cas de décisions actives contradictoires sur les mêmes objets (sans lien
-`supersedes`), **la plus récente prime**.
+`verdict: "annule"` est valide pour **tous** les types **à la seule condition** que `supersedes` soit
+renseigné (sinon 400 : « annule exige supersedes »). Sa sémantique : **retirer la cible sans rien
+affirmer**. C'est le SEUL moyen de lever un `doublon_signale/confirme/infirme` (dont le `verdict` est
+sinon interdit).
 
-Une révision est **contrainte** (400 sinon) : elle doit être de **votre** plateforme (vous ne
-révoquez pas la décision d'un autre service) **et du même `typeDecision`** que la décision visée.
-Ce garde-fou évite qu'une décision anodine désactive silencieusement un verrou d'un autre type.
+Effets : la décision cible **et** la ligne `annule` elle-même **disparaissent de tous les effets de
+lecture** (`decisions[]`, `rattachement`, filtre obsolètes) — une `annule` ne sert qu'à désactiver sa
+cible. Une révocation est **contrainte** (400 sinon) : elle doit être de **votre** plateforme (vous ne
+révoquez pas la décision d'un autre service) **et du même `typeDecision`** que la cible.
 
-**Une paire de doublon est NON ordonnée** : `(A, B)` et `(B, A)` désignent **la même** paire pour
-le référentiel (le pipeline la canonicalise). Pour revenir sur un `doublon_confirme(A, B)`, **supersédez-le**
-(même paire, `supersedes`) plutôt que de reposter `doublon_infirme(B, A)` : sans `supersedes`, les deux
-resteraient « actives » et c'est la récence qui trancherait — moins lisible dans `decisions[]`.
+- **Changer d'avis** (p. ex. passer de `confirme` à `infirme`) : postez simplement la nouvelle
+  décision. Sur les mêmes objets, en l'absence de `supersedes`, **la plus récente prime**.
+- **Une paire de doublon est NON ordonnée** : `(A, B)` et `(B, A)` désignent **la même** paire (le
+  pipeline la canonicalise). Pour révoquer, réémettez avec `annule` + `supersedes` plutôt que de
+  reposter dans l'ordre inverse — plus lisible et sans ambiguïté dans `decisions[]`.
 
 ## 5. Ce qui vous appartient
 
@@ -267,9 +276,9 @@ votre clé API.
 **Puis-je poster une décision sur une trace DGCL ?** Non recommandé — leurs `id` ne sont pas
 stables (voir §6). Attachez la décision à une trace `projet` du groupe.
 
-**Comment corriger une erreur de saisie de mon agent ?** Réémettez avec `supersedes` pointant la
-décision fautive ; la précédente devient inactive. La révision doit être de **votre** plateforme et
-du **même type** que la décision visée (400 sinon).
+**Comment annuler une décision de mon agent ?** Réémettez-la avec `verdict: "annule"` et `supersedes`
+pointant la décision fautive : la cible **et** la ligne d'annulation sortent de tous les effets de
+lecture. La révocation doit être de **votre** plateforme et du **même type** que la cible (400 sinon).
 
 **Je poste `doublon_confirme` mais le groupe ne fusionne pas tout de suite. Normal ?** Oui : le
 signal est immédiat (`decisions[]`), la fusion se fait au prochain rebuild (§4, §6).

--- a/docs/api/openapi-territoires-decisions.yaml
+++ b/docs/api/openapi-territoires-decisions.yaml
@@ -186,7 +186,8 @@ components:
           type: array
           description: >
             Décisions humaines ACTIVES portant sur une trace du groupe, toutes plateformes
-            confondues, SANS l'agent auteur (PII + cloisonnement inter-plateformes).
+            confondues, SANS l'agent auteur (PII + cloisonnement inter-plateformes). Les révocations
+            (verdict='annule') et les décisions supersédées sont exclues.
           items: { $ref: "#/components/schemas/Decision" }
     Decision:
       type: object
@@ -232,7 +233,13 @@ components:
           nullable: true
           description: "'pcaet' réservé à rattachement_pcaet (objetBId = SIREN porteur, 9 chiffres)"
         objetBId: { type: string, nullable: true }
-        verdict: { type: string, nullable: true, description: Valeurs contraintes par type (voir typeDecision) }
+        verdict:
+          type: string
+          nullable: true
+          description: >
+            Valeurs contraintes par type (voir typeDecision). Cas spécial : 'annule' est valide pour
+            TOUS les types SI supersedes est fourni (400 sinon) — révocation qui retire la cible sans
+            rien affirmer ; les lignes verdict='annule' sont exclues de tous les effets de lecture.
         auteur: { type: string, nullable: true }
         commentaire: { type: string, nullable: true, description: "Exposé cross-plateforme dans decisions[] — pas de PII" }
         payload: { type: object, nullable: true, description: "Max ~10 ko sérialisé ; forme imposée pour correction_signalee" }


### PR DESCRIPTION
## Complément à #511 (déjà mergée) — mécanisme de révocation `annule`

Défaut de contrat découvert en **acceptation réelle** (dry-run pipeline) : la règle introduite en
#511 « `supersedes` = même `typeDecision` » rend la **révocation inexprimable** pour
`doublon_signale/confirme/infirme`. Leur `verdict` est interdit, donc la ligne qui supersède est
elle-même une décision **active du même type** → le verrou persiste. On ne pouvait pas « défaire ».

## Amendement

`verdict: "annule"` devient **valide pour tous les types**, à la **seule condition** que
`supersedes` soit renseigné (`400` sinon : « annule exige supersedes »).

- **Sémantique** : retire la décision cible **sans rien affirmer**. C'est le seul moyen de lever un
  doublon (dont le `verdict` est sinon interdit).
- **Court-circuite** les règles de `verdict` **et** de `payload` propres au type (une révocation
  n'affirme ni verdict métier, ni correction). Les contraintes **structurelles d'objet B** du type
  restent appliquées (un doublon révoqué reste structurellement un doublon).
- **Pierre tombale** : les lignes `verdict='annule'` sont **exclues de tous les effets de lecture**
  (`decisions[]`, `rattachement`, filtre obsolètes) — helper `notTombstonePredicate` ajouté aux trois
  requêtes. Elles ne servent qu'à désactiver leur cible via `supersedes`.
- La compatibilité de la cible (même plateforme, même type — introduite en #511) reste vérifiée au
  `create()`.

## Fichiers

- `api/src/decisions/decision-contract.ts` : `ANNULE_VERDICT`, branche `annule` dans
  `validateDecisionContract` (return anticipé, bypass verdict/payload).
- `api/src/decisions/active-decisions.ts` : `notTombstonePredicate(alias)` (`verdict IS DISTINCT FROM 'annule'`).
- `api/src/territoires/territoires.service.ts` : prédicat ajouté à `attachActiveDecisions`,
  `obsolete_pids`, `rattachementsByPcaet`.
- `docs/api/GUIDE_DECISIONS.md` §4 « Revenir sur une décision » réécrit (exemple curl `annule`) ;
  `openapi-territoires-decisions.yaml` + DTO mis à jour.

## Tests — 101 (97 + 4)

- Contrat : `annule` sans `supersedes` → 400 (tous types) ; `annule` + `supersedes` → ok (bypass
  verdict/payload) ; contraintes d'objet B conservées.
- Service : persistance `verdict='annule'`.
- Territoire : exclusion `annule` assertée sur le SQL généré (3 requêtes).
- **Preuve read-only en prod** (injection `VALUES`) : une cible révoquée **et** sa ligne `annule`
  sortent de `decisions[]` tandis qu'une décision indépendante reste ; un `confirme` révoqué par
  `annule` → `rattachement: aucun`.

`type-check`/`lint`/`format:check` (tous packages) + gitleaks OK. SQL re-validé contre la prod.
**NE PAS MERGER** — en attente de revue.
