### PR TITLE
fix: retirer dataScopes de l'attente du create de service context (CI main)

### DIFF
--- a/api/src/services/services-context.service.spec.ts
+++ b/api/src/services/services-context.service.spec.ts
@@ -1106,7 +1106,6 @@ describe("ServiceContextService", () => {
         serviceId: service.id,
         ...validServiceContext,
         iframeUrl: null,
-        dataScopes: [],
         extraFields: [],
         regions: [],
         name: null,


### PR DESCRIPTION
## Suite de #516 — dernier test rouge

`ServiceContextService › create › should create a new service context`
(`services-context.service.spec.ts:1104`) reste rouge sur main **à cause de #516**.

### Cause

Mon hotfix #516 ajoutait `dataScopes: []` **avant chaque `extraFields: []`** via un sed
global. Il a donc AUSSI touché ce test — à tort : `serviceContextService.create()` renvoie
une ligne **`service_context`**, table qui n'a **pas** de colonne `data_scopes` (celle-ci
n'existe que sur `services`, cf. `schema.ts:147`). L'attente portait donc un champ absent de
l'objet réel → `toEqual` strict rouge. (Ce test **passait** avant #516 ; #516 l'a régressé.)

### Fix

Retirer le `dataScopes: []` de cette seule attente → retour à l'état d'avant #516 (passant).

Les **14** autres blocs conservés sont des retours de `findMatchingServicesContext` /
`getAllServicesContexts` (via `mapToServiceResponse`, qui spread `...services`) → lignes
`services`, qui portent bien `data_scopes` : eux ont besoin de l'attente `dataScopes: []`.

### Vérification

- `serviceContext` n'a aucune colonne `data_scopes` (seul `services` en a) — vérifié dans `schema.ts`.
- Les 14 `dataScopes` restants sont tous dans les describes `findMatchingServices` /
  `getAllServicesContexts` (lignes < 1076), aucun dans `describe("create")`.
- `type-check` + `lint` + `format:check` (tous packages) + gitleaks verts. (Suites
  testcontainer non exécutables dans la sandbox — pas de Docker.)

À queuer en priorité (débloque main + staging).