### PR TITLE
feat: sens TeT — projets d'un territoire PCAET + rattachement (miroir MEC)

### DIFF
--- a/api/src/territoires/dto/plans-projets-territoire.dto.ts
+++ b/api/src/territoires/dto/plans-projets-territoire.dto.ts
@@ -1,0 +1,53 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { TerritoireGroupeDto } from "./territoire-projets.dto";
+
+// En-tête de réponse : le PCAET résolu depuis la clé (SIREN porteur ou plan_id).
+// Seul le SIREN porteur est une clé stable (cf. decision-contract) — les plan_id
+// bougent d'un run d'ETL à l'autre et ne servent qu'à retrouver la ligne.
+export class PcaetEnteteDto {
+  @ApiProperty({ description: "SIREN du porteur du PCAET (clé stable, 9 chiffres)." })
+  sirenPorteur!: string;
+
+  @ApiPropertyOptional({ nullable: true, description: "Nom du PCAET." })
+  nom!: string | null;
+
+  @ApiPropertyOptional({
+    // Canal 'live' exclu de facto : seuls 'snapshot' et 'opendata' alimentent la référence.
+    enum: ["snapshot", "opendata"],
+    nullable: true,
+    description: "Source de la fiche PCAET de référence (source_nom).",
+  })
+  source!: string | null;
+}
+
+// Un groupe de la vue territoriale, augmenté de son rattachement AU PCAET interrogé.
+export class TerritoireGroupeRattacheDto extends TerritoireGroupeDto {
+  @ApiProperty({
+    enum: ["confirme", "infirme", "suggere", "aucun"],
+    description:
+      "État du rattachement du groupe (projet réel) à CE PCAET :\n" +
+      "- `confirme` / `infirme` : dérivé de la décision active `rattachement_pcaet` la plus récente " +
+      "entre une trace du groupe et ce PCAET (SIREN porteur) ;\n" +
+      "- `suggere` : aucune décision humaine, mais au moins une trace du groupe est marquée opération " +
+      "PCAET par le pipeline (`pcaet_operation_inscrite`) — signal indicatif, à confirmer côté TeT ;\n" +
+      "- `aucun` : ni décision, ni signal.",
+  })
+  rattachement!: "confirme" | "infirme" | "suggere" | "aucun";
+}
+
+export class PlansProjetsTerritoireResponse {
+  @ApiProperty({ type: PcaetEnteteDto, description: "PCAET résolu depuis la clé." })
+  pcaet!: PcaetEnteteDto;
+
+  @ApiProperty({ description: "Nombre total de groupes du territoire correspondant aux filtres." })
+  total!: number;
+
+  @ApiProperty()
+  limit!: number;
+
+  @ApiProperty()
+  offset!: number;
+
+  @ApiProperty({ type: [TerritoireGroupeRattacheDto] })
+  groupes!: TerritoireGroupeRattacheDto[];
+}

