### PR TITLE
fix(services): supprimer le repêchage générique, le score seul décide

### DIFF
--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -27,12 +27,6 @@ import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/ad
  * Ce module est ADDITIF et ISOLÉ : rien ne l'importe, il ne modifie rien. Le supprimer, c'est
  * `rm -rf src/admin` plus UNE ligne dans app.module.ts.
  */
-/** Distingue les trois raisons possibles — les confondre fausserait la lecture du catalogue. */
-function motifDe(pertinent: boolean, generique: boolean): "pertinence" | "generique" | "ecarte" {
-  if (pertinent) return "pertinence";
-  return generique ? "generique" : "ecarte";
-}
-
 @Injectable()
 export class AdminService {
   constructor(
@@ -164,25 +158,18 @@ export class AdminService {
         const brut = match?.normalizedScore ?? 0;
         const facteur = facteurPhase(s.phases as PoidsParPhase, phase);
         const score = brut * facteur;
-        const pertinent = score >= SEUIL_PERTINENCE;
-        const generique = !pertinent && s.presentationGenerique === "oui";
-
         return {
           slug: s.slug,
           nom: s.nom,
           scoreBrut: brut,
           facteurPhase: facteur,
           score,
-          retenu: pertinent || generique,
-          // Distinguer « pertinent » de « remonté en fallback » : ce sont deux raisons très
-          // différentes d'être affiché, et les confondre fausse toute lecture du catalogue.
-          motif: motifDe(pertinent, generique),
+          // Le score seul décide : il n'y a plus de repêchage générique. Le back-office doit
+          // montrer EXACTEMENT ce que fait l'API, sans quoi il ment sur ce que verra la
+          // collectivité.
+          retenu: score >= SEUIL_PERTINENCE,
           etiquettesCommunes: match?.labelsCommuns ?? { thematiques: [], sites: [], interventions: [] },
           profilGeneraliste: s.profilGeneraliste,
-          // Le drapeau qui décide du repêchage. Sans lui, le back-office ne peut pas rejouer la
-          // sélection à un autre seuil : il saurait qu'un service passe sous la barre, mais pas
-          // s'il retombe en « generique » ou disparaît.
-          presentationGenerique: s.presentationGenerique,
           categories: s.categories,
         };
       })

--- a/api/src/admin/dto/admin.dto.ts
+++ b/api/src/admin/dto/admin.dto.ts
@@ -101,23 +101,8 @@ export class ServiceSimuleResponse {
   @ApiProperty({ description: "Facteur de phase appliqué (0.5 à 1)." }) facteurPhase!: number;
   @ApiProperty({ description: "Score final = scoreBrut × facteurPhase." }) score!: number;
   @ApiProperty() retenu!: boolean;
-  @ApiProperty({
-    enum: ["pertinence", "generique", "ecarte"],
-    description:
-      "POURQUOI il est retenu (ou non). « pertinence » et « generique » sont deux raisons très " +
-      "différentes d'être affiché — les confondre fausse toute lecture du catalogue.",
-  })
-  motif!: "pertinence" | "generique" | "ecarte";
   @ApiProperty({ type: Object }) etiquettesCommunes!: AideLabelsCommuns;
   @ApiPropertyOptional({ nullable: true }) profilGeneraliste!: string | null;
-  @ApiPropertyOptional({
-    nullable: true,
-    description:
-      "Le drapeau qui décide du repêchage en fallback. Exposé pour que le back-office puisse " +
-      "recalculer le motif à un AUTRE seuil que celui en vigueur — sans lui, déplacer le curseur " +
-      "au-dessus du score d'un service ne dirait pas s'il retombe en « generique » ou en « ecarte ».",
-  })
-  presentationGenerique!: string | null;
   @ApiProperty({ type: [String] }) categories!: string[];
 }
 

--- a/api/src/services-numeriques/service-numerique-contract.ts
+++ b/api/src/services-numeriques/service-numerique-contract.ts
@@ -60,9 +60,12 @@ export function facteurPhase(phases: PoidsParPhase, phaseProjet: ProjetPhase | n
  * Score normalisé minimal pour qu'un service soit jugé PERTINENT. Même échelle que le
  * `cutoff` des aides et le seuil des questionnaires.
  *
- * En dessous, un service curé n'est pas écarté pour autant : s'il porte
- * `presentationGenerique = oui`, il remonte en fallback, classé après les services
- * réellement pertinents (§8.3). C'est indispensable ici : 7 des 28 services curés du
- * benchmark n'ont AUCUNE thématique fine renseignée et scoreraient zéro à jamais.
+ * En dessous, le service n'est pas affiché. Point. Il n'y a pas de repêchage : sur trois projets
+ * réels de staging, ce seuil sépare proprement (0,64 pour Bénéfriches sur une friche ; 0,03 pour
+ * EnvErgo sur un espace commercial).
+ *
+ * Les services du benchmark sans thématique fine scoreront donc zéro à jamais et resteront
+ * invisibles. C'est un défaut de DONNÉES, à corriger dans le benchmark — pas à masquer par une
+ * règle d'affichage qui noierait les services réellement pertinents.
  */
 export const SEUIL_PERTINENCE = 0.3;

--- a/api/src/services-numeriques/services-numeriques.service.ts
+++ b/api/src/services-numeriques/services-numeriques.service.ts
@@ -53,39 +53,42 @@ export class ServicesNumeriquesService {
   /**
    * Services numériques pertinents pour un projet, prêts à afficher.
    *
+   * LE SCORE SEUL DÉCIDE. Aucun repêchage, aucun verrou de curation — exactement comme pour les
+   * aides et les questionnaires.
+   *
+   * POURQUOI AUCUN REPÊCHAGE GÉNÉRIQUE. Le benchmark marque certains services « à présenter dans
+   * une présentation générique et peu contextualisée » : c'est une propriété utile pour une page
+   * VITRINE (un annuaire, une liste d'accueil), où il n'y a pas de contexte. Une fiche projet est
+   * l'exact opposé — elle est le contexte. Les faire remonter ici noyait 4 services parfaitement
+   * ciblés sous 50 qui n'avaient rien à voir avec le projet.
+   *
+   * Une liste vide est une réponse LÉGITIME, et plus utile qu'une liste de remplissage : elle dit
+   * « le catalogue n'a rien pour ce projet », ce qui est une information. Un projet de salle des
+   * fêtes n'a aucun service numérique dédié, et c'est un fait, pas une panne.
+   *
    * `findOneWithSource` : le projet peut vivre dans public.projets, data_mec ou data_tet.
    * Aucun service → 200 avec une liste vide, jamais 404.
    */
   async findForProjet(projetId: string, baseUrl: string): Promise<ProjetServicesResponse> {
     const { projet } = await this.getProjetsService.findOneWithSource(projetId);
 
-    // Aucun verrou de curation : c'est le SCORE seul qui décide, comme pour les aides et les
-    // questionnaires. Les 51 lignes non renseignées du benchmark (ni thématique, ni catégorie)
-    // s'éliminent d'elles-mêmes — leur score est nul et elles ne sont pas génériques.
     const catalogue = await this.dbService.database.select().from(servicesNumeriques);
 
-    const scores = this.scorer(projet, catalogue);
-
-    // 1. PERTINENCE — au-dessus du seuil, trié par score décroissant.
-    const pertinents = scores.filter((s) => s.score >= SEUIL_PERTINENCE).sort((a, b) => b.score - a.score);
-
-    // 2. FALLBACK — les services transverses (« à présenter dans une présentation générique »)
-    //    remontent même sans correspondance fine, APRÈS les pertinents. Sans cela, les services
-    //    dépourvus de thématique fine ne seraient jamais affichés, et un projet non encore
-    //    classifié ne verrait aucun service du tout.
-    const generiques = scores
-      .filter((s) => s.score < SEUIL_PERTINENCE && s.ligne.presentationGenerique === "oui")
+    const pertinents = this.scorer(projet, catalogue)
+      .filter((s) => s.score >= SEUIL_PERTINENCE)
       .sort((a, b) => b.score - a.score || a.ligne.nom.localeCompare(b.ligne.nom));
 
-    return { services: [...pertinents, ...generiques].map(({ ligne }) => this.toResponse(ligne, baseUrl)) };
+    return { services: pertinents.map(({ ligne }) => this.toResponse(ligne, baseUrl)) };
   }
 
   /**
    * Score de pertinence = score de matching sur les trois axes (le MÊME moteur que les aides
    * et les questionnaires), modulé par la phase du projet.
    *
-   * Un projet non classifié (le job LLM n'a pas tourné) donne un score nul à tout le monde :
-   * seuls les services génériques remonteront. C'est voulu.
+   * Un projet non classifié (le job LLM n'a pas tourné) donne un score nul à tout le monde, donc
+   * une liste vide. C'est voulu : on ne sait rien de ce projet, on n'a donc rien à en dire. Le
+   * masquer derrière une liste de services de remplissage ferait passer une donnée manquante
+   * pour un résultat.
    */
   private scorer(projet: ProjetResponse, lignes: LigneCatalogue[]): { ligne: LigneCatalogue; score: number }[] {
     const scoresProjet = projet.classificationScores;

--- a/api/test/admin.e2e-spec.ts
+++ b/api/test/admin.e2e-spec.ts
@@ -142,7 +142,10 @@ describe("Back-office (e2e)", () => {
       expect(questionnaires[0].reponses).toEqual({});
     });
 
-    it("distingue « pertinent » de « remonté en fallback générique »", async () => {
+    it("montre le sort réel des services : le score seul décide, sans repêchage", async () => {
+      // Le back-office doit refléter EXACTEMENT ce que fait l'API. S'il affichait encore un
+      // « repêché » que l'API ne pratique plus, il mentirait sur ce que verra la collectivité —
+      // et ce serait pire que pas d'écran du tout.
       await global.testDbService.database.insert(servicesNumeriques).values([
         {
           slug: "pertinent",
@@ -163,16 +166,17 @@ describe("Back-office (e2e)", () => {
       ]);
       const projetId = await creerProjet(EAU);
 
-      const { body } = await appeler<{ services: { slug: string; motif: string; retenu: boolean }[] }>(
+      const { body } = await appeler<{ services: { slug: string; retenu: boolean; score: number }[] }>(
         "POST",
         "/admin/simuler",
         { projetId },
       );
 
       const parSlug = new Map(body.services.map((s) => [s.slug, s]));
-      expect(parSlug.get("pertinent")!.motif).toBe("pertinence");
-      expect(parSlug.get("transverse")!.motif).toBe("generique");
-      expect(parSlug.get("transverse")!.retenu).toBe(true);
+      expect(parSlug.get("pertinent")!.retenu).toBe(true);
+      // Marqué « présentation générique », et pourtant écarté : ce drapeau ne décide plus de rien.
+      expect(parSlug.get("transverse")!.retenu).toBe(false);
+      expect(parSlug.get("transverse")!.score).toBe(0);
     });
 
     it("dit pourquoi un projet non classifié ne voit rien, au lieu d'une liste vide muette", async () => {

--- a/api/test/services-numeriques.e2e-spec.ts
+++ b/api/test/services-numeriques.e2e-spec.ts
@@ -192,8 +192,12 @@ describe("Services numériques (e2e)", () => {
     });
   });
 
-  describe("Fallback générique", () => {
-    it("remonte les services transverses après les services pertinents", async () => {
+  describe("Aucun repêchage", () => {
+    it("n'affiche PAS un service transverse sans recouvrement, même marqué « présentation générique »", async () => {
+      // Le benchmark marque certains services « à présenter dans une présentation générique et
+      // peu contextualisée » : c'est utile pour une page VITRINE, où il n'y a pas de contexte.
+      // Une fiche projet est l'exact opposé — elle EST le contexte. Les faire remonter ici noyait
+      // 4 services parfaitement ciblés sous 50 sans rapport avec le projet.
       await global.testDbService.database.insert(servicesNumeriques).values([
         service({ slug: "pertinent", nom: "Pertinent", classification: EAU }),
         service({
@@ -205,27 +209,37 @@ describe("Services numériques (e2e)", () => {
       ]);
       const projetId = await creerProjet(EAU);
 
-      expect((await getServices(projetId)).map((s) => s.id)).toEqual(["pertinent", "transverse"]);
+      expect((await getServices(projetId)).map((s) => s.id)).toEqual(["pertinent"]);
     });
 
-    it("n'affiche QUE les services génériques pour un projet non classifié", async () => {
-      // C'est ce qui évite qu'un projet fraîchement créé (job LLM pas encore passé) ne voie
-      // aucun service du tout.
+    it("renvoie une liste VIDE pour un projet non classifié", async () => {
+      // Le job LLM n'a pas tourné : on ne sait rien de ce projet, on n'a donc rien à en dire.
+      // Remplir l'écran ferait passer une donnée manquante pour un résultat.
       await global.testDbService.database
         .insert(servicesNumeriques)
         .values([
-          service({ slug: "cible", nom: "Ciblé", classification: EAU }),
           service({ slug: "transverse", nom: "Transverse", classification: EAU, presentationGenerique: "oui" }),
         ]);
       const projetId = await creerProjet(null);
 
-      expect((await getServices(projetId)).map((s) => s.id)).toEqual(["transverse"]);
+      expect(await getServices(projetId)).toEqual([]);
     });
 
-    it("n'affiche jamais un service curé sans thématique ni fallback générique", async () => {
-      // Cas réel du benchmark : « Boussole de la transition écologique » et « EnvErgo » sont
-      // marqués « À intégrer MEC » mais n'ont ni thématique fine ni présentation générique.
-      // Ce test documente qu'ils sont invisibles — c'est un défaut de DONNÉES, pas de code.
+    it("renvoie une liste VIDE quand le catalogue n'a rien pour ce projet", async () => {
+      // Cas réel : un projet de salle des fêtes. Aucun service numérique du benchmark ne traite
+      // ce type de lieu. Zéro service est la bonne réponse — et une information en soi.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "velo", nom: "Vélo", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      expect(await getServices(projetId)).toEqual([]);
+    });
+
+    it("n'affiche jamais un service sans thématique", async () => {
+      // Cas réel du benchmark : 11 lignes n'ont aucune classification. Elles scorent zéro à
+      // jamais et resteront invisibles. C'est un défaut de DONNÉES, pas de code — et il ne se
+      // rattrape pas par une règle d'affichage.
       await global.testDbService.database.insert(servicesNumeriques).values([
         service({
           slug: "invisible",

--- a/back-office/src/components/Catalogue.tsx
+++ b/back-office/src/components/Catalogue.tsx
@@ -30,15 +30,15 @@ export function Catalogue({ contenu }: { contenu: Contenu }) {
   }, [contenu.services, filtre]);
 
   const sansThematique = contenu.services.filter((s) => s.classification.thematiques.length === 0).length;
-  const generiques = contenu.services.filter((s) => s.presentationGenerique === "oui").length;
 
   return (
     <section className={fr.cx("fr-mt-4w")}>
       <div className={fr.cx("fr-callout", "fr-mb-3w")}>
         <p className={fr.cx("fr-mb-0")}>
-          <strong>{contenu.services.length}</strong> services — <strong>{sansThematique}</strong> sans aucune thématique
-          (donc jamais pertinents pour aucun projet, seulement repêchables) — <strong>{generiques}</strong> repêchables
-          en présentation générique.
+          <strong>{contenu.services.length}</strong> services, dont <strong>{sansThematique}</strong> sans aucune
+          thématique. Ces derniers ne remonteront <strong>jamais</strong>, sur aucun projet : sans thématique, leur
+          score est nul par construction, et il n&apos;y a pas de repêchage. C&apos;est un défaut de données à corriger
+          dans le benchmark — la liste ci-dessous les met en tête.
         </p>
       </div>
 
@@ -57,7 +57,6 @@ export function Catalogue({ contenu }: { contenu: Contenu }) {
               </th>
               <th scope="col">Lieux</th>
               <th scope="col">Modalités</th>
-              <th scope="col">Repêchable</th>
             </tr>
           </thead>
           <tbody>
@@ -87,7 +86,6 @@ export function Catalogue({ contenu }: { contenu: Contenu }) {
                 <td className={fr.cx("fr-text--xs")}>
                   {s.classification.interventions.map((t) => t.label).join(", ") || "—"}
                 </td>
-                <td>{s.presentationGenerique === "oui" ? "oui" : "—"}</td>
               </tr>
             ))}
           </tbody>

--- a/back-office/src/components/Services.tsx
+++ b/back-office/src/components/Services.tsx
@@ -3,13 +3,7 @@ import { fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
 import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 import { Etiquettes } from "./Etiquettes";
-import { motifAuSeuil, type Motif, type ServiceSimule } from "../types";
-
-const LIBELLE_MOTIF: Record<Motif, { texte: string; severite: "success" | "info" | "warning" }> = {
-  pertinence: { texte: "pertinent", severite: "success" },
-  generique: { texte: "repêché", severite: "info" },
-  ecarte: { texte: "écarté", severite: "warning" },
-};
+import { retenuAuSeuil, type ServiceSimule } from "../types";
 
 const pourcent = (n: number) => `${(n * 100).toFixed(0)} %`;
 
@@ -19,26 +13,25 @@ const pourcent = (n: number) => `${(n * 100).toFixed(0)} %`;
  * POURQUOI UN CURSEUR. L'API renvoie TOUS les candidats avec leur score, pas seulement les
  * retenus : rejouer la sélection à un autre seuil est donc de l'arithmétique locale, sans rappel
  * réseau. On voit l'effet d'un réglage avant de le figer dans le code — c'est la seule façon
- * honnête de choisir un seuil, plutôt que de le deviner puis de constater en production.
+ * honnête de choisir un seuil, plutôt que de le deviner puis de le constater en production.
+ *
+ * Le score seul décide : il n'y a pas de repêchage. Une liste vide est une réponse légitime.
  */
 export function Services({ services, seuilApi }: { services: ServiceSimule[]; seuilApi: number }) {
   const [seuil, setSeuil] = useState(seuilApi);
   const [masquerEcartes, setMasquerEcartes] = useState(true);
 
   const { comptes, visibles } = useMemo(() => {
-    const avecMotif = services.map((s) => ({ ...s, motifLocal: motifAuSeuil(s, seuil) }));
-    const compter = (m: Motif) => avecMotif.filter((s) => s.motifLocal === m).length;
+    const avecVerdict = services.map((s) => ({ ...s, affiche: retenuAuSeuil(s, seuil) }));
 
     return {
       comptes: {
-        pertinence: compter("pertinence"),
-        generique: compter("generique"),
-        ecarte: compter("ecarte"),
-        // Ce chiffre est le vrai diagnostic : un service qui ne partage AUCUNE étiquette avec le
-        // projet ne peut être remonté que par repêchage. Aucun seuil ne le rendra pertinent.
-        sansRecouvrement: avecMotif.filter((s) => s.score === 0).length,
+        affiches: avecVerdict.filter((s) => s.affiche).length,
+        // Le vrai diagnostic : un service qui ne partage AUCUNE étiquette avec le projet ne peut
+        // pas remonter, quel que soit le seuil. Baisser le curseur ne joue que sur les autres.
+        sansRecouvrement: avecVerdict.filter((s) => s.score === 0).length,
       },
-      visibles: masquerEcartes ? avecMotif.filter((s) => s.motifLocal !== "ecarte") : avecMotif,
+      visibles: masquerEcartes ? avecVerdict.filter((s) => s.affiche) : avecVerdict,
     };
   }, [services, seuil, masquerEcartes]);
 
@@ -74,22 +67,23 @@ export function Services({ services, seuilApi }: { services: ServiceSimule[]; se
         />
 
         <p className={fr.cx("fr-mt-2w", "fr-mb-0")}>
-          <Badge severity="success" noIcon>
-            {comptes.pertinence} pertinents
-          </Badge>{" "}
-          <Badge severity="info" noIcon>
-            {comptes.generique} repêchés
-          </Badge>{" "}
-          <Badge severity="warning" noIcon>
-            {comptes.ecarte} écartés
+          <Badge severity={comptes.affiches > 0 ? "success" : "warning"} noIcon>
+            {comptes.affiches} affiché{comptes.affiches > 1 ? "s" : ""} sur {services.length}
           </Badge>
         </p>
 
         <p className={fr.cx("fr-text--sm", "fr-mt-2w", "fr-mb-0")}>
           {comptes.sansRecouvrement} des {services.length} services ne partagent <strong>aucune</strong> étiquette avec
-          ce projet : aucun seuil ne les rendra pertinents. Baisser le curseur ne joue que sur les{" "}
+          ce projet : aucun seuil ne les fera remonter. Le curseur ne joue que sur les{" "}
           {services.length - comptes.sansRecouvrement} autres.
         </p>
+
+        {comptes.affiches === 0 && (
+          <p className={fr.cx("fr-text--sm", "fr-mt-2w", "fr-mb-0")}>
+            Une liste vide est une réponse légitime : elle dit que le catalogue n&apos;a rien pour ce projet, ce qui est
+            une information. C&apos;est plus utile qu&apos;une liste de remplissage.
+          </p>
+        )}
       </div>
 
       <ToggleSwitch
@@ -114,26 +108,23 @@ export function Services({ services, seuilApi }: { services: ServiceSimule[]; se
             </tr>
           </thead>
           <tbody>
-            {visibles.map((s) => {
-              const { texte, severite } = LIBELLE_MOTIF[s.motifLocal];
-              return (
-                <tr key={s.slug}>
-                  <td>{s.nom}</td>
-                  <td>
-                    <strong>{s.score.toFixed(2)}</strong>
-                  </td>
-                  <td className={fr.cx("fr-text--xs")}>{s.facteurPhase < 1 ? `× ${pourcent(s.facteurPhase)}` : "—"}</td>
-                  <td>
-                    <Badge severity={severite} noIcon small>
-                      {texte}
-                    </Badge>
-                  </td>
-                  <td>
-                    <Etiquettes communes={s.etiquettesCommunes} />
-                  </td>
-                </tr>
-              );
-            })}
+            {visibles.map((s) => (
+              <tr key={s.slug}>
+                <td>{s.nom}</td>
+                <td>
+                  <strong>{s.score.toFixed(2)}</strong>
+                </td>
+                <td className={fr.cx("fr-text--xs")}>{s.facteurPhase < 1 ? `× ${pourcent(s.facteurPhase)}` : "—"}</td>
+                <td>
+                  <Badge severity={s.affiche ? "success" : "warning"} noIcon small>
+                    {s.affiche ? "affiché" : "écarté"}
+                  </Badge>
+                </td>
+                <td>
+                  <Etiquettes communes={s.etiquettesCommunes} />
+                </td>
+              </tr>
+            ))}
           </tbody>
         </table>
       </div>

--- a/back-office/src/types.ts
+++ b/back-office/src/types.ts
@@ -17,9 +17,6 @@ export interface EtiquetteScoree {
 export type Classification = Record<Axe, EtiquetteScoree[]>;
 export type EtiquettesCommunes = Record<Axe, string[]>;
 
-/** Pourquoi un service est affiché — ou ne l'est pas. */
-export type Motif = "pertinence" | "generique" | "ecarte";
-
 export interface Seuils {
   eligibilite: number;
   pertinence: number;
@@ -49,10 +46,8 @@ export interface ServiceSimule {
   facteurPhase: number;
   score: number;
   retenu: boolean;
-  motif: Motif;
   etiquettesCommunes: EtiquettesCommunes;
   profilGeneraliste: string | null;
-  presentationGenerique: string | null;
   categories: string[];
 }
 
@@ -63,13 +58,11 @@ export interface ServiceSimule {
  * score, jamais seulement les retenus : déplacer le seuil est donc de l'arithmétique côté
  * navigateur, sans rappeler l'API. On voit l'effet d'un réglage avant de le figer dans le code.
  *
- * Doit rester la copie exacte de `motifDe` dans api/src/admin/admin.service.ts — sinon l'écran
- * ment sur ce que ferait la vraie API.
+ * Le score seul décide — il n'y a pas de repêchage. Cette fonction doit rester la copie exacte
+ * de la règle appliquée dans api/src/services-numeriques/services-numeriques.service.ts, sinon
+ * l'écran ment sur ce que verra la collectivité.
  */
-export const motifAuSeuil = (service: ServiceSimule, seuil: number): Motif => {
-  if (service.score >= seuil) return "pertinence";
-  return service.presentationGenerique === "oui" ? "generique" : "ecarte";
-};
+export const retenuAuSeuil = (service: ServiceSimule, seuil: number): boolean => service.score >= seuil;
 
 export interface ProjetSimule {
   id: string;


### PR DESCRIPTION
Sur « ceci est une friche », MEC affiche **54 services**. Il y en a **4** de pertinents.

| | |
|---|---|
| Bénéfriches | 0,64 |
| Mutafriches | 0,64 |
| Cartofriches | 0,32 |
| UrbanVitaliz | 0,32 |
| *…puis 50 services sans aucun rapport avec le projet* | 0,00 |

## L'erreur

Le code concaténait les services « génériques » **sans condition** :

```ts
return { services: [...pertinents, ...generiques].map(...) };
```

Le commentaire parlait de « filet de sécurité », mais rien ne le conditionnait : dès qu'un service portait le drapeau `presentationGenerique`, il sortait — que le projet ait zéro ou quatre correspondances.

Ce drapeau vient d'une colonne du benchmark DINUM : *« À présenter dans une présentation générique et peu contextualisée ? »*. Elle désigne les services qu'on peut montrer sur une page **vitrine**, hors contexte. Une fiche projet est l'exact opposé : **elle est le contexte**. Ce critère n'aurait jamais dû franchir cette frontière.

## Le correctif

Le score seul décide. Pas de repêchage.

Une liste vide est une réponse **légitime**, et plus utile qu'une liste de remplissage : elle dit « le catalogue n'a rien pour ce projet », ce qui est une information. Un projet de salle des fêtes n'a aucun service numérique dédié — c'est un fait, pas une panne. Le fallback avait été introduit par peur de l'écran vide ; noyer 4 résultats parfaits sous 50 sans rapport est bien pire.

**Le seuil de 0,30 ne bouge pas.** Vérifié sur trois projets réels de staging via `/admin/simuler` : il sépare proprement (0,64 pour Bénéfriches sur une friche ; 0,03 pour EnvErgo sur un espace commercial).

## Effet sur les trois projets réels de staging

| Projet | Avant | Après |
|---|---|---|
| Ceci est une friche | 54 | **4** |
| Création d'un espace commercial | 55 | **1** |
| Salle des fêtes | 54 | **0** |

Sur « salle des fêtes », zéro est la bonne réponse : aucun service du catalogue DINUM ne traite ce type de lieu. Le questionnaire AtoutBiodiv, lui, reste proposé — la collectivité n'a donc pas un écran vide.

## Conséquence assumée

Les **11 services du benchmark sans aucune thématique** ne remonteront jamais. C'est un défaut de **données**, à corriger dans le benchmark — pas à masquer par une règle d'affichage. L'onglet Catalogue du back-office les trie en tête, précisément pour qu'on les voie.

La colonne `presentation_generique` reste en base (donnée du benchmark) mais ne décide plus de rien. Le back-office suit : le motif « repêché » disparaît, sinon il mentirait sur ce que verra la collectivité.

## Tests

25 e2e passent. La suite « Fallback générique » devient « Aucun repêchage » et documente le nouveau comportement : un service transverse sans recouvrement n'est pas affiché même marqué « présentation générique » ; un projet non classifié renvoie une liste vide ; un catalogue sans rien pour le projet renvoie une liste vide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)