### PR TITLE
feat: prédiction des leviers des projets MEC (data_mec) + exposition sur le GET qualification

### DIFF
--- a/api/drizzle/0042_data_mec_llm_leviers.sql
+++ b/api/drizzle/0042_data_mec_llm_leviers.sql
@@ -1,0 +1,14 @@
+-- Prédiction LLM des leviers sur les projets MEC (data_mec.projets_operationnels).
+--
+-- llm_leviers          : jsonb [{ label, score }] (scores [0,1]), prédiction validée
+--                        contre le référentiel canonique des leviers. DISTINCT de
+--                        leviers_sgpe (déclaratif MEC, historiquement pollué) — jamais
+--                        écrasé par une prédiction.
+-- llm_leviers_version  : version du modèle/prompt ayant produit la prédiction. Permet un
+--                        re-run « prompt v2 » propre (remplacement, pas empilement de
+--                        générations). Interne : NON exposée par l'API.
+--
+-- IF NOT EXISTS OBLIGATOIRE : le script batch de stock (pipeline) peut créer ces colonnes
+-- avant le déploiement de l'API — définitions coordonnées, strictement identiques.
+ALTER TABLE "data_mec"."projets_operationnels" ADD COLUMN IF NOT EXISTS "llm_leviers" jsonb;
+ALTER TABLE "data_mec"."projets_operationnels" ADD COLUMN IF NOT EXISTS "llm_leviers_version" text;

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1783507993444,
       "tag": "0041_services_data_scopes",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1783602084851,
+      "tag": "0042_data_mec_llm_leviers",
+      "breakpoints": true
     }
   ]
 }

--- a/api/src/database/mec-schema.ts
+++ b/api/src/database/mec-schema.ts
@@ -102,6 +102,13 @@ export const mecProjetsOperationnels = dataMecSchema.table(
     }>(),
     probabiliteTe: doublePrecision("probabilite_te"),
 
+    // Leviers predicted by the LLM ([{ label, score }], scores [0,1]) — written by the
+    // leviers qualification job. DISTINCT from declarative leviersSgpe (never overwritten).
+    // llmLeviersVersion tags the model/prompt version for clean "prompt v2" re-runs; it is
+    // internal provenance and is NOT exposed by the API.
+    llmLeviers: jsonb("llm_leviers").$type<{ label: string; score: number }[]>(),
+    llmLeviersVersion: text("llm_leviers_version"),
+
     // CRTE first-class fields
     crteId: text("crte_id"),
     crteAnneeInscription: integer("crte_annee_inscription"),

--- a/api/src/mec/mec.service.spec.ts
+++ b/api/src/mec/mec.service.spec.ts
@@ -1,10 +1,10 @@
 import { Queue } from "bullmq";
 import { MecService } from "./mec.service";
 import { DatabaseService } from "@database/database.service";
-import { CreateMecProjetRequest } from "./dto/create-mec-projet.dto";
+import { CreateMecProjetRequest, UpdateMecProjetRequest } from "./dto/create-mec-projet.dto";
 import {
   PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
-  PROJECT_QUALIFICATION_LEVIERS_JOB,
+  PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB,
 } from "@/projet-qualification/const";
 
 // Test unitaire pur (DB + queue mockées) de l'enqueue de la prédiction leviers sur /mec/v1.