--- a/api/src/territoires/territoires.controller.spec.ts
+++ b/api/src/territoires/territoires.controller.spec.ts
@@ -3,7 +3,7 @@ import { TerritoiresService } from "./territoires.service";
 
 describe("TerritoiresController", () => {
   let controller: TerritoiresController;
-  let service: { territoireProjets: jest.Mock };
+  let service: { territoireProjets: jest.Mock; plansProjetsTerritoire: jest.Mock };
 
   const lastParams = (): Record<string, unknown> => {
     const calls = service.territoireProjets.mock.calls as unknown[][];
@@ -11,7 +11,16 @@ describe("TerritoiresController", () => {
   };
 
   beforeEach(() => {
-    service = { territoireProjets: jest.fn().mockResolvedValue({ total: 0, limit: 50, offset: 0, groupes: [] }) };
+    service = {
+      territoireProjets: jest.fn().mockResolvedValue({ total: 0, limit: 50, offset: 0, groupes: [] }),
+      plansProjetsTerritoire: jest.fn().mockResolvedValue({
+        pcaet: { sirenPorteur: "244400404", nom: "PCAET", source: "opendata" },
+        total: 0,
+        limit: 50,
+        offset: 0,
+        groupes: [],
+      }),
+    };
     controller = new TerritoiresController(service as unknown as TerritoiresService);
   });
 
@@ -71,6 +80,26 @@ describe("TerritoiresController", () => {
     it("valeur autre que 'true' → false", async () => {
       await controller.territoireProjets("01001", { masquerObsoletes: "1" });
       expect(lastParams().masquerObsoletes).toBe(false);
+    });
+  });
+
+  describe("plans/:cle/projets-territoire", () => {
+    const lastPlansCall = (): { cle: string; params: Record<string, unknown> } => {
+      const calls = service.plansProjetsTerritoire.mock.calls as unknown[][];
+      return { cle: calls[0][0] as string, params: calls[0][1] as Record<string, unknown> };
+    };
+
+    it("transmet la clé et les mêmes paramètres de filtrage (bornes limit, sources CSV) au service", async () => {
+      await controller.plansProjetsTerritoire("244400404", { sources: "MEC,Vivier COP", limit: "500" });
+      const { cle, params } = lastPlansCall();
+      expect(cle).toBe("244400404");
+      // Parsing mutualisé avec territoires/:code/projets : mêmes bornes et découpage.
+      expect(params).toMatchObject({ sources: ["MEC", "Vivier COP"], limit: 200 });
+    });
+
+    it("renvoie la réponse du service (en-tête pcaet + groupes)", async () => {
+      const result = await controller.plansProjetsTerritoire("019ce410-84fe-7174-a27c-4cec8c632cf4", {});
+      expect(result).toMatchObject({ pcaet: { sirenPorteur: "244400404" }, total: 0, groupes: [] });
     });
   });
 });

--- a/api/src/territoires/territoires.controller.ts
+++ b/api/src/territoires/territoires.controller.ts
@@ -3,9 +3,10 @@ import { ApiBearerAuth, ApiOperation, ApiQuery, ApiTags } from "@nestjs/swagger"
 import { ApiKeyGuard } from "@/auth/api-key-guard";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
-import { TerritoiresService } from "./territoires.service";
+import { TerritoiresService, TerritoireProjetsParams } from "./territoires.service";
 import { TerritoireProjetsResponse } from "./dto/territoire-projets.dto";
 import { PlansTerritoireResponse } from "./dto/plans-territoire.dto";
+import { PlansProjetsTerritoireResponse } from "./dto/plans-projets-territoire.dto";
 import { QualificationResponse } from "./dto/qualification.dto";
 
 type RawQuery = Record<string, string | string[] | undefined>;
@@ -29,6 +30,19 @@ const toCsvList = (value: string | string[] | undefined): string[] | undefined =
     .filter(Boolean);
   return arr.length > 0 ? arr : undefined;
 };
+
+// Paramètres de filtrage communs aux deux vues territoriales (territoires/:code/projets et
+// plans/:cle/projets-territoire) : même sémantique, mêmes bornes (limit 1..200, défaut 50).
+const parseProjetsParams = (query: RawQuery): TerritoireProjetsParams => ({
+  sources: toCsvList(query.sources),
+  copMillesime: first(query.copMillesime),
+  copStatutVivier: first(query.copStatutVivier),
+  // limit borné à 1..200 (limit=0 interdit).
+  limit: Math.min(Math.max(toInt(first(query.limit), 50), 1), 200),
+  offset: toInt(first(query.offset), 0),
+  inclureFinancementsSeuls: first(query.inclureFinancementsSeuls) === "true",
+  masquerObsoletes: first(query.masquerObsoletes) === "true",
+});
 
 @ApiBearerAuth()
 @ApiTags("Territoires")
@@ -78,16 +92,54 @@ export class TerritoiresController {
     description: "Groupes de projets du territoire",
   })
   territoireProjets(@Param("code") code: string, @Query() query: RawQuery): Promise<TerritoireProjetsResponse> {
-    return this.territoiresService.territoireProjets(code, {
-      sources: toCsvList(query.sources),
-      copMillesime: first(query.copMillesime),
-      copStatutVivier: first(query.copStatutVivier),
-      // limit borné à 1..200 (limit=0 interdit).
-      limit: Math.min(Math.max(toInt(first(query.limit), 50), 1), 200),
-      offset: toInt(first(query.offset), 0),
-      inclureFinancementsSeuls: first(query.inclureFinancementsSeuls) === "true",
-      masquerObsoletes: first(query.masquerObsoletes) === "true",
-    });
+    return this.territoiresService.territoireProjets(code, parseProjetsParams(query));
+  }
+
+  @TrackApiUsage()
+  @Get("plans/:cle/projets-territoire")
+  @ApiOperation({
+    summary: "Projets du territoire couvert par un PCAET (miroir TeT), avec rattachement par groupe",
+    description:
+      "cle = SIREN du porteur du PCAET (clé stable, 9 chiffres) ou un plan_id de la référence " +
+      "(opendata/snapshot/live), résolu vers la même fiche. 404 si la clé ne résout aucun PCAET. " +
+      "Renvoie les projets des communes couvertes, regroupés par cluster (même mécanique que " +
+      "territoires/:code/projets — traces, confiance, decisions[]), plus par groupe un champ " +
+      "`rattachement` (confirme|infirme|suggere|aucun) vis-à-vis de CE PCAET. Pour rattacher un " +
+      "projet, poster une décision rattachement_pcaet sur POST /decisions (objetA = trace du groupe, " +
+      "objetB = SIREN porteur).",
+  })
+  @ApiQuery({
+    name: "sources",
+    required: false,
+    description: "Sources (répétables ou séparées par des virgules), ex. MEC,Vivier COP.",
+  })
+  @ApiQuery({ name: "copMillesime", required: false, enum: ["2024", "2025"] })
+  @ApiQuery({
+    name: "copStatutVivier",
+    required: false,
+    enum: ["a_remonter", "a_travailler", "hors_cop_mais_crte", "non_remonte"],
+    description: "Statut vivier COP (cop_statut_vivier).",
+  })
+  @ApiQuery({ name: "limit", required: false, description: "Défaut 50, borné à 1..200." })
+  @ApiQuery({ name: "offset", required: false, description: "Défaut 0." })
+  @ApiQuery({
+    name: "inclureFinancementsSeuls",
+    required: false,
+    description: "Inclure les groupes dont toutes les traces sont des financements (défaut false).",
+  })
+  @ApiQuery({
+    name: "masquerObsoletes",
+    required: false,
+    description:
+      "Exclure les groupes dont une trace est marquée obsolète (décision active projet_statut, verdict 'obsolete'). Défaut false.",
+  })
+  @ApiEndpointResponses({
+    successStatus: 200,
+    response: PlansProjetsTerritoireResponse,
+    description: "Projets du territoire du PCAET, avec rattachement par groupe",
+  })
+  plansProjetsTerritoire(@Param("cle") cle: string, @Query() query: RawQuery): Promise<PlansProjetsTerritoireResponse> {
+    return this.territoiresService.plansProjetsTerritoire(cle, parseProjetsParams(query));
   }
 
   @TrackApiUsage()

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -323,4 +323,152 @@ describe("TerritoiresService", () => {
       expect(result.pcaet[0].rattachement).toBe("aucun");
     });
   });
