### PR TITLE
docs: INTEGRATION_MEC.md au standard humain 7 sections + README chapeau (C-2)

### DIFF
--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -1,169 +1,247 @@
-# Intégration MEC — vue territoriale DDT & décisions
+# Intégration MEC — vue territoriale DDT & feedback
 
-> Public : équipe MEC (Sylvain). Sprint juillet 2026, POC lecture seule + contrat de feedback.
+> Public : équipe Mon Espace Collectivité (tech + produit, Sylvain). Sprint juillet 2026, POC.
 > Spec machine : [`openapi-territoires-decisions.yaml`](./openapi-territoires-decisions.yaml)
-> (les mêmes endpoints sont aussi dans le Swagger `/api/projets` de l'instance).
+> (mêmes endpoints dans le Swagger `/api` de l'instance).
+> Miroir TeT de ce document : [`INTEGRATION_TET.md`](./INTEGRATION_TET.md).
 
-## Auth
+## 1. L'apport — à quoi ça sert
 
-Comme les autres endpoints : `Authorization: Bearer <MEC_API_KEY>`. La clé identifie la
-plateforme — `POST /decisions` enregistre automatiquement `plateforme_source = MEC`
-(le body ne peut pas se faire passer pour un autre service).
+Un agent DDT (ou une collectivité) veut voir, pour un territoire, **tous les projets de transition
+écologique qui s'y rattachent**, quelle que soit la source. L'API réunit sous un même toit les
+projets vus par MEC, le Vivier COP et les financements DGCL/Fonds Vert, **dédupliqués** : un projet
+réel = un **groupe**, même s'il apparaît dans plusieurs sources. Pour chaque projet MEC, vous
+obtenez aussi les **PCAET** qui couvrent son territoire et sa **qualification** (leviers,
+thématiques, probabilité TE) calculée par le pipeline.
 
-## Stabilité — à lire avant de persister quoi que ce soit
+En retour, l'agent peut **donner son avis** — « ces deux traces sont le même projet », « ce projet
+est obsolète », « ce champ est faux » — via un `POST /decisions` qui **survit aux recalculs** du
+pipeline (journal append-only, partagé avec TeT). C'est le **miroir** de ce que fait TeT : là où MEC
+part d'un projet et cherche ses PCAET, TeT part d'un PCAET et liste les projets de son territoire ;
+les deux écrivent dans le **même journal**.
 
-| Donnée | Stabilité |
-|---|---|
-| `traces[].id` (UUID/ID objet) | **Stable et contractuel** — c'est la seule référence à persister côté MEC (et la seule acceptée par `POST /decisions`). **Exception : les ids des traces DGCL** (`role: "financement"`, sources `DGCL *`) ne sont **pas contractuels** — ne jamais les persister ni les référencer dans une décision (une partie changera au prochain recalcul du pipeline ; réévaluation à la rentrée selon le deal DGCL) |
-| `traces[].externalId` | Stable (c'est votre propre id) |
-| Composition des groupes, `confiance` | **Recalculées à chaque run du pipeline** — ne jamais persister ; c'est pourquoi aucun identifiant de groupe n'est exposé |
-| `copMillesime`, `copStatutVivier`, leviers | Stables entre deux livraisons DREAL/référentiel |
+## 2. Le modèle mental
 
-## 1. `GET /territoires/{code}/projets`
+- **Trace** = une occurrence d'un projet réel dans **une** source (MEC, Vivier COP, Fonds Vert,
+  DGCL…). Sa seule référence stable est `traces[].id` — la seule à persister côté MEC, la seule
+  acceptée par `POST /decisions`.
+- **Groupe** = un projet réel, c.-à-d. l'ensemble de ses traces. Aucun identifiant de groupe n'est
+  exposé : les regroupements sont recalculés à chaque run du pipeline. On raisonne sur les
+  `traces[].id`, jamais sur « le groupe ».
+- **Rôle** : une trace est un `projet` ou un `financement` (DGCL, Fonds Vert). Un financement se
+  rattache au projet du groupe, ce n'est pas un projet distinct.
+- **Confiance** (du groupe) : `CERTAIN` (lien établi), `PROBABLE` (suggestion à confirmer), `null`
+  (trace seule).
+- **Décision** = un événement **append-only** (doublon, statut, rattachement PCAET, correction). On
+  ne modifie ni ne supprime : pour revenir en arrière, on poste une **révocation**
+  (`verdict: "annule"`, `supersedes: <id>`). Détails : [`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md).
 
-`code` = INSEE commune (5 chiffres) ou SIREN EPCI (9 chiffres, résolu en communes membres).
-
-Query params : `sources` (CSV de `source_origine` : `MEC`, `Vivier COP`, `Fonds Vert`, `DGCL DETR`…
-— ⚠ pas de source `TeT` en V1 : les fiches action TeT ne sont pas exposées dans cette vue),
-`copMillesime` (`2024`|`2025`), `copStatutVivier` (`a_remonter`, `a_travailler`,
-`hors_cop_mais_crte`, `non_remonte`), `limit` (1–200, défaut 50), `offset`,
-`inclureFinancementsSeuls` (défaut `false` : les groupes composés uniquement de
-financements DGCL/Fonds Vert sont masqués).
+## 3. Démarrer en 10 min (réponses réelles, territoire d'Amiens)
 
 ```bash
-curl -H "Authorization: Bearer $MEC_API_KEY" \
-  "$BASE/territoires/80021/projets?sources=Vivier%20COP&copMillesime=2024&limit=5"
+BASE=https://api.collectivites.beta.gouv.fr
+# La clé identifie la plateforme : POST /decisions enregistre plateforme_source = MEC
+# (le corps ne peut pas se faire passer pour un autre service).
+AUTH="Authorization: Bearer $MEC_API_KEY"
 ```
 
-Réponse : liste de **groupes**. Un groupe = les traces d'un même projet réel dans les
-différentes sources (regroupement par la déduplication du pipeline).
+**a) Lister les projets d'un territoire.** `code` = INSEE commune (5 chiffres ou 2A/2B+3) ou SIREN
+EPCI (9 chiffres, développé en ses communes membres).
 
-```json
+```bash
+curl -H "$AUTH" "$BASE/territoires/80021/projets?limit=5"
+```
+
+```jsonc
 {
-  "total": 23, "limit": 5, "offset": 0,
+  "total": 40,
+  "limit": 5,
+  "offset": 0,
   "groupes": [
     {
       "confiance": "PROBABLE",
       "traces": [
-        { "role": "projet", "source": "MEC", "id": "019dab93-…", "externalId": "51285",
-          "nom": "…", "statut": "En cours", "phase": "Opération", "budgetPrevisionnel": 150000,
-          "copMillesime": null, "copStatutVivier": null },
-        { "role": "projet", "source": "Vivier COP", "id": "cop_20675265", "externalId": null,
-          "nom": "…", "statut": "En instruction", "copMillesime": "2024", "copStatutVivier": "a_remonter" },
-        { "role": "financement", "source": "DGCL DSIL", "id": "dgcl-…",
-          "budgetPrevisionnel": 1308903, "montantAttribue": 150000 }
-      ]
+        {
+          "role": "projet",
+          "source": "MEC",
+          "id": "019dab94-c75e-7ef8-b7ec-7971a538bdd8",
+          "externalId": "48345",
+          "nom": "Rénover énergétiquement la crèche Pom'Cannelle",
+          "budgetPrevisionnel": 232605,
+        },
+        {
+          "role": "financement",
+          "source": "Fonds Vert",
+          "id": "12603143",
+          "statut": "Accepté",
+          "phase": "Réalisation",
+          "budgetPrevisionnel": 232604.72,
+        },
+        {
+          "role": "projet",
+          "source": "Vivier COP",
+          "id": "cop_20687601",
+          "statut": "En instruction",
+          "copMillesime": "2024",
+          "copStatutVivier": "a_remonter",
+        },
+      ],
+      // Décisions ACTIVES portant sur une trace du groupe, toutes plateformes, SANS l'auteur.
+      "decisions": [],
     },
-    { "confiance": null, "traces": [ { "role": "projet", "source": "Vivier COP", "…": "…" } ] }
-  ]
+  ],
 }
 ```
 
-**Sémantique UX convenue** :
-- `confiance: "CERTAIN"` → afficher comme **lien établi** entre les traces ;
-- `"PROBABLE"` → afficher comme **suggestion** (à confirmer par l'agent → `POST /decisions`) ;
-- `null` → singleton (une seule trace connue).
-- `role: "financement"` (DGCL DETR/DSIL/DPV, Fonds Vert) : à présenter comme financement
-  du projet du groupe, pas comme un projet distinct. ⚠ `budgetPrevisionnel` = montant **demandé**
-  (coût du dossier) ; `montantAttribue` = subvention réellement attribuée (DGCL uniquement,
-  null pour Fonds Vert).
-- Les filtres sélectionnent les projets **du territoire** ; le groupe renvoyé contient
-  ensuite *toutes* les traces du projet réel, y compris d'autres sources.
+Query params : `sources` (CSV de `source_origine` : `MEC`, `Vivier COP`, `Fonds Vert`, `DGCL DETR`…
+— ⚠ pas de source `TeT` en V1), `copMillesime` (`2024`|`2025`), `copStatutVivier` (`a_remonter`,
+`a_travailler`, `hors_cop_mais_crte`, `non_remonte`), `limit` (1–200, défaut 50), `offset`,
+`inclureFinancementsSeuls` (défaut `false` : masque les groupes 100 % financements),
+`masquerObsoletes` (défaut `false` : masque les groupes marqués obsolètes).
 
-## 2. `GET /projets/mec/{externalId}/plans-territoire`
+**Sémantique UX convenue** : `CERTAIN` → **lien établi** ; `PROBABLE` → **suggestion** (à confirmer
+par l'agent) ; `null` → singleton. `role: "financement"` → présenter comme financement du groupe.
+⚠ `budgetPrevisionnel` = montant **demandé** (coût du dossier) ; `montantAttribue` = subvention
+**attribuée** (DGCL uniquement, `null` pour Fonds Vert).
 
-Résout votre `externalId`, renvoie les PCAET couvrant les communes du projet
-(référentiel dédupliqué : un SIREN porteur = un PCAET).
+**b) Les PCAET couvrant un projet.** Résout votre `externalId`, renvoie les PCAET du territoire
+(référence dédupliquée : un SIREN porteur = un PCAET).
 
 ```bash
-curl -H "Authorization: Bearer $MEC_API_KEY" "$BASE/projets/mec/181/plans-territoire"
+curl -H "$AUTH" "$BASE/projets/mec/181/plans-territoire"
 ```
 
-```json
-{ "pcaet": [ { "nom": "PCAET …", "sirenPorteur": "241700640",
-               "presentDansTet": false, "tetExternalId": null, "source": "opendata" } ],
-  "fichesActionSuggerees": [] }
+```jsonc
+{
+  "pcaet": [
+    {
+      "nom": "PCAET",
+      "sirenPorteur": "241700640",
+      "source": "opendata",
+      "presentDansTet": false,
+      "tetExternalId": null,
+    },
+  ],
+  "fichesActionSuggerees": [],
+}
 ```
 
-⚠️ `presentDansTet`/`tetExternalId` : le deep-link TeT n'est possible que pour les plans
-connus de l'API TeT — aujourd'hui `tet_external_id` n'est renseigné pour aucun PCAET de la
-référence (seul le canal opendata l'alimente ; canaux snapshot/live TeT non branchés, issue #497).
-Prévoir l'affichage sans lien. `fichesActionSuggerees` : vide en V1 (bonus à venir).
+Chaque PCAET porte aussi un champ `rattachement` (`confirme`|`infirme`|`aucun`) vis-à-vis de CE
+projet, dérivé du journal de décisions — voir la symétrie TeT au §4. `presentDansTet`/`tetExternalId`
+sont **vides pour tous les PCAET aujourd'hui** (canal TeT non branché, cf. §6) : prévoir l'affichage
+sans deep-link. `fichesActionSuggerees` : vide en V1.
 
-### Ce que fait TeT de son côté (symétrie)
+**c) La qualification d'un projet** (le « GET leviers ») :
 
-Le même rattachement projet ↔ PCAET s'écrit et se lit **dans les deux sens**, sur le **même journal**.
-Côté TeT, l'endpoint miroir part du **PCAET** et liste les projets de son territoire :
-`GET /plans/{cle}/projets-territoire` (`cle` = SIREN porteur ou plan_id), avec par groupe un champ
-`rattachement` (`confirme`|`infirme`|`suggere`|`aucun`). Un rattachement coché depuis TeT
-(`POST /decisions`, `rattachement_pcaet`) est donc **immédiatement visible ici** (et réciproquement) —
-c'est la même décision. Détails côté TeT : [`INTEGRATION_TET.md`](./INTEGRATION_TET.md).
+```bash
+curl -H "$AUTH" "$BASE/projets/mec/48345/qualification"
+```
 
-## 3. `GET /projets/mec/{externalId}/qualification`
-
-Le « GET leviers » : qualification calculée par le pipeline.
-
-```json
-{ "externalId": "51285", "projetId": "019dab95-…",
-  "leviersSgpe": ["Rénovation (hors changement chaudières)"],
-  "llmThematiques": [ { "label": "…", "score": 0.95 } ],
-  "llmProbabiliteTe": 0.9, "llmClassifiedAt": "2026-05-02T…" }
+```jsonc
+{
+  "externalId": "48345",
+  "projetId": "019dab94-c75e-7ef8-b7ec-7971a538bdd8",
+  "leviersSgpe": ["Rénovation (hors changement chaudières)", "Sobriété des bâtiments (tertiaire)"],
+  "llmThematiques": [
+    { "label": "Audit ou travaux de rénovation énergétique tertiaire", "score": 0.97 },
+    { "label": "Sobriété énergétique", "score": 0.72 },
+  ],
+  "llmProbabiliteTe": 0.82,
+  "llmClassifiedAt": "2026-05-06T13:00:06Z",
+}
 ```
 
 `404` si l'`externalId` est inconnu (projet non encore synchronisé via le webhook).
 
-## 4. `POST /decisions` — le contrat de feedback
-
-Journal **append-only** : chaque validation/infirmation d'un agent (DDT, collectivité)
-est un événement qui **survit aux recalculs du pipeline**. Implémentation côté MEC prévue
-à la rentrée — le contrat est figé dès maintenant. **Détails, parcours et exemples : voir
-[`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md).**
-
-`typeDecision` est désormais un **vocabulaire fermé** (toute autre valeur → `400`), et chaque
-type impose ses contraintes (objetB/verdict/payload requis ou interdits) : `doublon_signale`,
-`doublon_confirme`, `doublon_infirme`, `rattachement_pcaet`, `projet_statut`, `correction_signalee`.
+**d) Donner son feedback** = poster une décision. `objetAId`/`objetBId` = **toujours des
+`traces[].id`**. Exemple : confirmer que la trace MEC et la trace Vivier COP sont le même projet.
 
 ```bash
-curl -X POST -H "Authorization: Bearer $MEC_API_KEY" -H "Content-Type: application/json" \
-  "$BASE/decisions" -d '{
-    "typeDecision": "doublon_confirme",
-    "objetAType": "projet", "objetAId": "019dab93-f4cc-7641-8bd6-3f69a44c49f3",
-    "objetBType": "projet", "objetBId": "cop_20675265",
-    "auteur": "agent-ddtm-59",
-    "commentaire": "Même projet, confirmé avec la collectivité"
-  }'
-# → 201 { "id": "77b096d7-…", "createdAt": "2026-07-07T…" }
+curl -X POST -H "$AUTH" -H "Content-Type: application/json" "$BASE/decisions" -d '{
+  "typeDecision": "doublon_confirme",
+  "objetAType": "projet", "objetAId": "019dab94-c75e-7ef8-b7ec-7971a538bdd8",
+  "objetBType": "projet", "objetBId": "cop_20687601",
+  "auteur": "agent-ddtm-80", "commentaire": "Même projet, vérifié avec la collectivité"
+}'
+# → 201 { "id": "…", "createdAt": "…" }
 ```
 
-Règles :
-- `objetAId`/`objetBId` = **toujours les `traces[].id`** (jamais un identifiant de groupe,
-  qui n'existe d'ailleurs pas dans l'API) ;
-- pour un doublon, `verdict` est **interdit** (le type porte le sens) ; `verdict` n'existe que
-  pour `rattachement_pcaet` (`confirme`|`infirme`) et `projet_statut` (`valide`|`obsolete`|`termine`) ;
-- pas de modification/suppression : pour revenir sur une décision, poster un nouvel
-  événement avec `supersedes: "<uuid de la décision révoquée>"` (le pipeline apprendra à les
-  consommer — un doublon `infirme` ne sera pas recréé) ;
-- `GET /decisions?objetId=<id>` (ou `?type=<type>`) pour relire les décisions — **chaque service
-  ne voit que ses propres décisions** (filtrées sur la plateforme authentifiée). En vue territoire,
-  `decisions[]` agrège toutes les plateformes, sans l'auteur.
+`typeDecision` est un **vocabulaire fermé** (toute autre valeur → `400`) : `doublon_signale`,
+`doublon_confirme`, `doublon_infirme`, `rattachement_pcaet`, `projet_statut`, `correction_signalee`.
+Chaque type impose ses contraintes (objetB/verdict/payload) et la révocation se fait par
+`verdict: "annule"` + `supersedes`. **Parcours, règles et exemples complets :
+[`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md).**
 
-## Cadrage POC PCAET — 5 EPCI (feature flag côté MEC)
+## 4. Le parcours
 
-| EPCI | SIREN (= `code` de l'endpoint territoires) |
-|---|---|
-| CU d'Arras | `200033579` |
-| CC de la Haute Saintonge | `200041523` |
-| CA Pornic Agglo Pays de Retz | `200067346` |
-| Nantes Métropole | `244400404` |
-| CA Valenciennes Métropole | `245901160` |
+1. L'agent DDT ouvre un territoire → `GET /territoires/{code}/projets`.
+2. L'écran liste les **groupes** ; on affiche `confiance` (lien établi / suggestion / singleton) et
+   les financements comme financements du groupe. Sur un projet MEC, on peut aller chercher ses PCAET
+   (`plans-territoire`) et sa qualification.
+3. L'agent tranche → `POST /decisions` (doublon, statut de projet, rattachement PCAET, correction).
+4. Au prochain GET, `decisions[]` porte l'historique **actif** du groupe (toutes plateformes, sans
+   l'auteur). La refonte des regroupements par le pipeline, elle, intervient au prochain **rebuild**
+   (signal immédiat, refonte différée).
 
-## Limites connues V1
+### Ce que fait TeT de son côté (symétrie)
 
-- Vivier COP : Hauts-de-France uniquement (millésimes 2024 atténuation+biodiv, 2025 adaptation) ;
+Le rattachement projet ↔ PCAET s'écrit et se lit **dans les deux sens**, sur le **même journal**.
+Côté TeT, l'endpoint miroir part du **PCAET** et liste les projets de son territoire :
+`GET /plans/{cle}/projets-territoire` (`cle` = SIREN porteur ou plan_id), avec par groupe le même
+champ `rattachement` (`confirme`|`infirme`|`suggere`|`aucun`). Un rattachement coché depuis TeT
+(`POST /decisions`, `rattachement_pcaet`) est **immédiatement visible ici**, et réciproquement — même
+décision. Détails : [`INTEGRATION_TET.md`](./INTEGRATION_TET.md).
+
+## 5. Ce qui vous appartient (et ce qu'il ne faut pas persister)
+
+| Donnée                                              | Stabilité                                                                                                                                                                                                                                                                                                                                                                       |
+| --------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `traces[].id` (UUID/ID objet)                       | **Stable et contractuel** — seule référence à persister côté MEC (et la seule acceptée par `POST /decisions`). **Exception : les traces DGCL** (`role: "financement"`, sources `DGCL *`) ne sont **pas contractuelles** — ne jamais les persister ni les référencer dans une décision (une partie changera au prochain recalcul ; réévaluation à la rentrée selon le deal DGCL) |
+| `traces[].externalId`                               | Stable (c'est votre propre id)                                                                                                                                                                                                                                                                                                                                                  |
+| Composition des groupes, `confiance`, `decisions[]` | **Recalculées / dérivées** à chaque lecture — ne jamais persister ; c'est pourquoi aucun identifiant de groupe n'est exposé                                                                                                                                                                                                                                                     |
+| `copMillesime`, `copStatutVivier`, leviers, `llm*`  | Stables entre deux livraisons DREAL/référentiel                                                                                                                                                                                                                                                                                                                                 |
+
+Vous êtes propriétaire de **vos décisions** (`plateforme_source = MEC`, dérivée de la clé). Vous ne
+révoquez que les vôtres ; `GET /decisions?objetId=…` (ou `?type=…`) ne renvoie que celles de MEC. La
+vue territoriale (`decisions[]`) agrège toutes les plateformes mais **jamais l'agent auteur** (PII).
+
+## 6. Garanties & limites
+
+- **Vivier COP** : Hauts-de-France uniquement (millésimes 2024 atténuation+biodiv, 2025 adaptation) ;
   ~10 % des lignes portent un rattachement territorial `needs_review` côté pipeline.
-- PCAET : la table de référence (`pcaet_reference`) est un livrable du chantier T4 déployé
-  séparément ; tant qu'elle n'est pas en production, `plans-territoire` renvoie `pcaet: []`
-  (pas d'erreur — dégradation propre). Couverture cible une fois livrée : 50,7 % des projets
-  MEC. Canal TeT-live exclu (bug d'ingestion webhook, issue #497).
-- Les groupes reflètent l'état de la déduplication : des doublons intra-MEC (~6 200 connus
-  côté MEC) apparaissent comme des groupes distincts tant qu'ils ne sont pas fusionnés.
+- **PCAET** : la référence (`pcaet_reference`) est **en production** — 558 PCAET, tous
+  `source: "opendata"` (ADEME). Couverture cible une fois pleinement alimentée : **50,7 %** des
+  projets MEC. `presentDansTet`/`tetExternalId` sont vides pour l'ensemble des 558 PCAET (canaux
+  snapshot/live TeT non branchés, [issue #497](https://github.com/betagouv/communs-de-la-transition-ecologique-des-collectivites/issues/497))
+  → pas de deep-link TeT pour l'instant.
+- **Regroupements** : les groupes reflètent l'état de la déduplication ; des doublons intra-MEC
+  (~6 200 connus) apparaissent comme des groupes distincts tant qu'ils ne sont pas fusionnés — d'où
+  l'intérêt de vos décisions `doublon_*`.
+- **Journal append-only** : pas d'`UPDATE`/`DELETE`. Revenir sur une décision = `verdict: "annule"`
+  - `supersedes` (les révocations sont exclues de toutes les lectures).
+
+## 7. Pour la suite — 4 étapes côté MEC
+
+1. **Nommer un interlocuteur technique + un interlocuteur produit** côté MEC (point de contact du POC).
+2. **Valider le flow sur les 5 EPCI POC** (ci-dessous) : lister un territoire → afficher groupes,
+   PCAET, qualification → poster une décision → la revoir dans `decisions[]`.
+3. **Implémenter `POST /decisions`** derrière un feature flag (prévu à la rentrée — le contrat est
+   figé dès maintenant, cf. [`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md)).
+4. **Bilan d'usage commun à la rentrée** : volumétrie des décisions, qualité des regroupements,
+   décision d'élargissement au-delà des 5 EPCI.
+
+### Les 5 EPCI POC
+
+| EPCI                         | SIREN (= `code` de l'endpoint territoires) |
+| ---------------------------- | ------------------------------------------ |
+| CU d'Arras                   | `200033579`                                |
+| CC de la Haute Saintonge     | `200041523`                                |
+| CA Pornic Agglo Pays de Retz | `200067346`                                |
+| Nantes Métropole             | `244400404`                                |
+| CA Valenciennes Métropole    | `245901160`                                |
+
+## Contact
+
+Questions d'intégration cet été : **Jean** (l'équipe API Collectivités est en effectif réduit en
+août — privilégier des demandes groupées et asynchrones). Sémantique des décisions :
+[`GUIDE_DECISIONS.md`](./GUIDE_DECISIONS.md).

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -99,6 +99,17 @@ Query params : `sources` (CSV de `source_origine` : `MEC`, `Vivier COP`, `Fonds 
 `inclureFinancementsSeuls` (défaut `false` : masque les groupes 100 % financements),
 `masquerObsoletes` (défaut `false` : masque les groupes marqués obsolètes).
 
+**Portée des filtres et sens de `total`** :
+
+- Les filtres (`sources`, `copMillesime`, `copStatutVivier`) portent sur les projets **du
+  territoire** : un groupe est renvoyé dès qu'**au moins une** de ses traces sur le territoire
+  matche. Le groupe est alors renvoyé **complet** — _toutes_ ses traces, y compris celles qui **ne
+  matchent pas** le filtre (autres sources, mais aussi autres `copMillesime`/`copStatutVivier`) et
+  les membres du cluster hors territoire.
+- `total` = nombre de **groupes**, pas de projets : plusieurs projets matchants fusionnés dans un
+  même cluster ne comptent que pour 1 (ex. réel : 29 projets Vivier COP `a_remonter` sur la CU
+  d'Arras → `total` 27).
+
 **Sémantique UX convenue** : `CERTAIN` → **lien établi** ; `PROBABLE` → **suggestion** (à confirmer
 par l'agent) ; `null` → singleton. `role: "financement"` → présenter comme financement du groupe.
 ⚠ `budgetPrevisionnel` = montant **demandé** (coût du dossier) ; `montantAttribue` = subvention

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -1,0 +1,52 @@
+# Documentation API Collectivités
+
+Point d'entrée de la documentation d'intégration de l'**API Collectivités** (le référentiel partagé
+des projets de transition écologique des collectivités : MEC, TeT, Vivier COP, financements
+DGCL/Fonds Vert, PCAET, dédupliqués). Chaque guide est écrit du point de vue de la plateforme qui
+l'intègre. Trouvez le vôtre ci-dessous.
+
+Base de l'API : `https://api.collectivites.beta.gouv.fr` · Auth : `Authorization: Bearer <clé>`
+(la clé identifie la plateforme ; `plateforme_source` en est dérivée). Spec machine :
+[`openapi-territoires-decisions.yaml`](./openapi-territoires-decisions.yaml) et le Swagger `/api` de
+l'instance.
+
+## Vous intégrez depuis…
+
+### Mon Espace Collectivité (MEC)
+
+- [**`INTEGRATION_MEC.md`**](./INTEGRATION_MEC.md) — vue territoriale DDT : lister les projets d'un
+  territoire (dédupliqués), les PCAET couvrant un projet, sa qualification, et donner du feedback.
+- [`classification-et-aides.md`](./classification-et-aides.md) — classification LLM des projets et
+  matching d'aides.
+- [`leviers-endpoint.md`](./leviers-endpoint.md) — endpoint `/qualification/leviers` (leviers SGPE).
+
+### Territoires en Transitions (TeT)
+
+- [**`INTEGRATION_TET.md`**](./INTEGRATION_TET.md) — vue miroir : partir d'un PCAET, lister les
+  projets de son territoire, et les **rattacher** un à un (`GET /plans/{cle}/projets-territoire`).
+
+### Transverse — toutes plateformes
+
+- [**`GUIDE_DECISIONS.md`**](./GUIDE_DECISIONS.md) — le contrat de **décisions** (`POST /decisions`) :
+  doublons, statut de projet, rattachement PCAET, correction, et la révocation par `annule`. À lire
+  dès que vous écrivez dans le référentiel, quelle que soit votre plateforme.
+
+### Interne / gouvernance
+
+- [**`DOCTRINE_ACCES_DONNEES.md`**](./DOCTRINE_ACCES_DONNEES.md) — « qui voit quoi » : scopes de
+  données, sources restreintes, attribution et retrait d'un accès, journalisation.
+
+## Repères communs
+
+- **Groupe** = un projet réel = l'ensemble de ses **traces** dans les différentes sources. Aucun
+  identifiant de groupe n'est exposé (les regroupements sont recalculés à chaque run) ; la seule
+  référence stable est `traces[].id`.
+- **Décision** = un événement **append-only** partagé entre plateformes ; on ne modifie ni ne
+  supprime, on **révoque** (`verdict: "annule"` + `supersedes`).
+- **Signal immédiat, refonte différée** : vos décisions sont lisibles tout de suite (`decisions[]`,
+  `rattachement`, filtre obsolètes) ; la refonte des regroupements par le pipeline intervient au
+  prochain rebuild.
+
+## Contact
+
+Intégration cet été : **Jean** (effectif réduit en août — demandes groupées et asynchrones).


### PR DESCRIPTION
## Bloc C partie 2 — refonte docs au standard humain

Aligne `INTEGRATION_MEC.md` sur le **standard des docs d'intégration** déjà appliqué à
`INTEGRATION_TET.md` et `GUIDE_DECISIONS.md` : 7 sections orientées « plateforme partenaire »,
vouvoiement, « groupe » (jamais « cluster »), aucune date promise, **réponses réelles vérifiées
contre la prod**.

### `INTEGRATION_MEC.md` (refonte)

Passage d'un plan « endpoint par endpoint » à la structure 7 sections :

1. **L'apport** — vue territoriale DDT + feedback, miroir de TeT.
2. **Le modèle mental** — trace / groupe / rôle / confiance / décision.
3. **Démarrer en 10 min** — **réponses réelles** : territoire d'Amiens (`80021`, groupe crèche
   Pom'Cannelle MEC+Fonds Vert+Vivier COP), `plans-territoire/181` (PCAET `241700640` opendata),
   `qualification/48345`, et un `POST /decisions` d'exemple.
4. **Le parcours** + « ce que fait TeT de son côté » (symétrie, même journal).
5. **Ce qui vous appartient** — tableau de stabilité (traces[].id contractuel sauf DGCL, groupes
   recalculés…).
6. **Garanties & limites** — Vivier COP HdF, PCAET (558 opendata, 50,7 % cible, deep-links TeT
   indisponibles #497), doublons intra-MEC, journal append-only.
7. **Pour la suite** — 4 étapes côté MEC + les 5 EPCI POC.

**Corrigé au passage** : l'ancien texte affirmait « tant que `pcaet_reference` n'est pas en
production, `pcaet: []` » — la matview **EST en production** (558 PCAET opendata).

### `docs/api/README.md` (nouveau — chapeau)

Oriente par **audience** : MEC (`INTEGRATION_MEC` + classification/leviers), TeT (`INTEGRATION_TET`),
transverse (`GUIDE_DECISIONS`), interne/gouvernance (`DOCTRINE_ACCES_DONNEES`), spec machine
(openapi). Plus des « repères communs » (groupe, décision append-only, signal immédiat).

### Vérifs

- Réponses des §3 **récupérées en lecture seule contre la prod** (Amiens 40 groupes, PCAET 181,
  qualification 48345).
- Prettier OK ; liens internes vérifiés.

### ⚠️ Dépendance d'ordre de merge

Le `README.md` référence [`DOCTRINE_ACCES_DONNEES.md`](docs/api/DOCTRINE_ACCES_DONNEES.md), livré par
la **PR #513** (data_scopes, en queue). **#513 doit merger avant cette PR** pour que le lien résolve
(l'ordre prévu — #513 est déjà en queue).

Docs uniquement, aucun code touché. **NE PAS MERGER avant #513.**