### PR TITLE
feat: doctrine d'accès aux données (data_scopes, registre vide)

### DIFF
--- a/api/drizzle/0041_services_data_scopes.sql
+++ b/api/drizzle/0041_services_data_scopes.sql
@@ -1,0 +1,10 @@
+-- Doctrine d'accès aux données : colonne data_scopes sur public.services.
+--
+-- public.services est le catalogue du widget (services découvrables), PAS la couche
+-- d'authentification (les clés API sont en variables d'environnement). Le scope d'un
+-- service appelant est donc résolu par NOM : services.name = serviceType du guard
+-- (MEC, TeT, DashboardTE, UrbanVitaliz…). Voir docs/api/DOCTRINE_ACCES_DONNEES.md.
+--
+-- Vide par défaut ('{}') : aucune donnée restreinte en base aujourd'hui → aucun
+-- filtrage, aucune régression. On installe le mécanisme AVANT la donnée.
+ALTER TABLE "services" ADD COLUMN "data_scopes" text[] NOT NULL DEFAULT '{}';

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -288,6 +288,13 @@
       "when": 1783419912637,
       "tag": "0040_decisions_humaines",
       "breakpoints": true
+    },
+    {
+      "idx": 41,
+      "version": "7",
+      "when": 1783507993444,
+      "tag": "0041_services_data_scopes",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -140,6 +140,11 @@ export const services = pgTable("services", {
   redirectionLabel: text("redirection_label"),
   iframeUrl: text("iframe_url"),
   extendLabel: text("extend_label"),
+  // Doctrine d'accès aux données : scopes détenus par ce service. Un service ne voit
+  // une source restreinte (RESTRICTED_SOURCES) que s'il porte le scope requis. La
+  // correspondance service appelant → ligne se fait par `name` = serviceType du guard
+  // (voir docs/api/DOCTRINE_ACCES_DONNEES.md). Vide par défaut → aucun accès restreint.
+  dataScopes: text("data_scopes").array().notNull().default([]),
 });
 
 export const serviceContext = pgTable(

--- a/api/src/security/restricted-sources.spec.ts
+++ b/api/src/security/restricted-sources.spec.ts
@@ -1,0 +1,27 @@
+import { forbiddenSourcesFor, hasRestrictedSources, RESTRICTED_SOURCES } from "./restricted-sources";
+
+describe("restricted-sources (doctrine d'accès)", () => {
+  it("registre par défaut VIDE : aucune source restreinte (non-régression stricte)", () => {
+    expect(Object.keys(RESTRICTED_SOURCES)).toHaveLength(0);
+    expect(hasRestrictedSources()).toBe(false);
+    expect(forbiddenSourcesFor([])).toEqual([]);
+    expect(forbiddenSourcesFor(["nimporte_quel_scope"])).toEqual([]);
+  });
+
+  // Registre simulé pour l'ouverture DGCL à venir.
+  const registry = { "DGCL non financés": "dgcl_non_finances" };
+
+  it("service sans le scope requis → la source est interdite", () => {
+    expect(forbiddenSourcesFor([], registry)).toEqual(["DGCL non financés"]);
+    expect(forbiddenSourcesFor(["autre_scope"], registry)).toEqual(["DGCL non financés"]);
+  });
+
+  it("service porteur du scope → la source est autorisée (absente des interdits)", () => {
+    expect(forbiddenSourcesFor(["dgcl_non_finances"], registry)).toEqual([]);
+  });
+
+  it("hasRestrictedSources reflète l'état du registre", () => {
+    expect(hasRestrictedSources({})).toBe(false);
+    expect(hasRestrictedSources(registry)).toBe(true);
+  });
+});

--- a/api/src/security/restricted-sources.ts
+++ b/api/src/security/restricted-sources.ts
@@ -1,0 +1,37 @@
+// ============================================================
+// Doctrine d'accès aux données — registre des sources restreintes
+// ============================================================
+//
+// « Qui voit quoi ». Certaines sources de projets ne sont visibles que par les
+// services de l'État qui détiennent le scope de données correspondant (voir
+// docs/api/DOCTRINE_ACCES_DONNEES.md). On installe le mécanisme AVANT la donnée :
+// le registre est VIDE aujourd'hui → aucune source restreinte → aucun filtrage,
+// non-régression stricte.
+//
+// Clé   : source_origine (schema_commun_v2.projets_operationnels.source_origine).
+// Valeur: scope requis, à présenter dans services.data_scopes du service appelant.
+
+export const RESTRICTED_SOURCES: Record<string, string> = {
+  // Ouverture DGCL à venir — la publication des dossiers NON financés est à la
+  // discrétion des préfets ; l'accès sera conditionné à un scope dédié :
+  // "DGCL non financés": "dgcl_non_finances",
+};
+
+/**
+ * Sources restreintes que le service appelant N'A PAS le droit de voir, compte tenu
+ * de ses scopes. Fonction pure (le registre est injectable pour les tests).
+ * Registre vide → `[]` (aucune restriction, aucun filtre à appliquer).
+ */
+export function forbiddenSourcesFor(
+  callerScopes: readonly string[],
+  registry: Record<string, string> = RESTRICTED_SOURCES,
+): string[] {
+  return Object.entries(registry)
+    .filter(([, requiredScope]) => !callerScopes.includes(requiredScope))
+    .map(([source]) => source);
+}
+
+/** Vrai si au moins une source est restreinte (permet de court-circuiter tout lookup). */
+export function hasRestrictedSources(registry: Record<string, string> = RESTRICTED_SOURCES): boolean {
+  return Object.keys(registry).length > 0;
+}

--- a/api/src/territoires/territoires.controller.spec.ts
+++ b/api/src/territoires/territoires.controller.spec.ts
@@ -1,9 +1,12 @@
+import { Request } from "express";
 import { TerritoiresController } from "./territoires.controller";
 import { TerritoiresService } from "./territoires.service";
 
 describe("TerritoiresController", () => {
   let controller: TerritoiresController;
   let service: { territoireProjets: jest.Mock; plansProjetsTerritoire: jest.Mock };
+
+  const req = { serviceType: "MEC" } as unknown as Request;
 
   const lastParams = (): Record<string, unknown> => {
     const calls = service.territoireProjets.mock.calls as unknown[][];
@@ -26,59 +29,67 @@ describe("TerritoiresController", () => {
 
   describe("sources (param répété vs virgules)", () => {
     it("aplati un param répété en tableau (pas de 500)", async () => {
-      await controller.territoireProjets("01001", { sources: ["MEC", "Vivier COP"] });
+      await controller.territoireProjets(req, "01001", { sources: ["MEC", "Vivier COP"] });
       expect(lastParams().sources).toEqual(["MEC", "Vivier COP"]);
     });
 
     it("découpe la forme séparée par des virgules", async () => {
-      await controller.territoireProjets("01001", { sources: "MEC,Vivier COP" });
+      await controller.territoireProjets(req, "01001", { sources: "MEC,Vivier COP" });
       expect(lastParams().sources).toEqual(["MEC", "Vivier COP"]);
     });
 
     it("sources absent → undefined", async () => {
-      await controller.territoireProjets("01001", {});
+      await controller.territoireProjets(req, "01001", {});
       expect(lastParams().sources).toBeUndefined();
     });
   });
 
   describe("limit (borné à 1..200)", () => {
     it("limit=0 est ramené à 1", async () => {
-      await controller.territoireProjets("01001", { limit: "0" });
+      await controller.territoireProjets(req, "01001", { limit: "0" });
       expect(lastParams().limit).toBe(1);
     });
 
     it("limit > 200 est plafonné à 200", async () => {
-      await controller.territoireProjets("01001", { limit: "500" });
+      await controller.territoireProjets(req, "01001", { limit: "500" });
       expect(lastParams().limit).toBe(200);
     });
 
     it("limit absent → défaut 50", async () => {
-      await controller.territoireProjets("01001", {});
+      await controller.territoireProjets(req, "01001", {});
       expect(lastParams().limit).toBe(50);
     });
   });
 
   it("mappe copStatutVivier et inclureFinancementsSeuls", async () => {
-    await controller.territoireProjets("01001", {
+    await controller.territoireProjets(req, "01001", {
       copStatutVivier: "a_remonter",
       inclureFinancementsSeuls: "true",
     });
     expect(lastParams()).toMatchObject({ copStatutVivier: "a_remonter", inclureFinancementsSeuls: true });
   });
 
+  it("transmet le serviceType appelant aux deux vues territoriales (doctrine d'accès)", async () => {
+    const reqTet = { serviceType: "TeT" } as unknown as Request;
+    await controller.territoireProjets(reqTet, "01001", {});
+    await controller.plansProjetsTerritoire(reqTet, "244400404", {});
+    expect((service.territoireProjets.mock.calls[0] as unknown[])[2]).toBe("TeT");
+    expect((service.plansProjetsTerritoire.mock.calls[0] as unknown[])[2]).toBe("TeT");
+  });
+
   describe("masquerObsoletes (défaut false)", () => {
     it("masquerObsoletes='true' → true", async () => {
-      await controller.territoireProjets("01001", { masquerObsoletes: "true" });
+      await controller.territoireProjets(req, "01001", { masquerObsoletes: "true" });
       expect(lastParams().masquerObsoletes).toBe(true);
     });
 
     it("absent → false", async () => {
-      await controller.territoireProjets("01001", {});
+      await controller.territoireProjets(req, "01001", {});
       expect(lastParams().masquerObsoletes).toBe(false);
     });
 
     it("valeur autre que 'true' → false", async () => {
-      await controller.territoireProjets("01001", { masquerObsoletes: "1" });
+      await controller.territoireProjets(req, "01001", { masquerObsoletes: "1" });
       expect(lastParams().masquerObsoletes).toBe(false);
     });
   });
@@ -90,7 +101,7 @@ describe("TerritoiresController", () => {
     };
 
     it("transmet la clé et les mêmes paramètres de filtrage (bornes limit, sources CSV) au service", async () => {
-      await controller.plansProjetsTerritoire("244400404", { sources: "MEC,Vivier COP", limit: "500" });
+      await controller.plansProjetsTerritoire(req, "244400404", { sources: "MEC,Vivier COP", limit: "500" });
       const { cle, params } = lastPlansCall();
       expect(cle).toBe("244400404");
       // Parsing mutualisé avec territoires/:code/projets : mêmes bornes et découpage.
@@ -98,7 +109,7 @@ describe("TerritoiresController", () => {
     });
 
     it("renvoie la réponse du service (en-tête pcaet + groupes)", async () => {
-      const result = await controller.plansProjetsTerritoire("019ce410-84fe-7174-a27c-4cec8c632cf4", {});
+      const result = await controller.plansProjetsTerritoire(req, "019ce410-84fe-7174-a27c-4cec8c632cf4", {});
       expect(result).toMatchObject({ pcaet: { sirenPorteur: "244400404" }, total: 0, groupes: [] });
     });
   });

--- a/api/src/territoires/territoires.controller.ts
+++ b/api/src/territoires/territoires.controller.ts
@@ -1,5 +1,6 @@
-import { Controller, Get, Param, Query, UseGuards } from "@nestjs/common";
+import { Controller, Get, Param, Query, Req, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
 import { ApiKeyGuard } from "@/auth/api-key-guard";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
@@ -91,8 +92,13 @@ export class TerritoiresController {
     response: TerritoireProjetsResponse,
     description: "Groupes de projets du territoire",
   })
-  territoireProjets(@Param("code") code: string, @Query() query: RawQuery): Promise<TerritoireProjetsResponse> {
-    return this.territoiresService.territoireProjets(code, parseProjetsParams(query));
+  territoireProjets(
+    @Req() request: Request,
+    @Param("code") code: string,
+    @Query() query: RawQuery,
+  ): Promise<TerritoireProjetsResponse> {
+    // serviceType dérivé de la clé API (doctrine d'accès : résout les scopes du service).
+    return this.territoiresService.territoireProjets(code, parseProjetsParams(query), request.serviceType!);
   }
 
   @TrackApiUsage()
@@ -138,8 +144,12 @@ export class TerritoiresController {
     response: PlansProjetsTerritoireResponse,
     description: "Projets du territoire du PCAET, avec rattachement par groupe",
   })
-  plansProjetsTerritoire(@Param("cle") cle: string, @Query() query: RawQuery): Promise<PlansProjetsTerritoireResponse> {
-    return this.territoiresService.plansProjetsTerritoire(cle, parseProjetsParams(query));
+  plansProjetsTerritoire(
+    @Req() request: Request,
+    @Param("cle") cle: string,
+    @Query() query: RawQuery,
+  ): Promise<PlansProjetsTerritoireResponse> {
+    return this.territoiresService.plansProjetsTerritoire(cle, parseProjetsParams(query), request.serviceType!);
   }
 
   @TrackApiUsage()

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -44,7 +44,7 @@ describe("TerritoiresService", () => {
         })
         .mockResolvedValueOnce({ rows: [] }); // décisions actives de la page (aucune)
 
-      const result = await service.territoireProjets("01001", params);
+      const result = await service.territoireProjets("01001", params, "MEC");
 
       expect(result).toEqual({
         total: 1,
@@ -85,7 +85,7 @@ describe("TerritoiresService", () => {
           ],
         });
 
-      const result = await service.territoireProjets("01001", params);
+      const result = await service.territoireProjets("01001", params, "MEC");
 
       // Une seule requête de décisions pour toute la page.
       expect(execute).toHaveBeenCalledTimes(3);
@@ -116,14 +116,14 @@ describe("TerritoiresService", () => {
 
     it("ne lance pas de requête de décisions quand la page est vide", async () => {
       execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
-      const result = await service.territoireProjets("01001", params);
+      const result = await service.territoireProjets("01001", params, "MEC");
       expect(result).toEqual({ total: 0, limit: 50, offset: 0, groupes: [] });
       expect(execute).toHaveBeenCalledTimes(2);
     });
 
     it("masquerObsoletes=true ajoute le filtre has_obsolete à la requête de page", async () => {
       execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
-      await service.territoireProjets("01001", { ...params, masquerObsoletes: true });
+      await service.territoireProjets("01001", { ...params, masquerObsoletes: true }, "MEC");
       const pageSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
       expect(pageSql).toContain("obsolete_pids");
       expect(pageSql).toContain("has_obsolete = FALSE");
@@ -135,22 +135,50 @@ describe("TerritoiresService", () => {
 
     it("masquerObsoletes=false (défaut) n'ajoute pas le filtre has_obsolete", async () => {
       execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
-      await service.territoireProjets("01001", params);
+      await service.territoireProjets("01001", params, "MEC");
       const pageSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
       // obsolete_pids reste calculé, mais le filtre n'est pas appliqué.
       expect(pageSql).toContain("obsolete_pids");
       expect(pageSql).not.toContain("has_obsolete = FALSE");
     });
 
+    describe("doctrine d'accès (data_scopes)", () => {
+      it("registre vide : aucune clause restreinte ni lookup de scope (non-régression)", async () => {
+        execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
+        await service.territoireProjets("01001", params, "MEC");
+        const pageSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
+        expect(pageSql).not.toContain("source_origine <> ALL");
+        // Court-circuit registre vide : aucune requête services.data_scopes.
+        expect(selectLimit).not.toHaveBeenCalled();
+      });
+
+      it("source restreinte sans scope : clause d'exclusion sur graines ET membres", async () => {
+        jest
+          .spyOn(
+            service as unknown as { resolveForbiddenSources: (s: string) => Promise<string[]> },
+            "resolveForbiddenSources",
+          )
+          .mockResolvedValue(["DGCL non financés"]);
+        execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
+
+        await service.territoireProjets("01001", params, "MEC");
+
+        const pageSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
+        // Injectée dans filtered_pids (graines) ET dans member_rows (membres de cluster).
+        const occurrences = pageSql.split("source_origine <> ALL").length - 1;
+        expect(occurrences).toBeGreaterThanOrEqual(2);
+      });
+    });
+
     it("accepte un code commune corse (2A/2B + 3)", async () => {
       execute.mockResolvedValueOnce({ rows: [{ ok: 1 }] }).mockResolvedValueOnce({ rows: [] });
-      const result = await service.territoireProjets("2a004", params);
+      const result = await service.territoireProjets("2a004", params, "MEC");
       expect(result.total).toBe(0);
     });
 
     it("404 pour une commune de format valide mais inconnue du référentiel", async () => {
       execute.mockResolvedValueOnce({ rows: [] });
-      await expect(service.territoireProjets("99999", params)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.territoireProjets("99999", params, "MEC")).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it("récupère le vrai total via un COUNT quand la page est vide au-delà de l'offset", async () => {
@@ -158,7 +186,7 @@ describe("TerritoiresService", () => {
         .mockResolvedValueOnce({ rows: [{ ok: 1 }] }) // existence commune
         .mockResolvedValueOnce({ rows: [] }) // page vide
         .mockResolvedValueOnce({ rows: [{ total: "12" }] }); // COUNT de repli
-      const result = await service.territoireProjets("01001", { ...params, offset: 100 });
+      const result = await service.territoireProjets("01001", { ...params, offset: 100 }, "MEC");
       expect(result.total).toBe(12);
       // Page vide → pas de requête de décisions.
       expect(execute).toHaveBeenCalledTimes(3);
@@ -166,24 +194,24 @@ describe("TerritoiresService", () => {
 
     it("résout un EPCI (SIREN 9 chiffres) en ses communes, 404 si aucune", async () => {
       execute.mockResolvedValueOnce({ rows: [] }); // périmètre vide
-      await expect(service.territoireProjets("200000172", params)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.territoireProjets("200000172", params, "MEC")).rejects.toBeInstanceOf(NotFoundException);
     });
 
     it("404 pour un code de format invalide (aucune requête)", async () => {
-      await expect(service.territoireProjets("abc", params)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.territoireProjets("abc", params, "MEC")).rejects.toBeInstanceOf(NotFoundException);
       expect(execute).not.toHaveBeenCalled();
     });
 
     it("400 si copMillesime invalide", async () => {
-      await expect(service.territoireProjets("01001", { ...params, copMillesime: "2099" })).rejects.toBeInstanceOf(
-        BadRequestException,
-      );
+      await expect(
+        service.territoireProjets("01001", { ...params, copMillesime: "2099" }, "MEC"),
+      ).rejects.toBeInstanceOf(BadRequestException);
       expect(execute).not.toHaveBeenCalled();
     });
 
     it("400 si copStatutVivier invalide", async () => {
       await expect(
-        service.territoireProjets("01001", { ...params, copStatutVivier: "peut_etre" }),
+        service.territoireProjets("01001", { ...params, copStatutVivier: "peut_etre" }, "MEC"),
       ).rejects.toBeInstanceOf(BadRequestException);
       expect(execute).not.toHaveBeenCalled();
     });
@@ -297,6 +325,11 @@ describe("TerritoiresService", () => {
       const rattachementSql = renderSql((execute.mock.calls[4] as unknown[])[0]);
       expect(rattachementSql).toContain("d.id DESC");
       expect(rattachementSql).toContain("verdict IS DISTINCT FROM");
+
+      // presentDansTet / tetExternalId neutralisent la chaîne vide (tet_external_id='' sur
+      // les fiches sans deep-link TeT ⇒ absence réelle, pas présence).
+      const pcaetSql = renderSql((execute.mock.calls[3] as unknown[])[0]);
+      expect(pcaetSql).toContain("NULLIF(pr.tet_external_id, '')");
     });
 
     it("rattachement='aucun' quand aucune décision active", async () => {
@@ -345,7 +378,7 @@ describe("TerritoiresService", () => {
         .mockResolvedValueOnce({ rows: [{ objetAId: "p1", verdict: "confirme" }] }) // rattachement à ce PCAET
         .mockResolvedValueOnce({ rows: [] }); // signal pcaet_operation_inscrite (aucun)
 
-      const result = await service.plansProjetsTerritoire("244400404", params);
+      const result = await service.plansProjetsTerritoire("244400404", params, "MEC");
 
       expect(result).toEqual({
         pcaet: { sirenPorteur: "244400404", nom: "PCAET de Nantes Métropole", source: "opendata" },
@@ -378,7 +411,7 @@ describe("TerritoiresService", () => {
         .mockResolvedValueOnce({ rows: [pcaetRow] })
         .mockResolvedValueOnce({ rows: [] }); // page vide → pas d'enrichissement ni de rattachement
 
-      const result = await service.plansProjetsTerritoire("019ce410-84fe-7174-a27c-4cec8c632cf4", params);
+      const result = await service.plansProjetsTerritoire("019ce410-84fe-7174-a27c-4cec8c632cf4", params, "MEC");
 
       expect(result.pcaet.sirenPorteur).toBe("244400404");
       expect(result).toMatchObject({ total: 0, groupes: [] });
@@ -395,12 +428,16 @@ describe("TerritoiresService", () => {
       execute
         .mockResolvedValueOnce({ rows: [{ present: true }] }) // référence présente
         .mockResolvedValueOnce({ rows: [] }); // clé inconnue
-      await expect(service.plansProjetsTerritoire("999999999", params)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.plansProjetsTerritoire("999999999", params, "MEC")).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
     });
 
     it("404 quand la référence PCAET n'est pas encore matérialisée", async () => {
       execute.mockResolvedValueOnce({ rows: [{ present: false }] });
-      await expect(service.plansProjetsTerritoire("244400404", params)).rejects.toBeInstanceOf(NotFoundException);
+      await expect(service.plansProjetsTerritoire("244400404", params, "MEC")).rejects.toBeInstanceOf(
+        NotFoundException,
+      );
       // Aucune requête de résolution lancée quand la matview est absente.
       expect(execute).toHaveBeenCalledTimes(1);
     });
@@ -416,7 +453,7 @@ describe("TerritoiresService", () => {
         .mockResolvedValueOnce({ rows: [] }) // aucune décision de rattachement
         .mockResolvedValueOnce({ rows: [{ id: "p1" }] }); // p1 marqué opération PCAET
 
-      const result = await service.plansProjetsTerritoire("244400404", params);
+      const result = await service.plansProjetsTerritoire("244400404", params, "MEC");
       expect(result.groupes[0].rattachement).toBe("suggere");
     });
 
@@ -431,7 +468,7 @@ describe("TerritoiresService", () => {
         .mockResolvedValueOnce({ rows: [] }) // rattachement : aucun
         .mockResolvedValueOnce({ rows: [] }); // signal : aucun
 
-      const result = await service.plansProjetsTerritoire("244400404", params);
+      const result = await service.plansProjetsTerritoire("244400404", params, "MEC");
       expect(result.groupes[0].rattachement).toBe("aucun");
     });
 
@@ -446,7 +483,7 @@ describe("TerritoiresService", () => {
         .mockResolvedValueOnce({ rows: [{ objetAId: "p1", verdict: "infirme" }] }) // décision infirme
         .mockResolvedValueOnce({ rows: [{ id: "p1" }] }); // signal présent, mais dominé
 
-      const result = await service.plansProjetsTerritoire("244400404", params);
+      const result = await service.plansProjetsTerritoire("244400404", params, "MEC");
       expect(result.groupes[0].rattachement).toBe("infirme");
     });
 
@@ -467,7 +504,7 @@ describe("TerritoiresService", () => {
         })
         .mockResolvedValueOnce({ rows: [] }); // signal
 
-      const result = await service.plansProjetsTerritoire("244400404", params);
+      const result = await service.plansProjetsTerritoire("244400404", params, "MEC");
       expect(result.groupes[0].rattachement).toBe("infirme");
     });
   });

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -1,9 +1,10 @@
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { DatabaseService } from "@database/database.service";
-import { mecExternalIds } from "@database/schema";
+import { mecExternalIds, services } from "@database/schema";
 import { and, eq, sql, SQL } from "drizzle-orm";
 import { activeDecisionPredicate, notTombstonePredicate } from "@/decisions/active-decisions";
 import { DECISION_TYPES } from "@/decisions/decision-contract";
+import { forbiddenSourcesFor, hasRestrictedSources } from "@/security/restricted-sources";
 import { splitLeviersCsv } from "./leviers-csv";
 import {
   TerritoireDecisionDto,
@@ -81,10 +82,14 @@ export class TerritoiresService {
    * Projets de transition écologique d'un territoire, regroupés par cluster de
    * déduplication. `code` = INSEE commune (5 chiffres / 2A|2B + 3) ou SIREN EPCI (9 chiffres).
    */
-  async territoireProjets(code: string, params: TerritoireProjetsParams): Promise<TerritoireProjetsResponse> {
+  async territoireProjets(
+    code: string,
+    params: TerritoireProjetsParams,
+    serviceType: string,
+  ): Promise<TerritoireProjetsResponse> {
     this.validateCopFilters(params);
     const communes = await this.resolveCommunes(code);
-    return this.projetsGroupes(communes, params);
+    return this.projetsGroupes(communes, params, serviceType);
   }
 
   // Valide les filtres COP (millésime, statut vivier) — 400 explicite sinon. Appelé AVANT
@@ -112,9 +117,15 @@ export class TerritoiresService {
   private async projetsGroupes(
     communes: string[],
     params: TerritoireProjetsParams,
+    serviceType: string,
   ): Promise<TerritoireProjetsResponse> {
     const { sources, copMillesime, copStatutVivier, limit, offset, inclureFinancementsSeuls, masquerObsoletes } =
       params;
+
+    // Doctrine d'accès : sources restreintes que ce service N'A PAS le droit de voir.
+    // Registre vide (aujourd'hui) → [] SANS aucune requête → SQL strictement inchangé.
+    // Partagé par les deux points d'entrée (territoireProjets, plansProjetsTerritoire).
+    const forbiddenSources = await this.resolveForbiddenSources(serviceType);
 
     // Filtres appliqués aux SEULS projets du territoire (avant expansion en cluster
     // complet — les membres hors territoire du même cluster sont conservés).
@@ -124,8 +135,19 @@ export class TerritoiresService {
     }
     if (copMillesime) filterConditions.push(sql`p.cop_millesime = ${copMillesime}`);
     if (copStatutVivier) filterConditions.push(sql`p.cop_statut_vivier = ${copStatutVivier}`);
+    // Exclut les sources restreintes de la sélection des projets-graines (filtered_pids).
+    // Non poussé quand la liste est vide → aucune clause ajoutée.
+    if (forbiddenSources.length > 0) {
+      filterConditions.push(sql`p.source_origine <> ALL(${textArray(forbiddenSources)})`);
+    }
     let filterWhere: SQL = sql``;
     for (const cond of filterConditions) filterWhere = sql`${filterWhere} AND ${cond}`;
+
+    // Exclut aussi les traces restreintes des MEMBRES de cluster (un cluster mixte ne doit
+    // pas laisser fuiter une trace restreinte via un projet-graine autorisé). Fragment vide
+    // quand rien n'est restreint → JOIN inchangé (byte-identique).
+    const memberRestrictedAnd: SQL =
+      forbiddenSources.length > 0 ? sql` AND p.source_origine <> ALL(${textArray(forbiddenSources)})` : sql``;
 
     // Rôle d'une trace : financement si sa source est une source de financement, sinon projet.
     const roleExpr = sql`CASE WHEN p.source_origine = ANY(${textArray([...FINANCEMENT_SOURCES])}) THEN 'financement' ELSE 'projet' END`;
@@ -218,7 +240,7 @@ export class TerritoiresService {
           -- La trace porte-t-elle une décision projet_statut active 'obsolete' ?
           EXISTS (SELECT 1 FROM obsolete_pids op WHERE op.oid = p.id) AS is_obsolete
         FROM group_members gm
-        JOIN schema_commun_v2.projets_operationnels p ON p.id = gm.pid
+        JOIN schema_commun_v2.projets_operationnels p ON p.id = gm.pid${memberRestrictedAnd}
       ),
       group_agg AS (
         SELECT
@@ -359,6 +381,33 @@ export class TerritoiresService {
   }
 
   /**
+   * Sources restreintes que le service appelant N'A PAS le droit de voir.
+   * Court-circuit strict : registre vide → `[]` SANS requête (SQL inchangé, non-régression).
+   * Sinon, un SEUL lookup des scopes du service (par nom) puis calcul pur.
+   */
+  private async resolveForbiddenSources(serviceType: string): Promise<string[]> {
+    if (!hasRestrictedSources()) return [];
+    const scopes = await this.getServiceScopes(serviceType);
+    return forbiddenSourcesFor(scopes);
+  }
+
+  /**
+   * Scopes de données d'un service, résolus par NOM (services.name = serviceType du
+   * guard). public.services est le catalogue du widget, pas la couche d'auth : la
+   * plupart des partenaires API (MEC, TeT, DashboardTE…) n'y ont pas de ligne → aucun
+   * scope → fail-closed (ils ne voient aucune source restreinte). Voir
+   * docs/api/DOCTRINE_ACCES_DONNEES.md pour la procédure d'attribution.
+   */
+  private async getServiceScopes(serviceType: string): Promise<string[]> {
+    const [row] = await this.dbService.database
+      .select({ dataScopes: services.dataScopes })
+      .from(services)
+      .where(eq(services.name, serviceType))
+      .limit(1);
+    return row?.dataScopes ?? [];
+  }
+
+  /**
    * Miroir de `territoireProjets` côté TeT : projets du territoire COUVERT par un PCAET,
    * regroupés par cluster, augmentés — par groupe — de leur `rattachement` à CE PCAET.
    * `cle` = SIREN du porteur (clé stable, 9 chiffres) OU un plan_id de la référence
@@ -366,10 +415,15 @@ export class TerritoiresService {
    * Flux d'écriture symétrique (le « je coche » côté TeT) = POST /decisions type
    * rattachement_pcaet (objetA = trace du groupe, objetB = SIREN porteur) — rien à coder ici.
    */
-  async plansProjetsTerritoire(cle: string, params: TerritoireProjetsParams): Promise<PlansProjetsTerritoireResponse> {
+  async plansProjetsTerritoire(
+    cle: string,
+    params: TerritoireProjetsParams,
+    serviceType: string,
+  ): Promise<PlansProjetsTerritoireResponse> {
     this.validateCopFilters(params);
     const pcaet = await this.resolvePcaet(cle);
-    const base = await this.projetsGroupes(pcaet.communes, params);
+    // Même doctrine d'accès que la vue territoriale (le filtre vit dans projetsGroupes).
+    const base = await this.projetsGroupes(pcaet.communes, params, serviceType);
     const groupes = await this.attachRattachements(base.groupes, pcaet.sirenPorteur);
     return {
       pcaet: { sirenPorteur: pcaet.sirenPorteur, nom: pcaet.nom, source: pcaet.source },
@@ -528,8 +582,10 @@ export class TerritoiresService {
       SELECT
         pr.nom,
         pr.siren_porteur AS "sirenPorteur",
-        (pr.tet_external_id IS NOT NULL) AS "presentDansTet",
-        pr.tet_external_id AS "tetExternalId",
+        -- tet_external_id vaut '' (chaîne vide) sur les lignes sans deep-link TeT, pas NULL :
+        -- neutralisé par NULLIF pour que presentDansTet/tetExternalId reflètent l'absence réelle.
+        (NULLIF(pr.tet_external_id, '') IS NOT NULL) AS "presentDansTet",
+        NULLIF(pr.tet_external_id, '') AS "tetExternalId",
         pr.source_nom AS source
       FROM schema_commun_v2.pcaet_reference pr
       WHERE pr.communes && ${textArray(communes)}

--- a/docs/api/DOCTRINE_ACCES_DONNEES.md
+++ b/docs/api/DOCTRINE_ACCES_DONNEES.md
@@ -1,0 +1,71 @@
+# Doctrine d'accès aux données — v0
+
+> Statut : **v0, à relire** (Livio, rentrée). Objet : « qui voit quoi » sur l'API Collectivités.
+> Le mécanisme est **installé avant la donnée** : aucune donnée restreinte n'est en base
+> aujourd'hui, le registre des sources restreintes est **vide**, aucun accès n'est donc filtré.
+
+## Pourquoi
+
+L'ouverture DGCL rendra accessibles des dossiers **non financés**, dont la publication est à la
+**discrétion des préfets**. Toute donnée n'est pas librement rediffusable : « qui voit quoi »
+devient une question de premier ordre. On implémente le contrôle d'accès **maintenant**, à vide,
+pour pouvoir affirmer — quand la donnée arrivera — que « le contrôle d'accès est déjà en production ».
+
+## Mécanisme (résumé technique)
+
+- Chaque **source** de projet peut être déclarée restreinte dans un registre applicatif
+  (`RESTRICTED_SOURCES` : `source_origine` → **scope** requis). Vide aujourd'hui.
+- Chaque **service** appelant peut détenir des **scopes** : colonne `public.services.data_scopes`
+  (`text[]`, défaut `{}`).
+- À chaque appel de l'endpoint territorial, on résout les scopes du service appelant : un projet
+  dont la source est restreinte n'apparaît que si le service porte le scope requis. Le filtrage
+  s'applique aux **projets-graines** et aux **membres de cluster** (une source restreinte ne fuit
+  pas via un regroupement mixte). **Fail-closed** : sans scope connu, aucune source restreinte n'est
+  visible.
+
+## Qui est « service de l'État »
+
+Un service connecté est un partenaire authentifié par **clé API** (en variable d'environnement),
+identifié par un `serviceType` : `MEC`, `TeT`, `DashboardTE`, `Recoco`, `UrbanVitaliz`, `SosPonts`,
+`FondVert`. L'attribution du statut « service de l'État » habilité à voir une source restreinte est
+une **décision d'administration** (pas un acquis technique) : elle se matérialise par l'ajout du
+scope correspondant au service (ci-dessous).
+
+## Attribution d'un scope — procédure
+
+Le scope est résolu **par NOM** : `services.name` doit être **égal au `serviceType`** du service
+appelant. `public.services` est le **catalogue du widget** (services découvrables), **pas** la couche
+d'authentification — d'où deux points d'attention :
+
+1. **Écart constaté (prod, juillet 2026)** : la plupart des partenaires API n'ont **pas** de ligne
+   dans `public.services`. Sur les 7 `serviceType`, seul **`UrbanVitaliz`** correspond exactement à
+   un `name` du catalogue ; `SosPonts` ≈ « SOS Ponts » (libellé différent) ; `MEC`, `TeT`,
+   `DashboardTE`, `Recoco`, `FondVert` sont **absents**. Tant qu'aucune source n'est restreinte,
+   c'est sans effet. **Avant** d'exposer de la donnée restreinte, il faudra soit créer/renommer les
+   lignes `services` correspondantes (éventuellement `is_listed=false` pour ne pas polluer le widget),
+   soit déplacer les scopes vers la couche d'auth. À trancher avec Livio.
+2. **Octroi** : pour habiliter un service `X` à une source de scope `s`, ajouter `s` à
+   `data_scopes` de la ligne `services` dont `name = 'X'` (via migration ou script d'admin
+   versionné — **jamais** de DDL/DML manuel en prod). Déclarer en parallèle la source dans
+   `RESTRICTED_SOURCES` (`source_origine` → `s`).
+
+## Journalisation
+
+Chaque appel authentifié est déjà tracé dans `public.api_requests` (`serviceName` = `serviceType`
+appelant, `endpoint`, `statusCode`, horodatage). L'accès à une source restreinte est donc **auditable**
+a posteriori par service et par endpoint, sans dispositif supplémentaire. (Aucune donnée personnelle
+de porteur n'est journalisée à ce niveau.)
+
+## Engagement de non-republication
+
+L'octroi d'un scope vaut **accès en lecture pour l'usage métier du service**, pas droit de
+**rediffusion**. Un service habilité s'engage à ne pas republier ni exposer à des tiers les données
+d'une source restreinte au-delà de son périmètre d'usage convenu. Cet engagement conditionne
+l'octroi et figure dans la convention d'accès du service.
+
+## Retrait
+
+Le retrait est **immédiat et réversible** : retirer le scope de `data_scopes` de la ligne `services`
+concernée suffit à masquer de nouveau la source à ce service dès l'appel suivant (le filtre est
+recalculé à chaque requête, aucun cache persistant). Retirer une source de `RESTRICTED_SOURCES` la
+rend au contraire visible de tous : à ne faire que sur décision explicite.


### PR DESCRIPTION
## Bloc C partie 1 — doctrine d'accès (`data_scopes`)

Installe le contrôle d'accès « qui voit quoi » **avant la donnée** (ouverture DGCL : dossiers non
financés, publication à la discrétion des préfets). **Aucune donnée restreinte en base aujourd'hui,
registre vide → aucun filtrage, non-régression stricte.** Argument de crédibilité : « le contrôle
d'accès est déjà en production ».

## Contenu

1. **Migration 0041 (manuscrite)** — `ALTER TABLE services ADD COLUMN data_scopes text[] NOT NULL
   DEFAULT '{}'`. SQL + entrée `_journal.json` (`when` = epoch ms réel via `date +%s%3N`, pas de
   snapshot — même pattern que 0038-0040). Colonne ajoutée au schéma Drizzle.
2. **Registre `RESTRICTED_SOURCES`** (`src/security/restricted-sources.ts`) : `source_origine` →
   scope requis, **VIDE**, avec l'exemple DGCL commenté. Helpers purs `forbiddenSourcesFor` /
   `hasRestrictedSources`.
3. **Filtre dans `GET /territoires/:code/projets`** : un projet dont la source est restreinte ne sort
   que si le service appelant porte le scope. Scope résolu par `services.name = serviceType` (guard),
   **1 lookup uniquement si le registre est non vide** (court-circuit strict sinon). Filtre appliqué
   aux **projets-graines** (`filtered_pids`) ET aux **membres de cluster** (`member_rows`) → pas de
   fuite via un regroupement mixte. **Registre vide → SQL inchangé** (fragments `sql` vides →
   byte-identiques).
4. **`docs/api/DOCTRINE_ACCES_DONNEES.md` v0** (relecture Livio) : service de l'État, attribution d'un
   scope, journalisation (`api_requests.serviceName`), non-republication, retrait.

## Écart important à trancher (documenté §Attribution)

`public.services` est le **catalogue du widget**, pas la couche d'auth (clés en env). Résolu par nom,
donc : sur les 7 `serviceType`, **seul `UrbanVitaliz` correspond exactement** à un `services.name` ;
`SosPonts` ≈ « SOS Ponts » ; **`MEC`, `TeT`, `DashboardTE`, `Recoco`, `FondVert` sont absents** du
catalogue. Sans impact tant que le registre est vide (fail-closed : pas de ligne → pas de scope →
aucune source restreinte visible). **Avant** d'exposer de la donnée restreinte, il faudra créer/renommer
les lignes `services` (ou déplacer les scopes vers l'auth). À arbitrer avec Livio.

## Tests (108, dont data_scopes)

- `restricted-sources.spec` : registre vide → aucune restriction ; simulé sans scope → source
  interdite ; avec scope → autorisée.
- `territoires.service.spec` : registre vide → **aucune clause `source_origine <> ALL` ni lookup de
  scope** (non-régression) ; `resolveForbiddenSources` simulé → clause d'exclusion présente **2×**
  (graines + membres).
- `territoires.controller.spec` : le `serviceType` appelant est transmis au service.
- **Validation read-only prod** : `territoireProjets("80021", …, "MEC")` inchangé (40 groupes) ;
  clause `p.source_origine <> ALL(ARRAY[…]::text[])` valide contre `projets_operationnels`.

`type-check`/`lint`/`format:check` (tous packages) + gitleaks OK.

## Hors périmètre

- Refonte des docs d'intégration (Bloc C-2) : **après** merge du Bloc B, non touchée ici.
- Le futur endpoint `plans/projets-territoire` (Bloc B, non mergé) devra appliquer le même filtre —
  à câbler à son merge.

**NE PAS MERGER** — en attente de revue.


---

## Reconstruction sur origin/main (post-merge Bloc B #514) + 2 ajouts

Rebasé/reconstruit sur `main` (Bloc B mergé). Bloc B ayant mutualisé la requête dans
`projetsGroupes(...)`, le hook de filtre y est réinjecté **une fois** → couvre les **deux** vues.

- **(a) Filtre data_scopes appliqué aussi au nouvel endpoint** `GET /plans/{cle}/projets-territoire`
  (même mécanique graines + membres) — automatique via `projetsGroupes`. Les deux points d'entrée
  (`territoireProjets`, `plansProjetsTerritoire`) transmettent le `serviceType`.
- **(b) Fix `presentDansTet` (signalé par Bloc B)** : `planFichesTerritoire` utilisait
  `tet_external_id IS NOT NULL` alors que la colonne peut valoir `''` (chaîne vide) sur les fiches
  sans deep-link TeT → passé à `NULLIF(pr.tet_external_id, '')` pour `presentDansTet` **et**
  `tetExternalId`. NB : la MV prod actuelle a `tet_external_id` **tout NULL** (post-nettoyage 922→558),
  donc le fix est un no-op sur la donnée d'aujourd'hui mais robuste au cas `''` (réapparaît au rebuild
  de la MV, tel qu'observé par Bloc B). Testé (SQL `NULLIF` asserté).

**Tests : 118.** Validé read-only prod : nouvel endpoint `plans/200067106/projets-territoire` = 149
groupes avec `rattachement` ; vue territoriale inchangée ; endpoints exécutés sans erreur.

**Prêt pour la queue.** (Hygiène git : adds nommés, aucun fichier étranger.)