+
+  describe("plansProjetsTerritoire", () => {
+    const params = { limit: 50, offset: 0, inclureFinancementsSeuls: false, masquerObsoletes: false };
+    // Ligne de référence PCAET renvoyée par resolvePcaet (Nantes Métropole, un des 5 EPCI POC).
+    const pcaetRow = {
+      sirenPorteur: "244400404",
+      nom: "PCAET de Nantes Métropole",
+      source: "opendata",
+      communes: ["44109"],
+    };
+
+    it("résout une clé SIREN, renvoie l'en-tête pcaet + les groupes + le rattachement par groupe", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ present: true }] }) // pcaet_reference présente
+        .mockResolvedValueOnce({ rows: [pcaetRow] }) // résolution de la clé
+        .mockResolvedValueOnce({
+          rows: [{ confiance: "CERTAIN", traces: [{ role: "projet", source: "MEC", id: "p1" }], total: "1" }],
+        }) // page de groupes
+        .mockResolvedValueOnce({ rows: [] }) // décisions actives de la page (decisions[])
+        .mockResolvedValueOnce({ rows: [{ objetAId: "p1", verdict: "confirme" }] }) // rattachement à ce PCAET
+        .mockResolvedValueOnce({ rows: [] }); // signal pcaet_operation_inscrite (aucun)
+
+      const result = await service.plansProjetsTerritoire("244400404", params);
+
+      expect(result).toEqual({
+        pcaet: { sirenPorteur: "244400404", nom: "PCAET de Nantes Métropole", source: "opendata" },
+        total: 1,
+        limit: 50,
+        offset: 0,
+        groupes: [
+          {
+            confiance: "CERTAIN",
+            traces: [{ role: "projet", source: "MEC", id: "p1" }],
+            decisions: [],
+            rattachement: "confirme",
+          },
+        ],
+      });
+      // 6 requêtes : existence + résolution + page + decisions[] + rattachement + signal.
+      expect(execute).toHaveBeenCalledTimes(6);
+      // La requête de rattachement cible CE pcaet, départage les created_at égaux (id DESC)
+      // et exclut les révocations (verdict='annule').
+      const rattachementSql = renderSql((execute.mock.calls[4] as unknown[])[0]);
+      expect(rattachementSql).toContain("rattachement_pcaet");
+      expect(rattachementSql).toContain("d.objet_b_id");
+      expect(rattachementSql).toContain("d.id DESC");
+      expect(rattachementSql).toContain("verdict IS DISTINCT FROM");
+    });
+
+    it("résout aussi une clé plan_id (NULLIF neutralise les canaux vides)", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ present: true }] })
+        .mockResolvedValueOnce({ rows: [pcaetRow] })
+        .mockResolvedValueOnce({ rows: [] }); // page vide → pas d'enrichissement ni de rattachement
+
+      const result = await service.plansProjetsTerritoire("019ce410-84fe-7174-a27c-4cec8c632cf4", params);
+
+      expect(result.pcaet.sirenPorteur).toBe("244400404");
+      expect(result).toMatchObject({ total: 0, groupes: [] });
+      // Page vide → aucune requête de décisions/rattachement/signal.
+      expect(execute).toHaveBeenCalledTimes(3);
+      // La résolution accepte SIREN OU plan_id, en neutralisant les canaux vides.
+      const resolveSql = renderSql((execute.mock.calls[1] as unknown[])[0]);
+      expect(resolveSql).toContain("siren_porteur");
+      expect(resolveSql).toContain("plan_id_opendata");
+      expect(resolveSql).toContain("NULLIF");
+    });
+
+    it("404 quand la clé ne résout aucun PCAET", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ present: true }] }) // référence présente
+        .mockResolvedValueOnce({ rows: [] }); // clé inconnue
+      await expect(service.plansProjetsTerritoire("999999999", params)).rejects.toBeInstanceOf(NotFoundException);
+    });
+
+    it("404 quand la référence PCAET n'est pas encore matérialisée", async () => {
+      execute.mockResolvedValueOnce({ rows: [{ present: false }] });
+      await expect(service.plansProjetsTerritoire("244400404", params)).rejects.toBeInstanceOf(NotFoundException);
+      // Aucune requête de résolution lancée quand la matview est absente.
+      expect(execute).toHaveBeenCalledTimes(1);
+    });
+
+    it("rattachement='suggere' à défaut de décision, sur le signal pcaet_operation_inscrite", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ present: true }] })
+        .mockResolvedValueOnce({ rows: [pcaetRow] })
+        .mockResolvedValueOnce({
+          rows: [{ confiance: null, traces: [{ role: "projet", source: "MEC", id: "p1" }], total: "1" }],
+        })
+        .mockResolvedValueOnce({ rows: [] }) // decisions[]
+        .mockResolvedValueOnce({ rows: [] }) // aucune décision de rattachement
+        .mockResolvedValueOnce({ rows: [{ id: "p1" }] }); // p1 marqué opération PCAET
+
+      const result = await service.plansProjetsTerritoire("244400404", params);
+      expect(result.groupes[0].rattachement).toBe("suggere");
+    });
+
+    it("rattachement='aucun' sans décision ni signal", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ present: true }] })
+        .mockResolvedValueOnce({ rows: [pcaetRow] })
+        .mockResolvedValueOnce({
+          rows: [{ confiance: null, traces: [{ role: "projet", source: "MEC", id: "p1" }], total: "1" }],
+        })
+        .mockResolvedValueOnce({ rows: [] }) // decisions[]
+        .mockResolvedValueOnce({ rows: [] }) // rattachement : aucun
+        .mockResolvedValueOnce({ rows: [] }); // signal : aucun
+
+      const result = await service.plansProjetsTerritoire("244400404", params);
+      expect(result.groupes[0].rattachement).toBe("aucun");
+    });
+
+    it("une décision humaine prime toujours sur le signal (infirme > suggere)", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ present: true }] })
+        .mockResolvedValueOnce({ rows: [pcaetRow] })
+        .mockResolvedValueOnce({
+          rows: [{ confiance: null, traces: [{ role: "projet", source: "MEC", id: "p1" }], total: "1" }],
+        })
+        .mockResolvedValueOnce({ rows: [] }) // decisions[]
+        .mockResolvedValueOnce({ rows: [{ objetAId: "p1", verdict: "infirme" }] }) // décision infirme
+        .mockResolvedValueOnce({ rows: [{ id: "p1" }] }); // signal présent, mais dominé
+
+      const result = await service.plansProjetsTerritoire("244400404", params);
+      expect(result.groupes[0].rattachement).toBe("infirme");
+    });
+
+    it("la décision la plus récente prime en cas de décisions actives contradictoires", async () => {
+      execute
+        .mockResolvedValueOnce({ rows: [{ present: true }] })
+        .mockResolvedValueOnce({ rows: [pcaetRow] })
+        .mockResolvedValueOnce({
+          rows: [{ confiance: null, traces: [{ role: "projet", source: "MEC", id: "p1" }], total: "1" }],
+        })
+        .mockResolvedValueOnce({ rows: [] }) // decisions[]
+        // Triées de la plus récente à la plus ancienne par la requête : infirme (récente) gagne.
+        .mockResolvedValueOnce({
+          rows: [
+            { objetAId: "p1", verdict: "infirme" },
+            { objetAId: "p1", verdict: "confirme" },
+          ],
+        })
+        .mockResolvedValueOnce({ rows: [] }); // signal
+
+      const result = await service.plansProjetsTerritoire("244400404", params);
+      expect(result.groupes[0].rattachement).toBe("infirme");
+    });
+  });
 });

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -12,6 +12,7 @@ import {
   TerritoireTraceDto,
 } from "./dto/territoire-projets.dto";
 import { PlansTerritoireResponse } from "./dto/plans-territoire.dto";
+import { PlansProjetsTerritoireResponse, TerritoireGroupeRattacheDto } from "./dto/plans-projets-territoire.dto";
 import { QualificationResponse } from "./dto/qualification.dto";
 
 type Row = Record<string, unknown>;
