### PR TITLE
fix: attentes des specs services après l'ajout de data_scopes (CI main)

### DIFF
--- a/api/src/services/services-context.service.spec.ts
+++ b/api/src/services/services-context.service.spec.ts
@@ -87,6 +87,7 @@ describe("ServiceContextService", () => {
         extendLabel: createContextDto.extendLabel,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -117,6 +118,7 @@ describe("ServiceContextService", () => {
         createdAt: expect.any(Date),
         description: createContextDto.description,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -149,6 +151,7 @@ describe("ServiceContextService", () => {
         name: service.name,
         description: "Context Description",
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -189,6 +192,7 @@ describe("ServiceContextService", () => {
         extendLabel: service.extendLabel,
         iframeUrl: service.iframeUrl,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -237,6 +241,7 @@ describe("ServiceContextService", () => {
         extendLabel: createContextDto.extendLabel,
         iframeUrl: createContextDto.iframeUrl,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -275,6 +280,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         isListed: true,
         iframeUrl: null,
+        dataScopes: [],
         extraFields: [],
       });
 
@@ -385,6 +391,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
 
@@ -428,6 +435,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -466,6 +474,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -501,6 +510,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
 
@@ -607,6 +617,7 @@ describe("ServiceContextService", () => {
         createdAt: expect.any(Date),
         description: createContextDto.description,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -643,6 +654,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -863,6 +875,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -900,6 +913,7 @@ describe("ServiceContextService", () => {
         extendLabel: null,
         iframeUrl: null,
         isListed: true,
+        dataScopes: [],
         extraFields: [],
       });
     });
@@ -1092,6 +1106,7 @@ describe("ServiceContextService", () => {
         serviceId: service.id,
         ...validServiceContext,
         iframeUrl: null,
+        dataScopes: [],
         extraFields: [],
         regions: [],
         name: null,

--- a/api/src/services/services.service.spec.ts
+++ b/api/src/services/services.service.spec.ts
@@ -59,6 +59,8 @@ describe("ServicesService", () => {
         id: expect.any(String),
         createdAt: expect.any(Date),
         ...serviceDTO,
+        // Colonne data_scopes (doctrine d'accès) : défaut '{}' → tableau vide.
+        dataScopes: [],
       });
     });
 


### PR DESCRIPTION
## Hotfix CI main — débloque le deploy staging

Depuis le merge de #513 (doctrine d'accès), la colonne `data_scopes` (`text[] NOT NULL
DEFAULT '{}'`) apparaît dans les lignes `services` retournées par l'API → mappée `[]` par
Drizzle. Les suites **testcontainer** de `services` faisaient des `toEqual` stricts sans ce
champ → **5+ tests rouges sur main**, deploy staging bloqué. (Invisible dans la sandbox sans
Docker ; diagnostiqué avec l'équipe.)

## Fix — specs uniquement, aucun code applicatif touché

- **`services-context.service.spec.ts`** : `dataScopes: []` ajouté aux **15** attentes de
  forme service (`findMatchingServicesContext` / `getAllServicesContexts`, via
  `mapToServiceResponse` qui spread `...services`). Sur les blocs qui font déjà `...service`
  (retour de `create()`, qui porte `dataScopes`), c'est un override explicite de même valeur
  (pas de clé dupliquée).
- **`services.service.spec.ts`** : idem sur l'attente du retour de `create()`.

## Périmètre vérifié (grep)

- `services.controller.spec.ts` : **mocke** le service (`jest.spyOn(...).mockResolvedValue`)
  → ne touche pas la DB, non concerné.
- `extra-fields.service.spec.ts` (testcontainer) : asserte des **valeurs de champs projet**
  (`{ name, value }`), pas la forme d'un service → non concerné.
- **Aucune autre spec testcontainer** ne référence la table `services`.

## Validation

`type-check` + `lint` + `format:check` (tous packages) + gitleaks verts. Les suites
testcontainer elles-mêmes ne tournent pas dans la sandbox (pas de Docker) : le correctif
aligne exactement les attentes sur le nouveau champ (default `'{}'` → `[]`, jamais null,
y compris pour les lignes backfillées par l'ALTER).

À mettre en queue en priorité (staging bloqué d'ici là).