@@ -47,17 +47,20 @@ describe("MecService — enqueue prédiction leviers (/mec/v1)", () => {
 
   const jobNames = (): string[] => (add.mock.calls as [string, unknown][]).map((c) => c[0]);
 
-  it("enqueue la prédiction leviers (data_mec) à la création d'un projet", async () => {
+  it("enqueue la prédiction leviers (data_mec) à la création, avec retry", async () => {
     selectLimit
       .mockResolvedValueOnce([{ siren: "218000217" }]) // resolveCollectivite (Commune)
       .mockResolvedValueOnce([]); // existingExternal → aucun (nouveau projet)
 
     await service.createOrUpdate(baseDto());
 
-    expect(jobNames()).toContain(PROJECT_QUALIFICATION_LEVIERS_JOB);
+    expect(jobNames()).toContain(PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB);
+    // Nom de job DISTINCT (robuste au rolling deploy) + options de retry alignées sur les
+    // autres producteurs (un échec LLM transitoire ne laisse pas llm_leviers NULL à vie).
     expect(add).toHaveBeenCalledWith(
-      PROJECT_QUALIFICATION_LEVIERS_JOB,
+      PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB,
       expect.objectContaining({ schema: "data_mec" }),
+      expect.objectContaining({ attempts: 3, backoff: { type: "exponential", delay: 5000 } }),
     );
   });
 
@@ -66,7 +69,7 @@ describe("MecService — enqueue prédiction leviers (/mec/v1)", () => {
 
     await service.createOrUpdate(baseDto({ leviers: ["Vélo"] }));
 
-    expect(jobNames()).toContain(PROJECT_QUALIFICATION_LEVIERS_JOB);
+    expect(jobNames()).toContain(PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB);
   });
 
   it("enqueue classification + leviers quand le contenu d'un projet existant change", async () => {
@@ -78,7 +81,45 @@ describe("MecService — enqueue prédiction leviers (/mec/v1)", () => {
     await service.createOrUpdate(baseDto());
 
     expect(jobNames()).toEqual(
-      expect.arrayContaining([PROJECT_QUALIFICATION_CLASSIFICATION_JOB, PROJECT_QUALIFICATION_LEVIERS_JOB]),
+      expect.arrayContaining([PROJECT_QUALIFICATION_CLASSIFICATION_JOB, PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB]),
     );
+  });
+
+  describe("update (PATCH /mec/v1/projets/:id)", () => {
+    const patch = (dto: UpdateMecProjetRequest) => service.update("p1", dto);
+
+    it("recalcule le hash et ré-enqueue classification + leviers quand le texte change", async () => {
+      selectLimit.mockResolvedValueOnce([
+        { id: "p1", nom: "Ancien nom", description: "ancienne desc", contentHash: "ancien-hash" },
+      ]);
+
+      await patch({ nom: "Nouveau nom de projet" });
+
+      expect(jobNames()).toEqual(
+        expect.arrayContaining([PROJECT_QUALIFICATION_CLASSIFICATION_JOB, PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB]),
+      );
+    });
+
+    it("ne ré-enqueue rien quand le PATCH ne touche pas nom/description", async () => {
+      selectLimit.mockResolvedValueOnce([{ id: "p1", nom: "Nom", description: "desc", contentHash: "hash" }]);
+
+      await patch({ budgetPrevisionnel: 1000 });
+
+      expect(add).not.toHaveBeenCalled();
+    });
+
+    it("ne ré-enqueue rien quand le texte fourni est identique (hash inchangé)", async () => {
+      // Le hash existant correspond au (nom, description) qui seront réappliqués.
+      const nom = "Nom identique";
+      const description = "desc identique";
+      const computeHash = (
+        service as unknown as { computeContentHash(n: string, d: string | null): string }
+      ).computeContentHash.bind(service);
+      selectLimit.mockResolvedValueOnce([{ id: "p1", nom, description, contentHash: computeHash(nom, description) }]);
+
+      await patch({ nom, description });
+
+      expect(add).not.toHaveBeenCalled();
+    });
   });
 });

--- a/api/src/mec/mec.service.spec.ts
+++ b/api/src/mec/mec.service.spec.ts
@@ -1,0 +1,84 @@
+import { Queue } from "bullmq";
+import { MecService } from "./mec.service";
+import { DatabaseService } from "@database/database.service";
+import { CreateMecProjetRequest } from "./dto/create-mec-projet.dto";
+import {
+  PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+  PROJECT_QUALIFICATION_LEVIERS_JOB,
+} from "@/projet-qualification/const";
+
+// Test unitaire pur (DB + queue mockées) de l'enqueue de la prédiction leviers sur /mec/v1.
+// Le worker lui-même est testé séparément (projet-qualification.leviers-mec.spec.ts).
+describe("MecService — enqueue prédiction leviers (/mec/v1)", () => {
+  let selectLimit: jest.Mock;
+  let insertValues: jest.Mock;
+  let updateWhere: jest.Mock;
+  let add: jest.Mock;
+  let service: MecService;
+
+  const makeDb = () => {
+    selectLimit = jest.fn();
+    insertValues = jest.fn().mockResolvedValue(undefined);
+    updateWhere = jest.fn().mockResolvedValue(undefined);
+    const database = {
+      select: jest.fn().mockReturnValue({ from: () => ({ where: () => ({ limit: selectLimit }) }) }),
+      insert: jest.fn().mockReturnValue({ values: insertValues }),
+      update: jest.fn().mockReturnValue({ set: () => ({ where: updateWhere }) }),
+    } as unknown as DatabaseService["database"];
+    return database;
+  };
+
+  const baseDto = (overrides: Partial<CreateMecProjetRequest> = {}): CreateMecProjetRequest =>
+    ({
+      nom: "Rénovation de l'école",
+      externalId: "mec-42",
+      description: "Isolation thermique et panneaux solaires",
+      collectivites: [{ type: "Commune", code: "80021" }],
+      ...overrides,
+    }) as CreateMecProjetRequest;
+
+  beforeEach(() => {
+    const dbService = { database: makeDb() } as unknown as DatabaseService;
+    const logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() } as never;
+    add = jest.fn().mockResolvedValue(undefined);
+    const queue = { add } as unknown as Queue;
+    service = new MecService(dbService, logger, queue);
+  });
+
+  const jobNames = (): string[] => (add.mock.calls as [string, unknown][]).map((c) => c[0]);
+
+  it("enqueue la prédiction leviers (data_mec) à la création d'un projet", async () => {
+    selectLimit
+      .mockResolvedValueOnce([{ siren: "218000217" }]) // resolveCollectivite (Commune)
+      .mockResolvedValueOnce([]); // existingExternal → aucun (nouveau projet)
+
+    await service.createOrUpdate(baseDto());
+
+    expect(jobNames()).toContain(PROJECT_QUALIFICATION_LEVIERS_JOB);
+    expect(add).toHaveBeenCalledWith(
+      PROJECT_QUALIFICATION_LEVIERS_JOB,
+      expect.objectContaining({ schema: "data_mec" }),
+    );
+  });
+
+  it("prédit les leviers même quand leviers_sgpe est fourni (provenances distinctes)", async () => {
+    selectLimit.mockResolvedValueOnce([{ siren: "218000217" }]).mockResolvedValueOnce([]);
+
+    await service.createOrUpdate(baseDto({ leviers: ["Vélo"] }));
+
+    expect(jobNames()).toContain(PROJECT_QUALIFICATION_LEVIERS_JOB);
+  });
+
+  it("enqueue classification + leviers quand le contenu d'un projet existant change", async () => {
+    selectLimit
+      .mockResolvedValueOnce([{ siren: "218000217" }]) // resolveCollectivite
+      .mockResolvedValueOnce([{ objetId: "existing-uuid" }]) // existingExternal → trouvé
+      .mockResolvedValueOnce([{ contentHash: "ancien-hash-different" }]); // contenu précédent
+
+    await service.createOrUpdate(baseDto());
+
+    expect(jobNames()).toEqual(
+      expect.arrayContaining([PROJECT_QUALIFICATION_CLASSIFICATION_JOB, PROJECT_QUALIFICATION_LEVIERS_JOB]),
+    );
+  });
+});

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -1,6 +1,6 @@
 import { Injectable, NotFoundException } from "@nestjs/common";
 import { InjectQueue } from "@nestjs/bullmq";
-import { Queue } from "bullmq";
+import { Queue, JobsOptions } from "bullmq";
 import { DatabaseService } from "@database/database.service";
 import {
   mecProjetsOperationnels,
@@ -18,8 +18,19 @@ import { uuidv7 } from "uuidv7";
 import {
   PROJECT_QUALIFICATION_QUEUE_NAME,
   PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
-  PROJECT_QUALIFICATION_LEVIERS_JOB,
+  PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB,
 } from "@/projet-qualification/const";
+
+// Options d'enqueue alignées sur les autres producteurs de la queue (create/update-projets,
+// fiches-action, aides) : retry des échecs LLM transitoires (429/529/timeout/parse), sinon un
+// seul échec laisserait llm_leviers NULL définitivement. + purge Redis : un resync bulk
+// enfilerait ~160k jobs, on ne garde pas les complétés et on plafonne les échoués.
+const QUALIFICATION_JOB_OPTS: JobsOptions = {
+  attempts: 3,
+  backoff: { type: "exponential", delay: 5000 },
+  removeOnComplete: true,
+  removeOnFail: { count: 1000 },
+};
 
 @Injectable()
 export class MecService {
@@ -201,7 +212,12 @@ export class MecService {
     const db = this.dbService.database;
 
     const [existing] = await db
-      .select({ id: mecProjetsOperationnels.id })
+      .select({
+        id: mecProjetsOperationnels.id,
+        nom: mecProjetsOperationnels.nom,
+        description: mecProjetsOperationnels.description,
+        contentHash: mecProjetsOperationnels.contentHash,
+      })
       .from(mecProjetsOperationnels)
       .where(eq(mecProjetsOperationnels.id, id))
       .limit(1);
@@ -247,8 +263,27 @@ export class MecService {
     if (dto.besoins !== undefined) fieldsToUpdate.besoins = dto.besoins;
     if (dto.planRattachement !== undefined) fieldsToUpdate.planRattachement = dto.planRattachement;
 
+    // Recalcule le content hash et ré-enclenche la qualification quand nom/description changent
+    // (même logique que createOrUpdate). Sinon le PATCH laisserait classification et leviers
+    // prédits sur l'ANCIEN texte — servis par le GET qualification, indiscernables de frais.
+    let contentChanged = false;
+    if (dto.nom !== undefined || dto.description !== undefined) {
+      const newNom = dto.nom ?? existing.nom;
+      const newDescription = dto.description !== undefined ? dto.description : existing.description;
+      const newHash = this.computeContentHash(newNom, newDescription);
+      if (newHash !== existing.contentHash) {
+        fieldsToUpdate.contentHash = newHash;
+        contentChanged = true;
+      }
+    }
+
     if (Object.keys(fieldsToUpdate).length > 0) {
       await db.update(mecProjetsOperationnels).set(fieldsToUpdate).where(eq(mecProjetsOperationnels.id, id));
+    }
+
+    if (contentChanged) {
+      this.scheduleClassification(id);
+      this.scheduleLeviersPrediction(id);
     }
 
     // Auto-create CRTE plan if crteId is provided in the update
@@ -378,7 +413,7 @@ export class MecService {
 
   private scheduleClassification(projetId: string): void {
     this.qualificationQueue
-      .add(PROJECT_QUALIFICATION_CLASSIFICATION_JOB, { projetId, schema: "data_mec" })
+      .add(PROJECT_QUALIFICATION_CLASSIFICATION_JOB, { projetId, schema: "data_mec" }, QUALIFICATION_JOB_OPTS)
       .then(() => this.logger.log(`Classification scheduled for MEC projet ${projetId}`))
       .catch((err) =>
         this.logger.error(
@@ -389,7 +424,7 @@ export class MecService {
 
   private scheduleLeviersPrediction(projetId: string): void {
     this.qualificationQueue
-      .add(PROJECT_QUALIFICATION_LEVIERS_JOB, { projetId, schema: "data_mec" })
+      .add(PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB, { projetId, schema: "data_mec" }, QUALIFICATION_JOB_OPTS)
       .then(() => this.logger.log(`Leviers prediction scheduled for MEC projet ${projetId}`))
       .catch((err) =>
         this.logger.error(

--- a/api/src/mec/mec.service.ts
+++ b/api/src/mec/mec.service.ts
@@ -18,6 +18,7 @@ import { uuidv7 } from "uuidv7";
 import {
   PROJECT_QUALIFICATION_QUEUE_NAME,
   PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+  PROJECT_QUALIFICATION_LEVIERS_JOB,
 } from "@/projet-qualification/const";
 
 @Injectable()
@@ -88,9 +89,10 @@ export class MecService {
 
       await db.update(mecProjetsOperationnels).set(fieldsToSet).where(eq(mecProjetsOperationnels.id, projetId));
 
-      // Schedule classification if content changed
+      // Schedule classification + leviers prediction if content changed
       if (existing && existing.contentHash !== contentHash) {
         this.scheduleClassification(projetId);
+        this.scheduleLeviersPrediction(projetId);
       }
     } else {
       projetId = uuidv7();
@@ -110,6 +112,9 @@ export class MecService {
       if (!dto.classificationThematiques || dto.classificationThematiques.length === 0) {
         this.scheduleClassification(projetId);
       }
+      // Leviers : toujours prédire, même si leviers_sgpe est fourni. Les deux familles
+      // coexistent (leviers_sgpe = déclaratif MEC, llm_leviers = prédiction), provenance distincte.
+      this.scheduleLeviersPrediction(projetId);
     }
 
     // 5. Upsert plans and link them
@@ -378,6 +383,17 @@ export class MecService {
       .catch((err) =>
         this.logger.error(
           `Failed to schedule classification for MEC projet ${projetId}: ${err instanceof Error ? err.message : String(err)}`,
+        ),
+      );
+  }
+
+  private scheduleLeviersPrediction(projetId: string): void {
+    this.qualificationQueue
+      .add(PROJECT_QUALIFICATION_LEVIERS_JOB, { projetId, schema: "data_mec" })
+      .then(() => this.logger.log(`Leviers prediction scheduled for MEC projet ${projetId}`))
+      .catch((err) =>
+        this.logger.error(
+          `Failed to schedule leviers prediction for MEC projet ${projetId}: ${err instanceof Error ? err.message : String(err)}`,
         ),
       );
   }

--- a/api/src/projet-qualification/const.ts
+++ b/api/src/projet-qualification/const.ts
@@ -4,6 +4,11 @@ export const PROJECT_QUALIFICATION_QUEUE_NAME = "project-qualification";
 export const PROJECT_QUALIFICATION_COMPETENCES_JOB = "project-qualification-competences-job";
 export const PROJECT_QUALIFICATION_LEVIERS_JOB = "project-qualification-leviers-job";
 export const PROJECT_QUALIFICATION_CLASSIFICATION_JOB = "project-qualification-classification-job";
+// Nom de job DISTINCT pour la prédiction leviers du chemin data_mec. Pendant un rolling
+// deploy Scalingo, l'ancien container (worker in-process, sans ce chemin) reçoit un job de
+// ce nom → aucun `case` ne matche → il throw (retry après bascule), il n'écrit JAMAIS
+// public.projets via le fallthrough legacy (IDs partagés data_mec/public). Voir #459.
+export const PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB = "project-qualification-leviers-data-mec-job";
 export const COMPETENCE_SCORE_TRESHOLD = 0.7;
 export const LEVIER_SCORE_TRESHOLD = 0.7;
 

--- a/api/src/projet-qualification/projet-qualification.leviers-mec.spec.ts
+++ b/api/src/projet-qualification/projet-qualification.leviers-mec.spec.ts
@@ -1,0 +1,117 @@
+import { InternalServerErrorException } from "@nestjs/common";
+import { Job } from "bullmq";
+import { ProjetQualificationService } from "./projet-qualification.service";
+import { PROJECT_QUALIFICATION_LEVIERS_JOB } from "./const";
+import { LEVIERS_PREDICTION_VERSION } from "@/shared/const/leviers";
+import { AnthropicService } from "@/projet-qualification/llm/anthropic.service";
+import { LeviersValidationService } from "@/projet-qualification/llm/validation/leviers-validation.service";
+import { DatabaseService } from "@database/database.service";
+import { LeviersAnalysisResult } from "@/projet-qualification/llm/prompts/types";
+import { LevierDto } from "@/projet-qualification/dto/projet-qualification.dto";
+
+// Test unitaire pur (DB mockée) du chemin leviers → data_mec du worker de qualification.
+// Ne dépend d'aucun testcontainer : constructible sans Nest DI (WorkerHost n'a pas de constructeur).
+describe("ProjetQualificationService — prédiction leviers data_mec", () => {
+  let service: ProjetQualificationService;
+  let analyzeLeviers: jest.Mock;
+  let validateAndCorrect: jest.Mock;
+  let limit: jest.Mock;
+  let setMock: jest.Mock;
+  let updateWhere: jest.Mock;
+  let database: DatabaseService["database"];
+
+  const makeJob = (projetId: string): Job<{ projetId: string; schema: string }> =>
+    ({ name: PROJECT_QUALIFICATION_LEVIERS_JOB, data: { projetId, schema: "data_mec" } }) as Job<{
+      projetId: string;
+      schema: string;
+    }>;
+
+  beforeEach(() => {
+    limit = jest.fn();
+    updateWhere = jest.fn().mockResolvedValue(undefined);
+    setMock = jest.fn().mockReturnValue({ where: updateWhere });
+
+    database = {
+      select: jest.fn().mockReturnValue({ from: () => ({ where: () => ({ limit }) }) }),
+      update: jest.fn().mockReturnValue({ set: setMock }),
+    } as unknown as DatabaseService["database"];
+
+    analyzeLeviers = jest.fn();
+    validateAndCorrect = jest.fn();
+
+    const anthropicService = { analyzeLeviers } as unknown as AnthropicService;
+    const leviersValidationService = { validateAndCorrect } as unknown as LeviersValidationService;
+    const dbService = { database } as unknown as DatabaseService;
+    const logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() };
+
+    service = new ProjetQualificationService(
+      {} as never,
+      {} as never,
+      anthropicService,
+      leviersValidationService,
+      {} as never,
+      {} as never,
+      dbService,
+      logger as never,
+    );
+  });
+
+  const analysis = (): LeviersAnalysisResult => ({
+    json: {
+      projet: "Rénovation école",
+      classification: "Le projet a un lien avec la transition écologique",
+      leviers: { "Rénovation (hors changement chaudières)": 0.9 },
+    },
+    raisonnement: "interne",
+    errorMessage: "",
+  });
+
+  it("écrit data_mec.llm_leviers ([{label, score}]) + version, pas leviers_sgpe", async () => {
+    limit.mockResolvedValueOnce([{ id: "p1", nom: "Rénovation école", description: "isolation" }]);
+    analyzeLeviers.mockResolvedValueOnce(analysis());
+    const validated: LevierDto[] = [
+      { nom: "Rénovation (hors changement chaudières)", score: 0.9 },
+      { nom: "Sobriété des bâtiments (tertiaire)", score: 0.3 },
+    ];
+    validateAndCorrect.mockReturnValueOnce(validated);
+
+    await service.process(makeJob("p1"));
+
+    // Threshold 0 : toute la distribution validée est passée (le consommateur filtre).
+    expect(validateAndCorrect).toHaveBeenCalledWith(expect.anything(), 0);
+    expect(setMock).toHaveBeenCalledWith({
+      llmLeviers: [
+        { label: "Rénovation (hors changement chaudières)", score: 0.9 },
+        { label: "Sobriété des bâtiments (tertiaire)", score: 0.3 },
+      ],
+      llmLeviersVersion: LEVIERS_PREDICTION_VERSION,
+    });
+  });
+
+  it("écrit un tableau vide + version quand aucun levier n'est prédit (distinct de NULL)", async () => {
+    limit.mockResolvedValueOnce([{ id: "p1", nom: "Projet neutre", description: "" }]);
+    analyzeLeviers.mockResolvedValueOnce(analysis());
+    validateAndCorrect.mockReturnValueOnce([]);
+
+    await service.process(makeJob("p1"));
+
+    expect(setMock).toHaveBeenCalledWith({ llmLeviers: [], llmLeviersVersion: LEVIERS_PREDICTION_VERSION });
+  });
+
+  it("ne fait rien quand le projet est introuvable", async () => {
+    limit.mockResolvedValueOnce([]);
+
+    await service.process(makeJob("absent"));
+
+    expect(analyzeLeviers).not.toHaveBeenCalled();
+    expect(setMock).not.toHaveBeenCalled();
+  });
+
+  it("remonte une erreur (InternalServerError) quand l'analyse LLM échoue", async () => {
+    limit.mockResolvedValueOnce([{ id: "p1", nom: "Rénovation école", description: "isolation" }]);
+    analyzeLeviers.mockResolvedValueOnce({ ...analysis(), errorMessage: "timeout LLM" });
+
+    await expect(service.process(makeJob("p1"))).rejects.toBeInstanceOf(InternalServerErrorException);
+    expect(setMock).not.toHaveBeenCalled();
+  });
+});

--- a/api/src/projet-qualification/projet-qualification.leviers-mec.spec.ts
+++ b/api/src/projet-qualification/projet-qualification.leviers-mec.spec.ts
@@ -1,7 +1,7 @@
 import { InternalServerErrorException } from "@nestjs/common";
 import { Job } from "bullmq";
 import { ProjetQualificationService } from "./projet-qualification.service";
-import { PROJECT_QUALIFICATION_LEVIERS_JOB } from "./const";
+import { PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB } from "./const";
 import { LEVIERS_PREDICTION_VERSION } from "@/shared/const/leviers";
 import { AnthropicService } from "@/projet-qualification/llm/anthropic.service";
 import { LeviersValidationService } from "@/projet-qualification/llm/validation/leviers-validation.service";
@@ -21,7 +21,7 @@ describe("ProjetQualificationService — prédiction leviers data_mec", () => {
   let database: DatabaseService["database"];
 
   const makeJob = (projetId: string): Job<{ projetId: string; schema: string }> =>
-    ({ name: PROJECT_QUALIFICATION_LEVIERS_JOB, data: { projetId, schema: "data_mec" } }) as Job<{
+    ({ name: PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB, data: { projetId, schema: "data_mec" } }) as Job<{
       projetId: string;
       schema: string;
     }>;

--- a/api/src/projet-qualification/projet-qualification.service.ts
+++ b/api/src/projet-qualification/projet-qualification.service.ts
@@ -24,6 +24,7 @@ import * as Sentry from "@sentry/node";
 import { AnthropicService } from "@/projet-qualification/llm/anthropic.service";
 import { LeviersValidationService } from "@/projet-qualification/llm/validation/leviers-validation.service";
 import { CompetencesValidationService } from "@/projet-qualification/llm/validation/competences-validation.service";
+import { LEVIERS_PREDICTION_VERSION } from "@/shared/const/leviers";
 
 @Processor("project-qualification")
 export class ProjetQualificationService extends WorkerHost {
@@ -60,6 +61,12 @@ export class ProjetQualificationService extends WorkerHost {
       // Handle data_mec classification directly (bypass public.projets read/write)
       if (schema === "data_mec" && job.name === PROJECT_QUALIFICATION_CLASSIFICATION_JOB) {
         await this.classifyMecProjet(projetId);
+        return;
+      }
+
+      // Handle data_mec leviers prediction directly (writes data_mec.llm_leviers, never public.projets)
+      if (schema === "data_mec" && job.name === PROJECT_QUALIFICATION_LEVIERS_JOB) {
+        await this.predictMecProjetLeviers(projetId);
         return;
       }
 
@@ -226,6 +233,55 @@ export class ProjetQualificationService extends WorkerHost {
       .where(eq(mecProjetsOperationnels.id, projetId));
 
     this.logger.log(`Successfully classified MEC projet ${projetId}`);
+  }
+
+  /**
+   * Prédit les leviers d'un projet MEC et les écrit dans data_mec.llm_leviers (jsonb
+   * [{ label, score }], scores [0,1]) + data_mec.llm_leviers_version. Modèle exact de
+   * classifyMecProjet : lit/écrit data_mec directement, ne touche NI public.projets NI
+   * leviers_sgpe (déclaratif MEC). Réutilise l'analyse LLM + LeviersValidationService.
+   */
+  private async predictMecProjetLeviers(projetId: string): Promise<void> {
+    const [projet] = await this.dbService.database
+      .select({
+        id: mecProjetsOperationnels.id,
+        nom: mecProjetsOperationnels.nom,
+        description: mecProjetsOperationnels.description,
+      })
+      .from(mecProjetsOperationnels)
+      .where(eq(mecProjetsOperationnels.id, projetId))
+      .limit(1);
+
+    if (!projet || (!projet.nom && !projet.description)) {
+      this.logger.log(`MEC projet ${projetId} not found or empty, skipping leviers prediction`);
+      return;
+    }
+
+    const context = `${projet.nom}\n${projet.description ?? ""}`;
+    this.logger.log(`Predicting leviers for MEC projet ${projetId}: ${projet.nom.slice(0, 60)}`);
+
+    const analysisResult = await this.anthropicService.analyzeLeviers(context);
+    if (analysisResult.errorMessage) {
+      throw new Error(
+        `Error while predicting leviers for MEC projet ${projetId} - error: ${analysisResult.errorMessage}`,
+      );
+    }
+
+    // Threshold 0 : on stocke toute la distribution prédite (validée contre le référentiel
+    // canonique), le consommateur filtre selon ses propres seuils (cf. INTEGRATION_MEC.md).
+    const validatedLeviers = this.leviersValidationService.validateAndCorrect(analysisResult.json, 0);
+    const llmLeviers = validatedLeviers.map((levier) => ({ label: levier.nom, score: levier.score }));
+
+    // Écriture systématique (même quand vide) avec la version : "prédit, rien de pertinent"
+    // se distingue ainsi de "pas encore prédit" (colonne NULL).
+    await this.dbService.database
+      .update(mecProjetsOperationnels)
+      .set({ llmLeviers, llmLeviersVersion: LEVIERS_PREDICTION_VERSION })
+      .where(eq(mecProjetsOperationnels.id, projetId));
+
+    this.logger.log(
+      `Successfully predicted ${llmLeviers.length} leviers for MEC projet ${projetId} (version ${LEVIERS_PREDICTION_VERSION})`,
+    );
   }
 
   private async classifyFicheAction(ficheActionId: string): Promise<void> {

--- a/api/src/projet-qualification/projet-qualification.service.ts
+++ b/api/src/projet-qualification/projet-qualification.service.ts
@@ -9,6 +9,7 @@ import {
   PROJECT_QUALIFICATION_COMPETENCES_JOB,
   PROJECT_QUALIFICATION_LEVIERS_JOB,
   PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
+  PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB,
 } from "@/projet-qualification/const";
 import { ClassificationService } from "@/projet-qualification/classification/classification.service";
 import { DatabaseService } from "@database/database.service";
@@ -64,8 +65,10 @@ export class ProjetQualificationService extends WorkerHost {
         return;
       }
 
-      // Handle data_mec leviers prediction directly (writes data_mec.llm_leviers, never public.projets)
-      if (schema === "data_mec" && job.name === PROJECT_QUALIFICATION_LEVIERS_JOB) {
+      // Handle data_mec leviers prediction directly (writes data_mec.llm_leviers, never public.projets).
+      // Distinct job name (pas LEVIERS_JOB + schema) : robuste au rolling deploy — un ancien
+      // container ne peut pas router ce job vers le chemin legacy public.projets.
+      if (job.name === PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB) {
         await this.predictMecProjetLeviers(projetId);
         return;
       }

--- a/api/src/projet-qualification/projet-qualification.service.ts
+++ b/api/src/projet-qualification/projet-qualification.service.ts
@@ -267,8 +267,10 @@ export class ProjetQualificationService extends WorkerHost {
       );
     }
 
-    // Threshold 0 : on stocke toute la distribution prédite (validée contre le référentiel
-    // canonique), le consommateur filtre selon ses propres seuils (cf. INTEGRATION_MEC.md).
+    // Seuil 0 (et NON LEVIER_SCORE_TRESHOLD=0,7 du flux legacy) : on stocke TOUS les leviers
+    // valides avec leur score BRUT ∈ [0,1] — alignement de contrat avec le batch de stock. Aucun
+    // pré-filtrage : le consommateur applique son propre seuil (référence legacy = 0,7 ;
+    // cf. INTEGRATION_MEC.md). validateAndCorrect ne fait que corriger/valider contre le référentiel.
     const validatedLeviers = this.leviersValidationService.validateAndCorrect(analysisResult.json, 0);
     const llmLeviers = validatedLeviers.map((levier) => ({ label: levier.nom, score: levier.score }));
 

--- a/api/src/shared/const/leviers.ts
+++ b/api/src/shared/const/leviers.ts
@@ -72,3 +72,9 @@ export const leviers = [
   "Intégration de l’élévation du niveau des mers dans l’aménagement du littoral",
   "Préservation des sites culturels et patrimoniaux",
 ] as const;
+
+// Version des prédictions LLM de leviers, écrite dans data_mec.llm_leviers_version à
+// chaque prédiction. Partagée entre le worker (temps réel) et le batch de stock (pipeline)
+// pour que le re-run « prompt v2 » de la rentrée soit un remplacement propre, pas un mélange
+// de générations. À incrémenter quand le prompt ou le modèle de leviers change.
+export const LEVIERS_PREDICTION_VERSION = "v1";

--- a/api/src/territoires/dto/qualification.dto.ts
+++ b/api/src/territoires/dto/qualification.dto.ts
@@ -17,6 +17,28 @@ export class QualificationResponse {
   })
   llmThematiques!: unknown;
 
+  @ApiPropertyOptional({
+    type: Object,
+    nullable: true,
+    description: "Sites LLM (jsonb tel quel : [{ label, score }] — taxonomie des sites, 60 labels).",
+  })
+  llmSites!: unknown;
+
+  @ApiPropertyOptional({
+    type: Object,
+    nullable: true,
+    description: "Interventions LLM (jsonb tel quel : [{ label, score }] — taxonomie des interventions, 15 labels).",
+  })
+  llmInterventions!: unknown;
+
+  @ApiPropertyOptional({
+    type: Object,
+    nullable: true,
+    description:
+      "Leviers prédits par nos modèles (jsonb : [{ label, score }], scores 0–1). Distinct de leviersSgpe (déclaratif MEC) : filtrez selon vos seuils. null tant que la prédiction n'a pas été livrée.",
+  })
+  llmLeviers!: unknown;
+
   @ApiPropertyOptional({ type: Number, nullable: true, description: "Probabilité de transition écologique (0–1)." })
   llmProbabiliteTe!: number | null;
 

--- a/api/src/territoires/dto/qualification.dto.ts
+++ b/api/src/territoires/dto/qualification.dto.ts
@@ -20,7 +20,8 @@ export class QualificationResponse {
   @ApiPropertyOptional({
     type: Object,
     nullable: true,
-    description: "Sites LLM (jsonb tel quel : [{ label, score }] — taxonomie des sites, 60 labels).",
+    description:
+      "Sites LLM (jsonb tel quel — taxonomie des sites, 60 labels). Éléments : { label, score }, avec une clé additionnelle possible `nom_propre` (nom propre du site). Ne parsez pas en mode strict.",
   })
   llmSites!: unknown;
 

--- a/api/src/territoires/territoires.service.spec.ts
+++ b/api/src/territoires/territoires.service.spec.ts
@@ -229,13 +229,16 @@ describe("TerritoiresService", () => {
       await expect(service.qualification("mec-orphan")).rejects.toBeInstanceOf(NotFoundException);
     });
 
-    it("découpe les leviers, normalise proba et date pour un external_id connu", async () => {
+    it("découpe les leviers, normalise proba et date, expose sites/interventions/leviers LLM", async () => {
       selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
       execute.mockResolvedValueOnce({
         rows: [
           {
             leviersSgpe: "Vélo,Covoiturage",
             llmThematiques: [{ label: "Mobilité", score: 0.9 }],
+            llmSites: [{ label: "Voirie", score: 0.8 }],
+            llmInterventions: [{ label: "Aménagement", score: 0.7 }],
+            llmLeviers: [{ label: "Vélo", score: 0.95 }],
             llmProbabiliteTe: 0.87,
             llmClassifiedAt: new Date("2026-07-01T08:00:00.000Z"),
           },
@@ -249,8 +252,41 @@ describe("TerritoiresService", () => {
         projetId: "proj-uuid",
         leviersSgpe: ["Vélo", "Covoiturage"],
         llmThematiques: [{ label: "Mobilité", score: 0.9 }],
+        llmSites: [{ label: "Voirie", score: 0.8 }],
+        llmInterventions: [{ label: "Aménagement", score: 0.7 }],
+        llmLeviers: [{ label: "Vélo", score: 0.95 }],
         llmProbabiliteTe: 0.87,
         llmClassifiedAt: "2026-07-01T08:00:00.000Z",
+      });
+    });
+
+    it("renvoie llmLeviers null quand la colonne pipeline est absente (to_jsonb → null)", async () => {
+      selectLimit.mockResolvedValueOnce([{ objetId: "proj-uuid" }]);
+      // La colonne llm_leviers n'existe pas encore dans schema_commun_v2 : to_jsonb(p) ->
+      // 'llm_leviers' renvoie NULL, jamais de 500.
+      execute.mockResolvedValueOnce({
+        rows: [
+          {
+            leviersSgpe: null,
+            llmThematiques: null,
+            llmSites: null,
+            llmInterventions: null,
+            llmLeviers: null,
+            llmProbabiliteTe: null,
+            llmClassifiedAt: null,
+          },
+        ],
+      });
+
+      const result = await service.qualification("mec-123");
+
+      expect(result).toMatchObject({
+        externalId: "mec-123",
+        projetId: "proj-uuid",
+        leviersSgpe: [],
+        llmLeviers: null,
+        llmProbabiliteTe: null,
+        llmClassifiedAt: null,
       });
     });
   });

--- a/api/src/territoires/territoires.service.ts
+++ b/api/src/territoires/territoires.service.ts
@@ -636,8 +636,9 @@ export class TerritoiresService {
   }
 
   /**
-   * Qualification LLM d'un projet MEC (résolu via son external_id) :
-   * leviers SGPE, thématiques LLM, probabilité TE et date de classification.
+   * Qualification LLM d'un projet MEC (résolu via son external_id) : leviers SGPE
+   * (déclaratif), leviers/sites/interventions/thématiques prédits par nos modèles,
+   * probabilité TE et date de classification.
    */
   async qualification(externalId: string): Promise<QualificationResponse> {
     const projetId = await this.resolveMecProjetId(externalId);
@@ -645,16 +646,26 @@ export class TerritoiresService {
     const [row] = await this.query<{
       leviersSgpe: string | null;
       llmThematiques: unknown;
+      llmSites: unknown;
+      llmInterventions: unknown;
+      llmLeviers: unknown;
       llmProbabiliteTe: number | string | null;
       llmClassifiedAt: Date | string | null;
     }>(sql`
       SELECT
-        "leviersSgpe" AS "leviersSgpe",
-        llm_thematiques AS "llmThematiques",
-        llm_probabilite_te AS "llmProbabiliteTe",
-        llm_classified_at AS "llmClassifiedAt"
-      FROM schema_commun_v2.projets_operationnels
-      WHERE id = ${projetId}
+        p."leviersSgpe" AS "leviersSgpe",
+        p.llm_thematiques AS "llmThematiques",
+        p.llm_sites AS "llmSites",
+        p.llm_interventions AS "llmInterventions",
+        -- llm_leviers est créée dans schema_commun_v2 côté pipeline (ETL), potentiellement
+        -- APRÈS ce déploiement API. to_jsonb(p) -> 'llm_leviers' renvoie NULL si la colonne
+        -- est absente (aucune erreur), la valeur jsonb sinon : lecture défensive sans requête
+        -- d'existence de colonne — jamais de 500, champ null tant que le pipeline n'a pas livré.
+        to_jsonb(p) -> 'llm_leviers' AS "llmLeviers",
+        p.llm_probabilite_te AS "llmProbabiliteTe",
+        p.llm_classified_at AS "llmClassifiedAt"
+      FROM schema_commun_v2.projets_operationnels p
+      WHERE p.id = ${projetId}
       LIMIT 1
     `);
 
@@ -669,6 +680,9 @@ export class TerritoiresService {
       projetId,
       leviersSgpe: splitLeviersCsv(row.leviersSgpe ?? null),
       llmThematiques: row.llmThematiques ?? null,
+      llmSites: row.llmSites ?? null,
+      llmInterventions: row.llmInterventions ?? null,
+      llmLeviers: row.llmLeviers ?? null,
       llmProbabiliteTe: row.llmProbabiliteTe != null ? Number(row.llmProbabiliteTe) : null,
       llmClassifiedAt: this.toIso(row.llmClassifiedAt ?? null),
     };

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -173,8 +173,10 @@ curl -H "$AUTH" "$BASE/projets/mec/48345/qualification"
 - **`leviersSgpe`** : leviers **transmis par MEC** (déclaratif). Historique : cette colonne peut
   contenir d'anciennes prédictions LLM fusionnées au déclaratif en avril 2026 ; nous n'y écrivons
   jamais nos prédictions.
-- **`llmLeviers`** : leviers **prédits par nos modèles**, avec un `score` (0–1). **Filtrez selon vos
-  seuils.** `null` tant que la prédiction n'a pas été livrée par le pipeline (déploiement ordonné).
+- **`llmLeviers`** : leviers **prédits par nos modèles**, avec un `score` **brut** (0–1). Tous les
+  leviers valides sont exposés **sans pré-filtrage** — c'est à vous de couper : **filtrez selon vos
+  seuils.** Le seuil de référence (équivalent du flux historique) est `score > 0,7`. `null` tant que
+  la prédiction n'a pas été livrée par le pipeline (déploiement ordonné).
   ⚠ **Limite v1 (connue) :** biais sur les projets à dominante **adaptation** — un même projet peut
   relever de leviers différents selon l'axe réduction/adaptation retenu ; un raffinement du prompt
   est prévu (le champ portera alors une nouvelle version, remplacement propre côté pipeline).

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -157,10 +157,30 @@ curl -H "$AUTH" "$BASE/projets/mec/48345/qualification"
     { "label": "Audit ou travaux de rénovation énergétique tertiaire", "score": 0.97 },
     { "label": "Sobriété énergétique", "score": 0.72 },
   ],
+  "llmSites": [{ "label": "Bâtiment tertiaire", "score": 0.94 }],
+  "llmInterventions": [{ "label": "Rénovation / réhabilitation", "score": 0.9 }],
+  "llmLeviers": [
+    { "label": "Rénovation (hors changement chaudières)", "score": 0.88 },
+    { "label": "Sobriété des bâtiments (tertiaire)", "score": 0.74 },
+  ],
   "llmProbabiliteTe": 0.82,
   "llmClassifiedAt": "2026-05-06T13:00:06Z",
 }
 ```
+
+**Provenance des champs** — deux familles à ne pas confondre :
+
+- **`leviersSgpe`** : leviers **transmis par MEC** (déclaratif). Historique : cette colonne peut
+  contenir d'anciennes prédictions LLM fusionnées au déclaratif en avril 2026 ; nous n'y écrivons
+  jamais nos prédictions.
+- **`llmLeviers`** : leviers **prédits par nos modèles**, avec un `score` (0–1). **Filtrez selon vos
+  seuils.** `null` tant que la prédiction n'a pas été livrée par le pipeline (déploiement ordonné).
+  ⚠ **Limite v1 (connue) :** biais sur les projets à dominante **adaptation** — un même projet peut
+  relever de leviers différents selon l'axe réduction/adaptation retenu ; un raffinement du prompt
+  est prévu (le champ portera alors une nouvelle version, remplacement propre côté pipeline).
+- **`llmThematiques` / `llmSites` / `llmInterventions`** : classifications prédites `[{ label, score }]`.
+  `llmSites` suit la taxonomie des **sites** (60 labels), `llmInterventions` celle des **interventions**
+  (15 labels).
 
 `404` si l'`externalId` est inconnu (projet non encore synchronisé via le webhook).
 

--- a/docs/api/INTEGRATION_MEC.md
+++ b/docs/api/INTEGRATION_MEC.md
@@ -182,7 +182,8 @@ curl -H "$AUTH" "$BASE/projets/mec/48345/qualification"
   est prévu (le champ portera alors une nouvelle version, remplacement propre côté pipeline).
 - **`llmThematiques` / `llmSites` / `llmInterventions`** : classifications prédites `[{ label, score }]`.
   `llmSites` suit la taxonomie des **sites** (60 labels), `llmInterventions` celle des **interventions**
-  (15 labels).
+  (15 labels). ⚠ Les éléments de `llmSites` peuvent porter une clé **additionnelle** `nom_propre` (nom
+  propre du site) : ne parsez pas ces objets en mode strict (n'échouez pas sur des clés en plus).
 
 `404` si l'`externalId` est inconnu (projet non encore synchronisé via le webhook).
 

--- a/docs/api/openapi-territoires-decisions.yaml
+++ b/docs/api/openapi-territoires-decisions.yaml
@@ -180,6 +180,36 @@ paths:
                       properties:
                         label: { type: string }
                         score: { type: number }
+                  llmSites:
+                    type: array
+                    nullable: true
+                    description: Taxonomie des sites (60 labels)
+                    items:
+                      type: object
+                      properties:
+                        label: { type: string }
+                        score: { type: number }
+                  llmInterventions:
+                    type: array
+                    nullable: true
+                    description: Taxonomie des interventions (15 labels)
+                    items:
+                      type: object
+                      properties:
+                        label: { type: string }
+                        score: { type: number }
+                  llmLeviers:
+                    type: array
+                    nullable: true
+                    description: >-
+                      Leviers prédits par nos modèles (scores 0–1). Distinct de leviersSgpe
+                      (déclaratif MEC) : filtrez selon vos seuils. null tant que la prédiction
+                      n'a pas été livrée par le pipeline.
+                    items:
+                      type: object
+                      properties:
+                        label: { type: string }
+                        score: { type: number }
                   llmProbabiliteTe: { type: number, nullable: true }
                   llmClassifiedAt: { type: string, format: date-time, nullable: true }
           description: Qualification

--- a/docs/api/openapi-territoires-decisions.yaml
+++ b/docs/api/openapi-territoires-decisions.yaml
@@ -183,12 +183,15 @@ paths:
                   llmSites:
                     type: array
                     nullable: true
-                    description: Taxonomie des sites (60 labels)
+                    description: >-
+                      Taxonomie des sites (60 labels). Les éléments peuvent porter une clé
+                      additionnelle `nom_propre` (nom propre du site) — ne pas parser en mode strict.
                     items:
                       type: object
                       properties:
                         label: { type: string }
                         score: { type: number }
+                        nom_propre: { type: string, nullable: true }
                   llmInterventions:
                     type: array
                     nullable: true


### PR DESCRIPTION
## Contexte

Chantier leviers côté API (GO Thomas, contrat validé). On ajoute une **prédiction LLM des leviers dédiée à l'ingestion `/mec/v1`**, écrite dans `data_mec`, et on l'expose (avec les classifications sites/interventions déjà calculées) sur le `GET qualification`.

Le job leviers legacy (`PROJECT_QUALIFICATION_LEVIERS_JOB`) n'existait que sur le chemin `public.projets`. L'ingest `/mec/v1` n'enquêtait que la classification. Écrire naïvement via `UpdateProjetsService` aurait été un no-op silencieux (ça écrit `public.projets`). Ce chemin est donc **totalement disjoint** : lecture/écriture directes de `data_mec`, jamais `public.projets`, jamais `leviers_sgpe`.

## Ce que fait cette PR

### 1. Stockage (`data_mec.projets_operationnels`)
- **Migration manuscrite `0042`** (pattern 0040/0041 : SQL + entrée `_journal.json`, `drizzle-kit generate` étant cassé) : deux colonnes en `ADD COLUMN IF NOT EXISTS` :
  - `llm_leviers jsonb` — `[{ label, score }]`, scores `[0,1]`, prédiction validée contre le référentiel canonique.
  - `llm_leviers_version text` — version du modèle/prompt.
  - `IF NOT EXISTS` **obligatoire** : le script batch de stock (pipeline) peut créer ces colonnes avant le déploiement — définitions coordonnées, identiques.
- Colonnes ajoutées au schéma Drizzle `mec-schema.ts`.

### 2. Versionnage
- `LEVIERS_PREDICTION_VERSION = "v1"` (export partagé, `shared/const/leviers.ts`), écrite dans `llm_leviers_version` à chaque prédiction. But : le re-run « prompt v2 » de la rentrée (biais adaptation) sera un **remplacement propre**, pas un empilement de générations.

### 3. Worker (`projet-qualification.service.ts`)
- Nouveau chemin dans `process()` pour `LEVIERS_JOB` + `schema:'data_mec'` → `predictMecProjetLeviers`, **modèle exact de `classifyMecProjet`** : réutilise `AnthropicService.analyzeLeviers` + `LeviersValidationService`, écrit `data_mec.llm_leviers` + `llm_leviers_version`.
- **Seuil 0** : on stocke toute la distribution validée, le consommateur filtre selon ses seuils.
- Écriture systématique (même vide) : « prédit, rien de pertinent » se distingue de « pas encore prédit » (`NULL`).

### 4. Enqueue sur `/mec/v1` (`mec.service.ts`)
- À côté de chaque `scheduleClassification` : création **et** update à contenu changé. Même politique bulk (l'enqueue vit dans `createOrUpdate`).
- Les leviers sont **prédits même si `leviers_sgpe` est fourni** (déclaratif MEC ≠ prédiction, provenances distinctes, les deux familles coexistent).

### 5. `GET /projets/mec/{externalId}/qualification` enrichi (lecture `schema_commun_v2`)
- `llmSites`, `llmInterventions` : colonnes v2 existantes, même passthrough jsonb que `llmThematiques`.
- `llmLeviers` : **lecture défensive** `to_jsonb(p) -> 'llm_leviers'`. La colonne est créée dans `schema_commun_v2` côté pipeline, potentiellement **après** ce déploiement : `to_jsonb` renvoie `NULL` si la colonne est absente (jamais de 500), **sans requête d'existence de colonne ni déploiement ordonné** — c'est l'option la plus simple, retenue ici.
- `llm_leviers_version` **n'est pas exposée** (provenance interne).
- `QualificationResponse` (DTO) + `openapi-territoires-decisions.yaml` à jour.

### 6. Doc `INTEGRATION_MEC.md`
- Provenance explicite : `leviersSgpe` = transmis par MEC (peut contenir d'anciennes prédictions fusionnées en avril 2026) ; `llmLeviers` = prédit par nos modèles avec score, « filtrez selon vos seuils ».
- **Limite v1 écrite d'avance** : biais connu sur les projets à dominante **adaptation** (leviers différents selon l'axe réduction/adaptation), raffinement prévu.
- `llmSites`/`llmInterventions` documentés (taxonomies 60/15).

### 7. Tests
- `mec.service.spec.ts` (enqueue) et `projet-qualification.leviers-mec.spec.ts` (handler) : **tests unitaires purs** (DB/queue mockées), exécutables sans Docker.
- `territoires.service.spec.ts` : forme enrichie + cas colonne pipeline absente (`llmLeviers` null).

## Coordination pipeline (batch de stock)
- La colonne `data_mec.llm_leviers` peut être créée par le batch **avant** le déploiement API → `IF NOT EXISTS` côté migration, définitions identiques.
- La colonne `schema_commun_v2.llm_leviers` est produite par l'ETL **indépendamment** → lecture défensive côté API (champ `null` tant que non livrée).
- `LEVIERS_PREDICTION_VERSION` doit rester alignée entre worker et batch.

## Validation
- `cd api && pnpm type-check && pnpm lint && pnpm format:check` : OK.
- Tests unitaires purs (39) : OK. Les specs testcontainer nécessitent Docker (non exécutées ici).

⚠️ **Ne pas merger** — revue Thomas.

---

## Suite à la revue adversariale (correctifs appliqués)

- **[majeur] Retry + purge** : `scheduleLeviersPrediction` et `scheduleClassification` enfilaient sans options (attempts=1) → un échec LLM transitoire laissait `llm_leviers` NULL à vie. Aligné sur les autres producteurs : `{ attempts: 3, backoff exponentiel 5s }` + `removeOnComplete` / `removeOnFail: {count: 1000}` (un resync bulk laissait ~160k jobs completed dans Redis).
- **[majeur] PATCH stale** : `update()` écrivait nom/description sans recalculer le content hash ni ré-enclencher la qualification → le GET servait des leviers prédits sur l'ancien texte. Corrigé (recompute hash + ré-enqueue si le texte change, même logique que `createOrUpdate`).
- **[mineur] Fenêtre rolling deploy** : nom de job **distinct** pour le chemin data_mec (`PROJECT_QUALIFICATION_LEVIERS_DATA_MEC_JOB`) → un ancien container ne peut plus router ce job vers le fallthrough legacy `public.projets` (il throw → rejoué après bascule).
- **[mineur] Doc `llmSites`** : les éléments peuvent porter une clé `nom_propre` en plus de `{label, score}` — documenté dans le DTO, l'openapi et INTEGRATION_MEC.md (ne pas parser en mode strict).

## Limites connues

- **Backlog FIFO sur resync massif** : `createBulk` enfile inconditionnellement, et le worker tourne en concurrence 1 (FIFO). Un gros resync = potentiellement des jours de backlog, et une **double prédiction** vs le batch de stock. On ne complexifie pas maintenant (pas de flags/priorités).
- **Options si le backlog devient un problème** : augmenter la concurrence du worker (⚠ attention au rate limit Anthropic — **aucun limiter BullMQ** en place aujourd'hui), **ou** neutraliser l'enqueue côté bulk et passer par le batch de stock pour les gros volumes.