@@ -81,9 +82,16 @@ export class TerritoiresService {
    * déduplication. `code` = INSEE commune (5 chiffres / 2A|2B + 3) ou SIREN EPCI (9 chiffres).
    */
   async territoireProjets(code: string, params: TerritoireProjetsParams): Promise<TerritoireProjetsResponse> {
-    const { sources, copMillesime, copStatutVivier, limit, offset, inclureFinancementsSeuls, masquerObsoletes } =
-      params;
+    this.validateCopFilters(params);
+    const communes = await this.resolveCommunes(code);
+    return this.projetsGroupes(communes, params);
+  }
 
+  // Valide les filtres COP (millésime, statut vivier) — 400 explicite sinon. Appelé AVANT
+  // toute requête (résolution du territoire incluse) par les deux points d'entrée
+  // (territoireProjets, plansProjetsTerritoire).
+  private validateCopFilters(params: TerritoireProjetsParams): void {
+    const { copMillesime, copStatutVivier } = params;
     if (copMillesime !== undefined && !COP_MILLESIMES.includes(copMillesime as (typeof COP_MILLESIMES)[number])) {
       throw new BadRequestException(`copMillesime invalide (attendu : ${COP_MILLESIMES.join(", ")})`);
     }
@@ -93,8 +101,20 @@ export class TerritoiresService {
     ) {
       throw new BadRequestException(`copStatutVivier invalide (attendu : ${COP_STATUTS_VIVIER.join(", ")})`);
     }
+  }
 
-    const communes = await this.resolveCommunes(code);
+  /**
+   * Cœur de la vue territoriale : regroupe par cluster de déduplication les projets des
+   * `communes` fournies, applique les filtres et enrichit chaque groupe de ses décisions
+   * actives. Partagé par `territoireProjets` (code → communes) et `plansProjetsTerritoire`
+   * (PCAET → communes couvertes). Suppose les filtres COP déjà validés (validateCopFilters).
+   */
+  private async projetsGroupes(
+    communes: string[],
+    params: TerritoireProjetsParams,
+  ): Promise<TerritoireProjetsResponse> {
+    const { sources, copMillesime, copStatutVivier, limit, offset, inclureFinancementsSeuls, masquerObsoletes } =
+      params;
 
     // Filtres appliqués aux SEULS projets du territoire (avant expansion en cluster
     // complet — les membres hors territoire du même cluster sont conservés).
@@ -336,6 +356,140 @@ export class TerritoiresService {
         if (g.decisions.length < DECISIONS_PER_GROUP_CAP) g.decisions.push(decision);
       }
     }
+  }
+
+  /**
+   * Miroir de `territoireProjets` côté TeT : projets du territoire COUVERT par un PCAET,
+   * regroupés par cluster, augmentés — par groupe — de leur `rattachement` à CE PCAET.
+   * `cle` = SIREN du porteur (clé stable, 9 chiffres) OU un plan_id de la référence
+   * (opendata/snapshot/live) résolu vers la même ligne. 404 si la clé ne résout aucun PCAET.
+   * Flux d'écriture symétrique (le « je coche » côté TeT) = POST /decisions type
+   * rattachement_pcaet (objetA = trace du groupe, objetB = SIREN porteur) — rien à coder ici.
+   */
+  async plansProjetsTerritoire(cle: string, params: TerritoireProjetsParams): Promise<PlansProjetsTerritoireResponse> {
+    this.validateCopFilters(params);
+    const pcaet = await this.resolvePcaet(cle);
+    const base = await this.projetsGroupes(pcaet.communes, params);
+    const groupes = await this.attachRattachements(base.groupes, pcaet.sirenPorteur);
+    return {
+      pcaet: { sirenPorteur: pcaet.sirenPorteur, nom: pcaet.nom, source: pcaet.source },
+      total: base.total,
+      limit: base.limit,
+      offset: base.offset,
+      groupes,
+    };
+  }
+
+  /**
+   * Résout une clé PCAET en sa ligne de référence (SIREN porteur, nom, source, communes).
+   * `cle` = SIREN porteur (clé stable) OU un des plan_id (opendata/snapshot/live). Les
+   * plan_id vides ('' — canaux non alimentés) sont neutralisés par NULLIF pour qu'une clé
+   * vide/absente ne matche jamais. 404 si la référence est absente (matérialisation non
+   * déployée) ou si la clé ne correspond à aucun PCAET.
+   */
+  private async resolvePcaet(
+    cle: string,
+  ): Promise<{ sirenPorteur: string; nom: string | null; source: string | null; communes: string[] }> {
+    // pcaet_reference (matview) est un livrable ETL déployé séparément : garde to_regclass
+    // (cf. planFichesTerritoire) — 404 explicite plutôt qu'un 500 « relation does not exist ».
+    if (!(await this.pcaetReferenceExists())) {
+      throw new NotFoundException(
+        "Référence PCAET indisponible (matérialisation schema_commun_v2.pcaet_reference non déployée).",
+      );
+    }
+
+    const [row] = await this.query<{
+      sirenPorteur: string;
+      nom: string | null;
+      source: string | null;
+      communes: string[] | null;
+    }>(sql`
+      SELECT pr.siren_porteur AS "sirenPorteur", pr.nom, pr.source_nom AS source, pr.communes
+      FROM schema_commun_v2.pcaet_reference pr
+      WHERE pr.siren_porteur = ${cle}
+         OR NULLIF(pr.plan_id_opendata, '') = ${cle}
+         OR NULLIF(pr.plan_id_snapshot, '') = ${cle}
+         OR NULLIF(pr.plan_id_live, '') = ${cle}
+      -- Départage déterministe si une clé coïncidait avec un SIREN ET un plan_id (jamais
+      -- observé : SIREN à 9 chiffres, plan_id en UUID) : la correspondance SIREN prime.
+      ORDER BY (pr.siren_porteur = ${cle}) DESC
+      LIMIT 1
+    `);
+
+    if (!row) {
+      throw new NotFoundException(
+        `PCAET introuvable pour la clé « ${cle} » (attendu : SIREN du porteur — 9 chiffres — ou un plan_id de la référence).`,
+      );
+    }
+    return { sirenPorteur: row.sirenPorteur, nom: row.nom, source: row.source, communes: row.communes ?? [] };
+  }
+
+  /**
+   * Calcule, pour chaque groupe, son rattachement à UN pcaet (SIREN porteur donné), et
+   * renvoie les groupes augmentés du champ `rattachement`. Deux requêtes (journal + signal),
+   * jamais de N+1 :
+   * - décision : `rattachement_pcaet` ACTIVE la plus récente (created_at, id DESC) entre une
+   *   trace du groupe et ce PCAET → verdict confirme|infirme (la plus récente prime en cas de
+   *   décisions actives contradictoires) ; pierres tombales (verdict='annule') exclues ;
+   * - signal : à défaut de décision, `pcaet_operation_inscrite='true'` sur une trace → 'suggere'
+   *   (indicatif — une décision humaine prime toujours) ; sinon 'aucun'.
+   */
+  private async attachRattachements(
+    groupes: TerritoireGroupeDto[],
+    sirenPorteur: string,
+  ): Promise<TerritoireGroupeRattacheDto[]> {
+    // Un id de trace n'appartient qu'à un seul groupe (un projet est dans un seul cluster).
+    const groupByTraceId = new Map<string, TerritoireGroupeDto>();
+    for (const g of groupes) {
+      for (const t of g.traces) {
+        if (t.id != null) groupByTraceId.set(t.id, g);
+      }
+    }
+    const ids = [...groupByTraceId.keys()];
+    if (ids.length === 0) return groupes.map((g) => ({ ...g, rattachement: "aucun" as const }));
+
+    // Décisions de rattachement à CE pcaet, portant sur une trace de la page, actives et
+    // non révoquées, triées de la plus récente à la plus ancienne (départage id DESC).
+    const decisionRows = await this.query<{ objetAId: string; verdict: string | null }>(sql`
+      SELECT d.objet_a_id AS "objetAId", d.verdict
+      FROM decisions_humaines.decisions d
+      WHERE d.type_decision = 'rattachement_pcaet'
+        AND d.objet_b_type = 'pcaet'
+        AND d.objet_b_id = ${sirenPorteur}
+        AND d.objet_a_id = ANY(${textArray(ids)})
+        AND ${activeDecisionPredicate("d")}
+        -- Révocations (verdict='annule') exclues : une décision annulée ne rattache rien.
+        AND ${notTombstonePredicate("d")}
+      ORDER BY d.created_at DESC, d.id DESC
+    `);
+    // « La plus récente prime » : on fige chaque groupe à sa 1re décision rencontrée (la plus
+    // récente), verdict confirme|infirme retenu. Un groupe non figé reste candidat au signal.
+    const decided = new Map<TerritoireGroupeDto, "confirme" | "infirme">();
+    const resolved = new Set<TerritoireGroupeDto>();
+    for (const r of decisionRows) {
+      const g = groupByTraceId.get(r.objetAId);
+      if (!g || resolved.has(g)) continue;
+      resolved.add(g);
+      if (r.verdict === "confirme" || r.verdict === "infirme") decided.set(g, r.verdict);
+    }
+
+    // Signal indicatif 'suggere' : une trace du groupe est marquée opération PCAET par le
+    // pipeline. Ne concerne que les groupes SANS décision (une décision humaine prime).
+    const signalRows = await this.query<{ id: string }>(sql`
+      SELECT p.id
+      FROM schema_commun_v2.projets_operationnels p
+      WHERE p.id = ANY(${textArray(ids)}) AND p.pcaet_operation_inscrite = 'true'
+    `);
+    const signalGroups = new Set<TerritoireGroupeDto>();
+    for (const r of signalRows) {
+      const g = groupByTraceId.get(r.id);
+      if (g) signalGroups.add(g);
+    }
+
+    return groupes.map((g) => ({
+      ...g,
+      rattachement: decided.get(g) ?? (signalGroups.has(g) ? ("suggere" as const) : ("aucun" as const)),
+    }));
   }
 
   /**

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -86,8 +86,18 @@ curl -H "Authorization: Bearer $MEC_API_KEY" "$BASE/projets/mec/181/plans-territ
 ```
 
 ⚠️ `presentDansTet`/`tetExternalId` : le deep-link TeT n'est possible que pour les plans
-connus de l'API TeT (~1/3 des cas) — prévoir l'affichage sans lien.
-`fichesActionSuggerees` : vide en V1 (bonus à venir).
+connus de l'API TeT — aujourd'hui `tet_external_id` n'est renseigné pour aucun PCAET de la
+référence (seul le canal opendata l'alimente ; canaux snapshot/live TeT non branchés, issue #497).
+Prévoir l'affichage sans lien. `fichesActionSuggerees` : vide en V1 (bonus à venir).
+
+### Ce que fait TeT de son côté (symétrie)
+
+Le même rattachement projet ↔ PCAET s'écrit et se lit **dans les deux sens**, sur le **même journal**.
+Côté TeT, l'endpoint miroir part du **PCAET** et liste les projets de son territoire :
+`GET /plans/{cle}/projets-territoire` (`cle` = SIREN porteur ou plan_id), avec par groupe un champ
+`rattachement` (`confirme`|`infirme`|`suggere`|`aucun`). Un rattachement coché depuis TeT
+(`POST /decisions`, `rattachement_pcaet`) est donc **immédiatement visible ici** (et réciproquement) —
+c'est la même décision. Détails côté TeT : [`INTEGRATION_TET.md`](./INTEGRATION_TET.md).
 
 ## 3. `GET /projets/mec/{externalId}/qualification`
 

--- a/docs/api/INTEGRATION_TET.md
+++ b/docs/api/INTEGRATION_TET.md
@@ -1,0 +1,216 @@
+# Intégration TeT — rattacher les projets d'un territoire à un PCAET
+
+> Public : équipe Territoires en Transitions (tech + produit). Sprint juillet 2026, POC.
+> Spec machine : [`openapi-territoires-decisions.yaml`](./openapi-territoires-decisions.yaml)
+> (mêmes endpoints dans le Swagger `/api` de l'instance).
+> Miroir MEC de ce document : [`INTEGRATION_MEC.md`](./INTEGRATION_MEC.md).
+
+## 1. L'apport — à quoi ça sert
+
+Un porteur de PCAET (EPCI) veut savoir **quels projets de son territoire relèvent de son plan**, et
+les **rattacher** un à un. L'API réunit sous un même toit les projets vus par MEC, le Vivier COP et
+les financements DGCL/Fonds Vert, **dédupliqués** (un projet réel = un groupe, même s'il apparaît
+dans plusieurs sources). Vous interrogez un PCAET par le **SIREN de son porteur**, vous recevez les
+projets des communes couvertes, et pour chacun un état de **rattachement** à _ce_ PCAET
+(`confirme` / `infirme` / `suggere` / `aucun`). Le geste « je coche ce projet dans mon PCAET » est un
+`POST /decisions` : il **survit aux recalculs** du pipeline (journal append-only, partagé avec MEC).
+
+C'est le **miroir** de ce que fait MEC : là où MEC part d'un projet et cherche ses PCAET
+(`GET /projets/mec/{externalId}/plans-territoire`), TeT part d'un PCAET et liste les projets de son
+territoire (`GET /plans/{cle}/projets-territoire`). Les deux écrivent dans le **même journal** de
+rattachements — un rattachement coché côté TeT est visible côté MEC, et réciproquement.
+
+## 2. Le modèle mental
+
+- **PCAET** = une fiche de référence identifiée par le **SIREN de son porteur** (clé stable). La
+  référence (`schema_commun_v2.pcaet_reference`) compte aujourd'hui **558 PCAET**, tous issus du
+  canal _opendata_ (ADEME). Un PCAET couvre une liste de **communes** (INSEE).
+- **Groupe** = un projet réel, c.-à-d. l'ensemble de ses **traces** dans les différentes sources
+  (MEC, Vivier COP, financements). Aucun identifiant de groupe n'est exposé : les clusters sont
+  recalculés à chaque run. La seule référence stable est `traces[].id`.
+- **Rattachement** (par groupe, vis-à-vis du PCAET interrogé) :
+  - `confirme` / `infirme` — une **décision humaine** (la vôtre, ou celle de MEC) l'affirme ;
+  - `suggere` — **pas** de décision, mais le pipeline a marqué une trace du groupe comme opération
+    PCAET : un candidat à confirmer ;
+  - `aucun` — ni décision, ni signal.
+- **Décision** = un événement **append-only**. On ne modifie ni ne supprime : pour revenir sur un
+  rattachement, on poste une **révocation** (`verdict: "annule"`, `supersedes: <id>`). Voir
+  [`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md).
+
+## 3. Démarrer en 10 min (réponses réelles, territoire de Nantes Métropole)
+
+```bash
+BASE=https://api.collectivites.beta.gouv.fr
+# Clé API TeT à provisionner (plateforme_source = TeT, dérivée de la clé) — cf. étape 1 du §7.
+AUTH="Authorization: Bearer $TET_API_KEY"
+```
+
+**a) Lister les projets du territoire d'un PCAET.** `cle` = SIREN du porteur (ici Nantes Métropole,
+`244400404`) **ou** un `plan_id` de la référence (opendata/snapshot/live) — les deux résolvent la
+même fiche.
+
+```bash
+curl -H "$AUTH" "$BASE/plans/244400404/projets-territoire?limit=200"
+```
+
+```jsonc
+{
+  "pcaet": { "sirenPorteur": "244400404", "nom": "PCAET de Nantes Métropole", "source": "opendata" },
+  "total": 490,
+  "limit": 200,
+  "offset": 0,
+  "groupes": [
+    {
+      "confiance": "PROBABLE",
+      "traces": [
+        {
+          "role": "projet",
+          "source": "MEC",
+          "id": "019b9e2f-5dda-7877-a6d5-13f526e05513",
+          "externalId": "3138",
+          "nom": "Rénovation énergétique du COSEC…",
+          "statut": "En cours",
+          "phase": "Opération",
+          "budgetPrevisionnel": 3776713,
+        },
+        {
+          "role": "financement",
+          "source": "Fonds Vert",
+          "id": "11629149",
+          "nom": "Rénovation énergétique du complexe sportif…",
+          "budgetPrevisionnel": 1232940,
+        },
+      ],
+      "decisions": [],
+      "rattachement": "suggere", // signal pipeline : à confirmer
+    },
+    {
+      "confiance": null,
+      "traces": [
+        {
+          "role": "projet",
+          "source": "MEC",
+          "id": "019b0d22-166b-7082-bdb5-2d7e86ca6bdc",
+          "externalId": "2164",
+          "nom": "Création d'un parc éolien off shore",
+          "statut": "En cours",
+        },
+      ],
+      "decisions": [],
+      "rattachement": "aucun",
+    },
+  ],
+}
+```
+
+Query params (identiques à `GET /territoires/{code}/projets`) : `sources` (CSV de `source_origine`),
+`copMillesime` (`2024`|`2025`), `copStatutVivier`, `limit` (1–200, défaut 50), `offset`,
+`inclureFinancementsSeuls` (défaut `false`), `masquerObsoletes` (défaut `false`).
+
+**b) Cocher un projet dans le PCAET** = poster une décision de rattachement. `objetAId` = la
+`traces[].id` du projet ; `objetBId` = le **SIREN porteur** ; `objetBType` = `pcaet`.
+
+```bash
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" "$BASE/decisions" -d '{
+  "typeDecision": "rattachement_pcaet",
+  "objetAType": "projet", "objetAId": "019b0d22-166b-7082-bdb5-2d7e86ca6bdc",
+  "objetBType": "pcaet",  "objetBId": "244400404",
+  "verdict": "confirme",
+  "auteur": "agent-tet-44", "commentaire": "Rattaché depuis TeT"
+}'
+# → 201 { "id": "…", "createdAt": "…" }
+```
+
+**c) Le revoir marqué.** Le même GET renvoie désormais `"rattachement": "confirme"` pour ce groupe
+(vérifié de bout en bout contre la prod : `aucun → confirme → aucun`).
+
+**d) Décocher** = révoquer, jamais supprimer :
+
+```bash
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" "$BASE/decisions" -d '{
+  "typeDecision": "rattachement_pcaet",
+  "objetAType": "projet", "objetAId": "019b0d22-166b-7082-bdb5-2d7e86ca6bdc",
+  "objetBType": "pcaet",  "objetBId": "244400404",
+  "verdict": "annule", "supersedes": "<id de la décision à révoquer>"
+}'
+```
+
+Clé inconnue → `404` explicite : `PCAET introuvable pour la clé « 000000000 » (attendu : SIREN du
+porteur — 9 chiffres — ou un plan_id de la référence).`
+
+## 4. Le parcours
+
+1. L'agent TeT ouvre le PCAET de son EPCI → `GET /plans/{siren}/projets-territoire`.
+2. L'écran liste les groupes ; on met en avant les `suggere` (candidats) et les `confirme` (déjà
+   rattachés). Un groupe ↔ un projet réel ; on affiche `confiance` (CERTAIN = lien établi,
+   PROBABLE = suggestion, null = singleton) et les financements comme financements du groupe.
+3. L'agent coche/décoche → `POST /decisions` (`rattachement_pcaet`, `confirme`/`infirme`, ou
+   `annule` pour revenir en arrière).
+4. Au prochain GET, le `rattachement` du groupe reflète la décision. `decisions[]` porte l'historique
+   actif (toutes plateformes, sans l'auteur — cloisonnement PII).
+
+### Ce que fait MEC de son côté
+
+MEC part du **projet** : `GET /projets/mec/{externalId}/plans-territoire` liste les PCAET couvrant
+les communes du projet, avec le **même** champ `rattachement`. Un rattachement posté depuis TeT est
+donc immédiatement visible côté MEC (journal partagé), et inversement. Détails :
+[`INTEGRATION_MEC.md`](./INTEGRATION_MEC.md).
+
+## 5. Ce qui vous appartient (et ce qu'il ne faut pas persister)
+
+| Donnée                                               | Stabilité                                                                                                                                                                                                       |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `pcaet.sirenPorteur`                                 | **Stable et contractuel** — c'est la clé du PCAET, la seule à persister et à référencer dans une décision (`objetBId`)                                                                                          |
+| `traces[].id`                                        | **Stable et contractuel** — seule référence de projet à persister (`objetAId`). **Exception : les traces DGCL** (`role: "financement"`, sources `DGCL *`) ne sont **pas** contractuelles — ne pas les persister |
+| `traces[].externalId`                                | Stable côté MEC (leur id) ; ne concerne pas TeT                                                                                                                                                                 |
+| `plan_id_*` (opendata/snapshot/live)                 | **Instables** — bougent d'un run à l'autre. Acceptés en entrée (`cle`) par commodité, jamais à persister ni à référencer                                                                                        |
+| Composition des groupes, `confiance`, `rattachement` | **Recalculés / dérivés** à chaque lecture — ne pas persister ; relire l'API                                                                                                                                     |
+
+Vous êtes propriétaire de **vos décisions** (`plateforme_source = TeT`, dérivée de la clé). Vous ne
+révoquez que les vôtres ; `GET /decisions?objetId=…` ne renvoie que celles de TeT. La vue
+territoriale (`decisions[]`) agrège toutes les plateformes mais **jamais l'agent auteur**.
+
+## 6. Garanties & limites
+
+- **Couverture PCAET** : cible **50,7 %** des projets une fois la référence pleinement alimentée.
+  Aujourd'hui la référence est nourrie par le **seul canal opendata** (ADEME) : 558 PCAET, tous
+  `source: "opendata"`.
+- **Deep-links TeT indisponibles pour l'instant** : les canaux _snapshot_ et _live_ de TeT ne sont
+  pas encore alimentés → `tet_external_id` est vide pour l'ensemble des 558 PCAET, donc pas de lien
+  profond vers TeT. Débloqué par le correctif du webhook plans (voir étape 4 du §7).
+- **`suggere` = signal indicatif**, pas une vérité : dérivé de `pcaet_operation_inscrite` (pipeline).
+  Une décision humaine prime **toujours** sur le signal.
+- **Journal append-only** : pas d'`UPDATE`/`DELETE`. Revenir sur une décision = `verdict: "annule"`
+  - `supersedes` (les pierres tombales sont exclues de toutes les lectures).
+- **`total` vs page** : `total` est le nombre de groupes du territoire ; paginez avec `limit`/`offset`
+  (Nantes : 490 groupes).
+- **Pas de source `TeT` côté projets** : les fiches action TeT ne sont pas (encore) exposées comme
+  traces ; seul le rattachement PCAET circule dans les deux sens.
+
+## 7. Pour la suite — 5 étapes côté TeT
+
+1. **Nommer un interlocuteur technique + un interlocuteur produit** côté TeT (point de contact du POC).
+2. **Valider le flow sur les 5 EPCI POC** (ci-dessous) : lister → cocher → revoir marqué → décocher.
+3. **Consommer l'endpoint** `GET /plans/{cle}/projets-territoire` et **poster les rattachements**
+   (`POST /decisions`, `rattachement_pcaet`).
+4. **Corriger le webhook plans** qui ingère des plans **sans SIREN ni communes** (notre
+   [issue #497](https://github.com/betagouv/communs-de-la-transition-ecologique-des-collectivites/issues/497))
+   — débloque **~la moitié** de la couverture PCAET manquante et les deep-links TeT.
+5. **Bilan d'usage commun à la rentrée** : volumétrie des rattachements, qualité des `suggere`,
+   décision d'élargissement au-delà des 5 EPCI.
+
+### Les 5 EPCI POC
+
+| EPCI                         | SIREN (= `cle`) |
+| ---------------------------- | --------------- |
+| CU d'Arras                   | `200033579`     |
+| CC de la Haute Saintonge     | `200041523`     |
+| CA Pornic Agglo Pays de Retz | `200067346`     |
+| Nantes Métropole             | `244400404`     |
+| CA Valenciennes Métropole    | `245901160`     |
+
+## Contact
+
+Questions d'intégration cet été : **Jean** (l'équipe API Collectivités est en effectif réduit en
+août — privilégier des demandes groupées et asynchrones). Sémantique des décisions :
+[`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md).

--- a/docs/api/openapi-territoires-decisions.yaml
+++ b/docs/api/openapi-territoires-decisions.yaml
@@ -59,6 +59,62 @@ paths:
                     items: { $ref: "#/components/schemas/Groupe" }
           description: Groupes de traces du territoire
         "404": { description: Territoire inconnu ou code invalide }
+  /plans/{cle}/projets-territoire:
+    get:
+      summary: Projets du territoire couvert par un PCAET (miroir TeT), rattachement par groupe
+      description: >
+        Miroir de /territoires/{code}/projets côté TeT : part d'un PCAET, liste les projets des
+        communes qu'il couvre, regroupés par projet réel, avec par groupe le rattachement à CE PCAET.
+        Écriture symétrique via POST /decisions (rattachement_pcaet). Voir INTEGRATION_TET.md.
+      parameters:
+        - name: cle
+          in: path
+          required: true
+          schema: { type: string }
+          description: SIREN du porteur du PCAET (clé stable, 9 chiffres) ou un plan_id de la référence (opendata/snapshot/live)
+        - name: sources
+          in: query
+          schema: { type: string }
+          description: "Filtre source_origine, CSV (ex. `MEC,Vivier COP`)"
+        - name: copMillesime
+          in: query
+          schema: { type: string, enum: ["2024", "2025"] }
+        - name: copStatutVivier
+          in: query
+          schema: { type: string, enum: [a_remonter, a_travailler, hors_cop_mais_crte, non_remonte] }
+        - name: limit
+          in: query
+          schema: { type: integer, default: 50, minimum: 1, maximum: 200 }
+        - name: offset
+          in: query
+          schema: { type: integer, default: 0 }
+        - name: inclureFinancementsSeuls
+          in: query
+          schema: { type: boolean, default: false }
+        - name: masquerObsoletes
+          in: query
+          schema: { type: boolean, default: false }
+      responses:
+        "200":
+          content:
+            application/json:
+              schema:
+                type: object
+                properties:
+                  pcaet:
+                    type: object
+                    properties:
+                      sirenPorteur: { type: string }
+                      nom: { type: string, nullable: true }
+                      source: { type: string, enum: [snapshot, opendata], nullable: true }
+                  total: { type: integer }
+                  limit: { type: integer }
+                  offset: { type: integer }
+                  groupes:
+                    type: array
+                    items: { $ref: "#/components/schemas/GroupeRattache" }
+          description: Projets du territoire du PCAET, avec rattachement par groupe
+        "404": { description: Clé ne résolvant aucun PCAET, ou référence PCAET non matérialisée }
   /projets/mec/{externalId}/plans-territoire:
     get:
       summary: PCAET couvrant les communes d'un projet MEC
@@ -189,6 +245,21 @@ components:
             confondues, SANS l'agent auteur (PII + cloisonnement inter-plateformes). Les révocations
             (verdict='annule') et les décisions supersédées sont exclues.
           items: { $ref: "#/components/schemas/Decision" }
+    GroupeRattache:
+      description: >
+        Groupe augmenté de son rattachement au PCAET interrogé (endpoint /plans/{cle}/projets-territoire).
+      allOf:
+        - $ref: "#/components/schemas/Groupe"
+        - type: object
+          properties:
+            rattachement:
+              type: string
+              enum: [confirme, infirme, suggere, aucun]
+              description: >
+                confirme|infirme = décision active rattachement_pcaet la plus récente entre une trace
+                du groupe et ce PCAET (SIREN porteur) ; suggere = pas de décision mais une trace est
+                marquée opération PCAET (pcaet_operation_inscrite) — indicatif, une décision prime ;
+                aucun = ni décision ni signal.
     Decision:
       type: object
       properties:


### PR DESCRIPTION
## Contexte

Bloc B « sens TeT » : symétriser le pont TeT↔MEC. Là où MEC part d'un projet et cherche ses PCAET (`GET /projets/mec/{externalId}/plans-territoire`), TeT part d'un **PCAET** et liste les projets de son **territoire**. Base : `main` (contient décisions v2 + amendement `annule`/`notTombstonePredicate` + module territoires).

## Endpoint

`GET /plans/{cle}/projets-territoire`

- **`cle`** = SIREN du porteur du PCAET (clé stable, 9 chiffres) **ou** un `plan_id` de la référence (`plan_id_opendata`/`snapshot`/`live`), résolu vers la même ligne de `schema_commun_v2.pcaet_reference` (matview, 558 PCAET). `404` explicite si la clé ne résout aucun PCAET, ou si la matview n'est pas déployée (`to_regclass`). Les `plan_id` vides (canaux non alimentés) sont neutralisés par `NULLIF` pour qu'une clé vide ne matche jamais.
- **Réponse** : projets des communes couvertes, regroupés par cluster — **réutilise** `territoireProjets` via un `projetsGroupes(communes, params)` partagé (mêmes traces/confiance/`decisions[]`, mêmes filtres `sources`/`copMillesime`/`copStatutVivier`/`limit`/`offset`/`inclureFinancementsSeuls`/`masquerObsoletes`). En-tête : `{ pcaet: { sirenPorteur, nom, source }, total, limit, offset, groupes }`.
- **`rattachement`** par groupe, vis-à-vis de CE PCAET :
  - `confirme`/`infirme` : décision active `rattachement_pcaet` la plus récente (tie-break `id DESC`) entre une trace du groupe et ce PCAET (`objet_b_id` = SIREN porteur) — la plus récente prime ; pierres tombales `verdict='annule'` exclues (`notTombstonePredicate`, comme les 3 autres effets de lecture) ;
  - `suggere` : à défaut de décision, signal **trivial** `pcaet_operation_inscrite='true'` sur une trace (indicatif — une décision humaine prime toujours) ;
  - `aucun` sinon.

Écriture symétrique (le « je coche » côté TeT) = `POST /decisions` `rattachement_pcaet` **existant** — rien de neuf côté écriture, documenté.

## Docs

- **`docs/api/INTEGRATION_TET.md`** (nouveau) — standard humain 7 sections : apport / modèle mental / démarrer en 10 min (réponses réelles) / parcours / ce qui vous appartient / garanties-limites / FAQ+contact. Flow « je vois les projets de mon territoire, je coche ceux de mon PCAET », les 5 EPCI POC, les 5 prochaines étapes TeT (dont correctif webhook #497), limites (couverture 50,7 %, deep-links TeT indisponibles aujourd'hui).
- **`docs/api/INTEGRATION_MEC.md`** — § « Ce que fait TeT de son côté » (lève l'asymétrie) + note deep-links.
- **`openapi-territoires-decisions.yaml`** — path + schéma `GroupeRattache`.

## Vérification

- **Flux TeT complet joué contre la prod (lecture)** sur Nantes Métropole (`244400404`) : `GET` (aucun) → insertion SQL de test `rattachement_pcaet confirme` (plateforme `interne`) → `GET` (confirme) → révocation `verdict='annule'` `supersedes` → `GET` (aucun). Résolution par SIREN **et** par `plan_id` vérifiée, `404` clé inconnue vérifié. Harnais `ts-node` jetable supprimé après usage.
- **Tests unitaires** (résolution clé SIREN/plan_id, rattachement par groupe confirme/infirme/suggere/aucun, priorité décision>signal, plus-récente-prime, 404 clé inconnue, 404 matview absente) : `decisions` + `territoires` = **111 tests OK**.
- **type-check / lint / prettier** : 0 erreur.

## Notes

- Base rebasée sur `main` (l'amendement `annule` est arrivé sur `main` en cours de route) → `notTombstonePredicate` utilisé, pas de TODO.
- Recouvre `territoires.service.ts`/`.controller.ts` avec la PR #513 (data_scopes) → conflit de merge normal à l'intégration.