### PR TITLE
feat(questionnaires): éligibilité par étiquette, et non par score

### DIFF
--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -6,7 +6,7 @@ import { AideClassification, AideMatchResult } from "@/aides/dto/aides.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { QUESTIONNAIRES } from "@/questionnaires/content";
 import { calculerStatut, evaluerCondition, reconcilierReponses } from "@/questionnaires/questionnaire-contract";
-import { SEUIL_ELIGIBILITE } from "@/questionnaires/questionnaires.service";
+import { etiquettesManquantes } from "@/questionnaires/questionnaires.service";
 import { facteurPhase, SEUIL_PERTINENCE, type PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
 import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
 
@@ -27,6 +27,16 @@ import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/ad
  * Ce module est ADDITIF et ISOLÉ : rien ne l'importe, il ne modifie rien. Le supprimer, c'est
  * `rm -rf src/admin` plus UNE ligne dans app.module.ts.
  */
+/** Toutes les étiquettes requises, à plat — le cas « projet non classifié ». */
+function requisesAPlat(def: (typeof QUESTIONNAIRES)[number]): { axe: string; label: string }[] {
+  const { thematiques, sites, interventions } = def.etiquettesRequises;
+  return [
+    ...thematiques.map((label) => ({ axe: "thematiques", label })),
+    ...sites.map((label) => ({ axe: "sites", label })),
+    ...interventions.map((label) => ({ axe: "interventions", label })),
+  ];
+}
+
 @Injectable()
 export class AdminService {
   constructor(
@@ -45,7 +55,7 @@ export class AdminService {
         libelle: q.source.nom,
         version: q.version,
         banniere: q.banniere,
-        classification: q.classification,
+        etiquettesRequises: q.etiquettesRequises,
         questions: q.questions,
         recommandations: q.recommandations,
       })),
@@ -60,7 +70,7 @@ export class AdminService {
         phases: s.phases as PoidsParPhase,
         logoUrl: s.logoUrl,
       })),
-      seuils: { eligibilite: SEUIL_ELIGIBILITE, pertinence: SEUIL_PERTINENCE },
+      seuils: { pertinence: SEUIL_PERTINENCE },
     };
   }
 
@@ -87,7 +97,7 @@ export class AdminService {
       },
       questionnaires: this.simulerQuestionnaires(scoresProjet, requete.reponses ?? {}),
       services: await this.simulerServices(scoresProjet, projet.phase),
-      seuils: { eligibilite: SEUIL_ELIGIBILITE, pertinence: SEUIL_PERTINENCE },
+      seuils: { pertinence: SEUIL_PERTINENCE },
     };
   }
 
@@ -108,27 +118,29 @@ export class AdminService {
     );
   }
 
+  /**
+   * L'éligibilité est un CRITÈRE, pas un score : on rend donc les étiquettes qui MANQUENT.
+   *
+   * « non proposé, score 0,11 » n'apprend rien et ne se corrige pas. « non proposé : il manque
+   * le lieu Place ou centre-bourg » dit exactement quoi regarder — soit la classification du
+   * projet est fausse, soit le questionnaire vise autre chose.
+   */
   private simulerQuestionnaires(
     scoresProjet: AideClassification | null,
     reponsesParSlug: Record<string, Record<string, string>>,
   ): SimulationResponse["questionnaires"] {
-    const parSlug = new Map<string, AideClassification>(QUESTIONNAIRES.map((q) => [q.slug, q.classification]));
-    const scores = this.confronter(scoresProjet, parSlug);
-
     return QUESTIONNAIRES.map((def) => {
-      const match = scores.get(def.slug);
-      const score = match?.normalizedScore ?? 0;
+      // Sans classification, TOUTES les étiquettes requises manquent : c'est la vérité, et c'est
+      // plus parlant qu'un « non éligible » sans motif.
+      const manquantes = scoresProjet ? etiquettesManquantes(scoresProjet, def.etiquettesRequises) : requisesAPlat(def);
       const reponses = reconcilierReponses(def, reponsesParSlug[def.slug] ?? {});
       const statut = calculerStatut(def, reponses);
-      const retenu = score >= SEUIL_ELIGIBILITE;
+      const retenu = manquantes.length === 0;
 
       return {
         slug: def.slug,
-        score,
         retenu,
-        // Pourquoi ce score : les étiquettes réellement partagées avec le projet. Sans ça, un
-        // score de 0,12 est un chiffre opaque et on ne peut rien en faire.
-        etiquettesCommunes: match?.labelsCommuns ?? { thematiques: [], sites: [], interventions: [] },
+        etiquettesManquantes: manquantes,
         statut,
         reponses,
         recommandations: def.recommandations.map((r) => ({
@@ -140,7 +152,7 @@ export class AdminService {
           declenchee: retenu && statut !== "non_commence" && evaluerCondition(r.condition, reponses),
         })),
       };
-    }).sort((a, b) => b.score - a.score);
+    }).sort((a, b) => a.etiquettesManquantes.length - b.etiquettesManquantes.length || a.slug.localeCompare(b.slug));
   }
 
   private async simulerServices(

--- a/api/src/admin/dto/admin.dto.ts
+++ b/api/src/admin/dto/admin.dto.ts
@@ -16,11 +16,15 @@ import type {
 // Le contrat servi à MEC, lui, ne change pas d'un iota.
 
 export class SeuilsResponse {
-  @ApiProperty({ description: "Score normalisé minimal pour qu'un questionnaire soit proposé." })
-  eligibilite!: number;
-
   @ApiProperty({ description: "Score normalisé minimal pour qu'un service soit jugé pertinent." })
   pertinence!: number;
+}
+
+export class EtiquetteManquanteResponse {
+  @ApiProperty({ enum: ["thematiques", "sites", "interventions"] })
+  axe!: string;
+
+  @ApiProperty() label!: string;
 }
 
 export class QuestionnaireContenuResponse {
@@ -28,8 +32,8 @@ export class QuestionnaireContenuResponse {
   @ApiProperty() libelle!: string;
   @ApiProperty() version!: number;
   @ApiProperty({ type: Object }) banniere!: BanniereDef;
-  @ApiProperty({ type: Object, description: "Classification d'éligibilité — jamais exposée à MEC." })
-  classification!: AideClassification;
+  @ApiProperty({ type: Object, description: "Étiquettes définissantes — jamais exposées à MEC." })
+  etiquettesRequises!: { thematiques: readonly string[]; sites: readonly string[]; interventions: readonly string[] };
   @ApiProperty({ type: [Object] }) questions!: QuestionDef[];
   @ApiProperty({ type: [Object], description: "Recommandations AVEC leur condition — jamais exposée à MEC." })
   recommandations!: RecommandationDef[];
@@ -85,10 +89,16 @@ export class RecommandationSimuleeResponse {
 
 export class QuestionnaireSimuleResponse {
   @ApiProperty() slug!: string;
-  @ApiProperty({ description: "Score normalisé [0,1] du questionnaire pour ce projet." }) score!: number;
-  @ApiProperty({ description: "Au-dessus du seuil d'éligibilité." }) retenu!: boolean;
-  @ApiProperty({ type: Object, description: "Pourquoi ce score : les étiquettes partagées avec le projet." })
-  etiquettesCommunes!: AideLabelsCommuns;
+  @ApiProperty({ description: "Le projet porte TOUTES les étiquettes définissantes du questionnaire." })
+  retenu!: boolean;
+  @ApiProperty({
+    type: [EtiquetteManquanteResponse],
+    description:
+      "Les étiquettes que le projet NE porte PAS (confiance < 0,8). Vide = questionnaire proposé. " +
+      "L'éligibilité est un critère, pas un score : « il manque le lieu Place ou centre-bourg » " +
+      "dit quoi regarder, là où « score 0,11 » n'apprend rien.",
+  })
+  etiquettesManquantes!: EtiquetteManquanteResponse[];
   @ApiProperty() statut!: StatutQuestionnaire;
   @ApiProperty({ type: Object }) reponses!: Record<string, string>;
   @ApiProperty({ type: [RecommandationSimuleeResponse] }) recommandations!: RecommandationSimuleeResponse[];

--- a/api/src/questionnaires/content/README.md
+++ b/api/src/questionnaires/content/README.md
@@ -32,21 +32,38 @@ réapparaît — un champ mort ne doit pas pouvoir revenir en silence dans une P
 
 ## Comment l'éligibilité fonctionne réellement
 
-Chaque questionnaire est **classifié comme l'est une aide**, sur les trois mêmes axes, dans
-les mêmes taxonomies (`classification.ts`, typé : une étiquette hors taxonomie ne compile
-pas). L'éligibilité est ensuite un **score**, calculé par le moteur du matching des aides
-(`AidesMatchingService`, réutilisé tel quel) :
+Chaque questionnaire déclare les **étiquettes qui le définissent**, dans les taxonomies fermées
+du schéma commun (`classification.ts`, typé : une étiquette hors taxonomie ne compile pas).
 
-- pondération par axe : thématiques 0.45, sites 0.35, interventions 0.20 ;
-- seuil de confiance 0.8 : une étiquette dont le LLM n'est pas sûr ne compte pas ;
-- score normalisé dans [0, 1], comparé à `SEUIL_ELIGIBILITE` (0.3, dans
-  `questionnaires.service.ts`).
+La règle : **le projet doit porter TOUTES ces étiquettes**, avec une confiance ≥ 0.8 (le même
+seuil que le matching des aides — en dessous, le job LLM hésite, on n'agit pas dessus).
 
-Le seuil est délibérément permissif : un faux positif coûte un onglet ignoré, un faux négatif
-coûte une opportunité de biodiversité jamais vue.
+**Toutes**, et non au moins une. Sur `atoutbiodiv-solaire` (« école » + « solaire sur le bâti »),
+« école » seule attraperait n'importe quel projet d'école, et « solaire » seul n'importe quelle
+installation photovoltaïque. C'est la conjonction qui définit le questionnaire.
 
-Conséquence directe : un projet **non encore classifié** (le job LLM n'a pas tourné) ne se
-voit proposer aucun questionnaire.
+### Pourquoi un critère, et pas un score
+
+Le score de matching des aides a été essayé ici, et il échoue pour une raison **structurelle** :
+il normalise par le maximum du **projet**. Deux projets portant tous deux « Place ou centre-bourg »
+obtenaient 1.00 et 0.11 selon que leur classification était pauvre ou riche — le second était
+écarté alors qu'il est bel et bien une place.
+
+Un questionnaire n'est pas une aide. Une aide _ressemble_ plus ou moins à un projet : un score a
+du sens. Un questionnaire, lui, s'applique ou ne s'applique pas — c'est une salle des fêtes, ou
+ce n'en est pas une. Un critère ne doit pas dépendre de la largeur de la classification d'à côté.
+
+Bénéfice secondaire : on peut dire **pourquoi** un questionnaire n'est pas proposé (« il manque
+le lieu _Place ou centre-bourg_ »). Un score de 0.11 ne se corrige pas ; une étiquette manquante,
+si — soit la classification du projet est fausse, soit le questionnaire vise autre chose.
+
+Conséquence directe : un projet **non encore classifié** (le job LLM n'a pas tourné) ne se voit
+proposer aucun questionnaire.
+
+### Le garde-fou qui compte
+
+Un questionnaire qui n'exige **aucune** étiquette serait proposé à **tous** les projets — une
+conjonction vide est vraie. Le chargeur refuse de démarrer dans ce cas.
 
 ## Ajouter un questionnaire
 

--- a/api/src/questionnaires/content/classification.ts
+++ b/api/src/questionnaires/content/classification.ts
@@ -1,89 +1,77 @@
-import { AideClassification } from "@/aides/dto/aides.dto";
 import type { Intervention } from "@/projet-qualification/classification/const/interventions";
 import type { Site } from "@/projet-qualification/classification/const/sites";
 import type { Thematique } from "@/projet-qualification/classification/const/thematiques";
 
 /**
- * Classification des questionnaires sur les trois axes du schéma commun.
+ * Étiquettes qui DÉFINISSENT chaque questionnaire, sur les trois axes du schéma commun.
  *
  * POURQUOI CE FICHIER EXISTE. Les fichiers partenaires portent un bloc `eligibilite`
- * ({ thematiques: ["Équipements et services publics"], competences: [] }) qui emploie le
+ * ({ thematiques: ["Équipements et services publics"], competences: [] }) rédigé dans le
  * vocabulaire thématique de MEC. Ce vocabulaire n'existe PAS dans les taxonomies fermées de
- * l'API, bien plus fines (137 thématiques : « Voirie », « Sobriété énergétique », « Vélo
- * (mobilité douce) »…). Une règle booléenne sur ces libellés n'aurait matché aucun projet.
+ * l'API, bien plus fines (137 thématiques). Une règle sur ces libellés n'aurait matché aucun
+ * projet, silencieusement. L'éligibilité est donc décidée par Communs (spec §2), ici.
  *
- * L'éligibilité est donc décidée par Communs (spec §2 : « toute la logique métier vit dans
- * Communs »), par le MÊME moteur de score que les aides (AidesMatchingService) : le
- * questionnaire est classifié comme l'est une aide, et son score de matching contre la
- * classification du projet décide s'il est proposé.
+ * POURQUOI UNE RÈGLE PAR ÉTIQUETTE, ET NON UN SCORE. Un questionnaire n'est pas une aide.
+ * Une aide ressemble plus ou moins à un projet — un score a du sens. Un questionnaire, lui,
+ * est défini par un critère : c'est une salle des fêtes, ou ce n'en est pas une.
  *
- * Le typage sur Thematique/Site/Intervention est volontaire : une étiquette hors taxonomie
- * ne compile pas. Les scores sont ceux d'un contenu éditorialisé à la main — 1.0 quand le
- * questionnaire porte frontalement sur l'étiquette, plus bas quand elle n'est qu'adjacente.
+ * Le score de matching a d'ailleurs été essayé, et il échoue ici pour une raison structurelle :
+ * il normalise par le maximum du PROJET. Deux projets portant tous deux « Place ou centre-bourg »
+ * obtenaient 1,00 et 0,11 selon que leur classification était pauvre ou riche — le second était
+ * écarté alors qu'il est bel et bien une place. Un critère ne doit pas dépendre de la largeur de
+ * la classification d'à côté.
+ *
+ * LA RÈGLE. Le questionnaire est proposé si le projet porte TOUTES ses étiquettes définissantes,
+ * avec une confiance ≥ SEUIL_CONFIANCE. Toutes, et non au moins une : sur `atoutbiodiv-solaire`,
+ * « école » seule attraperait n'importe quel projet d'école, et « solaire » seul n'importe quelle
+ * installation photovoltaïque. C'est la conjonction qui définit le questionnaire.
+ *
+ * Le typage sur Thematique/Site/Intervention est volontaire : une étiquette hors taxonomie ne
+ * compile pas.
  */
-
-type Etiquettes<T extends string> = { label: T; score: number }[];
-
-interface ClassificationQuestionnaire extends AideClassification {
-  thematiques: Etiquettes<Thematique>;
-  sites: Etiquettes<Site>;
-  interventions: Etiquettes<Intervention>;
+export interface EtiquettesRequises {
+  thematiques: readonly Thematique[];
+  sites: readonly Site[];
+  interventions: readonly Intervention[];
 }
 
-export const CLASSIFICATIONS: Record<string, ClassificationQuestionnaire> = {
-  // Salle des fêtes / salle associative : construction ou rénovation d'un équipement public,
-  // avec des abords (parking, cheminements) qui sont le principal levier biodiversité.
+/**
+ * Confiance minimale de l'étiquette DANS LA CLASSIFICATION DU PROJET pour qu'elle compte.
+ *
+ * Même valeur que le seuil du moteur de matching des aides (AidesMatchingService.DEFAULT_THRESHOLD) :
+ * en dessous, le job LLM n'est pas assez sûr de lui pour qu'on agisse dessus.
+ */
+export const SEUIL_CONFIANCE = 0.8;
+
+export const ETIQUETTES_REQUISES: Record<string, EtiquettesRequises> = {
+  // Le lieu SEUL définit ce questionnaire.
   "atoutbiodiv-salle": {
-    thematiques: [
-      { label: "Végétalisation d'espaces publics", score: 0.9 },
-      { label: "Gestion des eaux pluviales", score: 0.85 },
-    ],
-    sites: [
-      { label: "Salle des fêtes, salle associative, pôle musical", score: 1.0 },
-      { label: "Bâtiment public", score: 0.9 },
-    ],
-    interventions: [
-      { label: "Construction bâtiment", score: 0.9 },
-      { label: "Rénovation bâtiment", score: 0.85 },
-    ],
+    thematiques: [],
+    sites: ["Salle des fêtes, salle associative, pôle musical"],
+    interventions: [],
   },
 
-  // Voie verte / piste cyclable : l'axe « sites » est faible (la taxonomie n'a pas de site
-  // « piste cyclable »), le poids porte donc sur les thématiques mobilité douce et voirie.
-  "atoutbiodiv-piste": {
-    thematiques: [
-      { label: "Vélo (mobilité douce)", score: 1.0 },
-      { label: "Voirie", score: 0.85 },
-      { label: "Randonnée, vélo tourisme, VTT", score: 0.8 },
-    ],
-    sites: [{ label: "Stationnements pour vélos", score: 0.8 }],
-    interventions: [
-      { label: "Construction sauf bâtiment (voirie, ...)", score: 0.9 },
-      { label: "Rénovation sauf bâtiment (voirie, ...)", score: 0.85 },
-    ],
-  },
-
-  // Place / centre-bourg : désimperméabilisation et végétalisation d'un espace public.
+  // Idem : le lieu seul. Une place, ou pas une place.
   "atoutbiodiv-place": {
-    thematiques: [
-      { label: "Végétalisation d'espaces publics", score: 1.0 },
-      { label: "Gestion des eaux pluviales", score: 0.9 },
-    ],
-    sites: [{ label: "Place ou centre-bourg", score: 1.0 }],
-    interventions: [{ label: "Aménagement urbain et restructuration", score: 0.95 }],
+    thematiques: [],
+    sites: ["Place ou centre-bourg"],
+    interventions: [],
   },
 
-  // Panneaux solaires sur une école : toiture (végétalisation en complément des panneaux),
-  // cour à désimperméabiliser, volet pédagogique.
+  // Ici c'est la THÉMATIQUE qui définit le questionnaire : la taxonomie n'a aucun lieu
+  // « piste cyclable » ni « voie verte », mais elle a la thématique correspondante.
+  "atoutbiodiv-piste": {
+    thematiques: ["Voie douce, piste cyclable"],
+    sites: [],
+    interventions: [],
+  },
+
+  // Le seul des quatre à exiger DEUX étiquettes, et il le faut : des panneaux solaires SUR UNE
+  // ÉCOLE. La thématique seule attraperait n'importe quelle installation solaire ; le lieu seul,
+  // n'importe quel projet d'école.
   "atoutbiodiv-solaire": {
-    thematiques: [
-      { label: "Agrivoltaïsme, panneaux solaires sur le bâti", score: 1.0 },
-      { label: "Végétalisation d'espaces publics", score: 0.8 },
-    ],
-    sites: [
-      { label: "Ecole", score: 1.0 },
-      { label: "Bâtiment public", score: 0.85 },
-    ],
-    interventions: [{ label: "Rénovation bâtiment", score: 0.85 }],
+    thematiques: ["Agrivoltaïsme, panneaux solaires sur le bâti"],
+    sites: ["Ecole"],
+    interventions: [],
   },
 };

--- a/api/src/questionnaires/content/content.spec.ts
+++ b/api/src/questionnaires/content/content.spec.ts
@@ -3,7 +3,7 @@ import { sites } from "@/projet-qualification/classification/const/sites";
 import { thematiques } from "@/projet-qualification/classification/const/thematiques";
 import type { QuestionnaireFichier } from "../questionnaire-contract";
 import { assembler, QUESTIONNAIRES, questionnaireParSlug } from "./index";
-import { CLASSIFICATIONS } from "./classification";
+import { ETIQUETTES_REQUISES } from "./classification";
 
 // Ces tests portent sur le CONTENU (JSON partenaire + classification Communs). Ils sont le
 // filet qui protège une PR de contenu : une coquille dans un id de question, une option
@@ -90,19 +90,20 @@ describe("Contenu des questionnaires", () => {
     },
   );
 
-  it("chaque questionnaire porte une classification d'éligibilité", () => {
+  it("chaque questionnaire exige au moins une étiquette", () => {
     for (const def of QUESTIONNAIRES) {
-      expect(CLASSIFICATIONS[def.slug]).toBeDefined();
-      // Sans étiquette, le questionnaire ne serait jamais proposé à aucun projet.
+      expect(ETIQUETTES_REQUISES[def.slug]).toBeDefined();
+      // Une conjonction VIDE est vraie : un questionnaire sans étiquette requise serait proposé
+      // à TOUS les projets. C'est le pire cas, et il doit être impossible.
       const nbEtiquettes =
-        def.classification.thematiques.length +
-        def.classification.sites.length +
-        def.classification.interventions.length;
+        def.etiquettesRequises.thematiques.length +
+        def.etiquettesRequises.sites.length +
+        def.etiquettesRequises.interventions.length;
       expect(nbEtiquettes).toBeGreaterThan(0);
     }
   });
 
-  it("les étiquettes de classification appartiennent aux taxonomies fermées", () => {
+  it("les étiquettes requises appartiennent aux taxonomies fermées", () => {
     const referentiels = {
       thematiques: new Set<string>(thematiques),
       sites: new Set<string>(sites),
@@ -111,10 +112,8 @@ describe("Contenu des questionnaires", () => {
 
     for (const def of QUESTIONNAIRES) {
       for (const axe of ["thematiques", "sites", "interventions"] as const) {
-        for (const { label, score } of def.classification[axe]) {
+        for (const label of def.etiquettesRequises[axe]) {
           expect(referentiels[axe].has(label)).toBe(true);
-          expect(score).toBeGreaterThan(0);
-          expect(score).toBeLessThanOrEqual(1);
         }
       }
     }
@@ -154,12 +153,25 @@ describe("Garde-fous du chargeur de contenu", () => {
     expect(() => assembler(avecEligibilite as QuestionnaireFichier)).toThrow(/eligibilite.*n'est plus supporté/s);
   });
 
-  it("refuse un questionnaire sans classification d'éligibilité", () => {
-    // Sans classification, le questionnaire ne serait proposé à aucun projet — un bug
-    // parfaitement silencieux en production.
-    const inconnu = { ...fichierValide(), slug: "questionnaire-sans-classification" };
+  it("refuse un questionnaire sans étiquette d'éligibilité déclarée", () => {
+    // Sans étiquette, le questionnaire ne serait proposé à aucun projet — un bug parfaitement
+    // silencieux en production.
+    const inconnu = { ...fichierValide(), slug: "questionnaire-sans-etiquette" };
 
-    expect(() => assembler(inconnu)).toThrow(/aucune classification/);
+    expect(() => assembler(inconnu)).toThrow(/aucune étiquette d'éligibilité/);
+  });
+
+  it("refuse un questionnaire qui n'exige AUCUNE étiquette", () => {
+    // Le pire cas, et il est contre-intuitif : une conjonction VIDE est VRAIE. Un questionnaire
+    // qui n'exige rien serait proposé à TOUS les projets, sans exception. Mieux vaut refuser de
+    // démarrer que d'inonder toutes les collectivités de France.
+    ETIQUETTES_REQUISES["questionnaire-vide"] = { thematiques: [], sites: [], interventions: [] };
+
+    try {
+      expect(() => assembler({ ...fichierValide(), slug: "questionnaire-vide" })).toThrow(/proposé à TOUS les projets/);
+    } finally {
+      delete ETIQUETTES_REQUISES["questionnaire-vide"];
+    }
   });
 
   it("refuse une condition qui pointe une question inexistante", () => {

--- a/api/src/questionnaires/content/index.ts
+++ b/api/src/questionnaires/content/index.ts
@@ -1,5 +1,5 @@
 import { QuestionnaireDef, type QuestionnaireFichier, type RecommandationsFichier } from "../questionnaire-contract";
-import { CLASSIFICATIONS } from "./classification";
+import { ETIQUETTES_REQUISES } from "./classification";
 
 import piste from "./questionnaires/atoutbiodiv-piste.json";
 import place from "./questionnaires/atoutbiodiv-place.json";
@@ -42,16 +42,27 @@ export function assembler(fichier: QuestionnaireFichier): QuestionnaireDef {
   if ("eligibilite" in fichier) {
     throw new Error(
       `Questionnaire "${slug}" : le champ "eligibilite" n'est plus supporté. L'éligibilité est décidée ` +
-        `par Communs, par score de matching sur les trois axes de classification — déclarez-la dans ` +
-        `content/classification.ts (taxonomies fermées : thematiques, sites, interventions).`,
+        `par Communs : le projet doit porter les étiquettes définissantes du questionnaire — déclarez-les ` +
+        `dans content/classification.ts (taxonomies fermées : thematiques, sites, interventions).`,
     );
   }
 
-  const classification = CLASSIFICATIONS[slug];
-  if (!classification) {
+  const etiquettesRequises = ETIQUETTES_REQUISES[slug];
+  if (!etiquettesRequises) {
     throw new Error(
-      `Questionnaire "${slug}" : aucune classification d'éligibilité (content/classification.ts). ` +
+      `Questionnaire "${slug}" : aucune étiquette d'éligibilité (content/classification.ts). ` +
         `Sans elle, le questionnaire ne serait jamais proposé à aucun projet.`,
+    );
+  }
+
+  // Une liste vide sur les trois axes serait pire qu'une absence : le questionnaire n'exigerait
+  // RIEN, donc il serait proposé à TOUS les projets. Une conjonction vide est vraie.
+  const nbEtiquettes =
+    etiquettesRequises.thematiques.length + etiquettesRequises.sites.length + etiquettesRequises.interventions.length;
+  if (nbEtiquettes === 0) {
+    throw new Error(
+      `Questionnaire "${slug}" : aucune étiquette requise. Il serait proposé à TOUS les projets ` +
+        `(une conjonction vide est vraie). Déclarez au moins une étiquette dans content/classification.ts.`,
     );
   }
 
@@ -82,7 +93,7 @@ export function assembler(fichier: QuestionnaireFichier): QuestionnaireDef {
     }
   }
 
-  return { ...fichier, classification, recommandations: fichierRecos.recommandations };
+  return { ...fichier, etiquettesRequises, recommandations: fichierRecos.recommandations };
 }
 
 /**

--- a/api/src/questionnaires/content/questionnaires/atoutbiodiv-piste.json
+++ b/api/src/questionnaires/content/questionnaires/atoutbiodiv-piste.json
@@ -6,7 +6,7 @@
   },
   "banniere": {
     "icone": "🌿",
-    "titre": "Optimisez le potentiel biodiversité de votre projet",
+    "titre": "Optimisez le potentiel biodiversité de votre projet de voie douce ou de piste cyclable",
     "sousTitre": "Bermes, corridors, trame noire — optimisez les co-bénéfices biodiversité de votre infrastructure linéaire"
   },
   "questions": [

--- a/api/src/questionnaires/content/questionnaires/atoutbiodiv-place.json
+++ b/api/src/questionnaires/content/questionnaires/atoutbiodiv-place.json
@@ -6,7 +6,7 @@
   },
   "banniere": {
     "icone": "🌿",
-    "titre": "Optimisez le potentiel biodiversité de votre projet",
+    "titre": "Optimisez le potentiel biodiversité de votre projet de place ou de centre-bourg",
     "sousTitre": "Désimperméabilisation, végétalisation, corridors — identifiez les actions adaptées à votre place"
   },
   "questions": [

--- a/api/src/questionnaires/content/questionnaires/atoutbiodiv-salle.json
+++ b/api/src/questionnaires/content/questionnaires/atoutbiodiv-salle.json
@@ -6,7 +6,7 @@
   },
   "banniere": {
     "icone": "🌿",
-    "titre": "Optimisez le potentiel biodiversité de votre projet",
+    "titre": "Optimisez le potentiel biodiversité de votre projet de salle des fêtes ou de salle polyvalente",
     "sousTitre": "Identifiez des actions à impact et renforcez votre dossier — Fonds vert, Agence de l'Eau, DETR bonifiée"
   },
   "questions": [

--- a/api/src/questionnaires/content/questionnaires/atoutbiodiv-solaire.json
+++ b/api/src/questionnaires/content/questionnaires/atoutbiodiv-solaire.json
@@ -6,7 +6,7 @@
   },
   "banniere": {
     "icone": "🌿",
-    "titre": "Optimisez le potentiel biodiversité de votre projet",
+    "titre": "Optimisez le potentiel biodiversité de votre projet de panneaux solaires sur école",
     "sousTitre": "Toiture végétalisée, cour désimperméabilisée, biodiversité pédagogique — optimisez les co-bénéfices"
   },
   "questions": [

--- a/api/src/questionnaires/eligibilite.spec.ts
+++ b/api/src/questionnaires/eligibilite.spec.ts
@@ -1,26 +1,25 @@
-import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { AideClassification } from "@/aides/dto/aides.dto";
-import { CustomLogger } from "@logging/logger.service";
 import { QUESTIONNAIRES } from "./content";
-import { SEUIL_ELIGIBILITE } from "./questionnaires.service";
+import { SEUIL_CONFIANCE } from "./content/classification";
+import { etiquettesManquantes } from "./questionnaires.service";
 
-// L'éligibilité d'un questionnaire n'est PAS une règle booléenne : c'est un score, calculé
-// par le même moteur que le matching des aides (thématiques 0.45, sites 0.35, interventions
-// 0.20, seuils de confiance à 0.8). Ces tests pinnent le comportement du scoring sur la
-// classification réelle des quatre questionnaires — c'est ce qui décide de ce qu'une
-// collectivité voit s'afficher.
+/**
+ * L'éligibilité d'un questionnaire est un CRITÈRE, pas un score : le projet porte-t-il TOUTES les
+ * étiquettes qui définissent le questionnaire, avec une confiance ≥ 0,8 ?
+ *
+ * POURQUOI PAS UN SCORE. Le moteur de matching des aides a été essayé ici, et il échoue pour une
+ * raison structurelle : il normalise par le maximum du PROJET. Deux projets portant tous deux
+ * « Place ou centre-bourg » obtenaient 1,00 et 0,11 selon que leur classification était pauvre ou
+ * riche — le second était écarté alors qu'il est bel et bien une place. Le test « espace
+ * commercial » ci-dessous verrouille précisément cette régression.
+ *
+ * Les trois premiers cas sont les classifications RÉELLES de trois projets de staging, telles que
+ * le job LLM les a produites. Pas des cas inventés : un projet composé à la main est trop propre,
+ * et il dit ce qu'on veut entendre.
+ */
 
-const logger = { log: jest.fn(), warn: jest.fn(), error: jest.fn() } as unknown as CustomLogger;
-const matching = new AidesMatchingService(logger);
-
-const classifications = new Map<string, AideClassification>(QUESTIONNAIRES.map((q) => [q.slug, q.classification]));
-
-/** Reproduit exactement la sélection de QuestionnairesService.questionnairesEligibles. */
-const questionnairesProposes = (projet: AideClassification): { slug: string; score: number }[] =>
-  matching
-    .match(projet, classifications, QUESTIONNAIRES.length)
-    .filter((m) => m.normalizedScore >= SEUIL_ELIGIBILITE)
-    .map((m) => ({ slug: m.idAt, score: m.normalizedScore }));
+const proposes = (projet: AideClassification): string[] =>
+  QUESTIONNAIRES.filter((def) => etiquettesManquantes(projet, def.etiquettesRequises).length === 0).map((d) => d.slug);
 
 const projet = (p: Partial<AideClassification>): AideClassification => ({
   thematiques: [],
@@ -29,118 +28,112 @@ const projet = (p: Partial<AideClassification>): AideClassification => ({
   ...p,
 });
 
-describe("Éligibilité des questionnaires (scoring)", () => {
-  it("propose AtoutBiodiv-salle à un projet de salle des fêtes", () => {
-    const proposes = questionnairesProposes(
-      projet({
-        sites: [{ label: "Salle des fêtes, salle associative, pôle musical", score: 0.95 }],
-        interventions: [{ label: "Construction bâtiment", score: 0.9 }],
-      }),
-    );
+// Classification réelle du projet « Salle des fêtes » (staging).
+const SALLE_REELLE = projet({
+  thematiques: [
+    { label: "Parc immobilier détenu par un acteur public", score: 0.4 },
+    { label: "Cohésion sociale et inclusion", score: 0.35 },
+  ],
+  sites: [
+    { label: "Salle des fêtes, salle associative, pôle musical", score: 0.98 },
+    { label: "Salle de sport ou gymnase", score: 0.45 },
+    { label: "Bâtiment public", score: 0.3 },
+  ],
+  interventions: [
+    { label: "Construction bâtiment", score: 0.75 },
+    { label: "Rénovation bâtiment", score: 0.65 },
+  ],
+});
 
-    expect(proposes.map((p) => p.slug)).toEqual(["atoutbiodiv-salle"]);
-    expect(proposes[0].score).toBeGreaterThan(0.8);
-  });
+// Classification réelle du projet « Création d'un espace commercial » (staging) : RICHE — cinq
+// étiquettes au-dessus du seuil de confiance, réparties sur les trois axes.
+const COMMERCIAL_REEL = projet({
+  thematiques: [{ label: "Attractivité économique", score: 0.9 }],
+  sites: [
+    { label: "Commerce, restaurant, café de proximité, ou multiple rural", score: 0.98 },
+    { label: "Place ou centre-bourg", score: 0.82 },
+  ],
+  interventions: [
+    { label: "Construction bâtiment", score: 0.85 },
+    { label: "Dynamisation", score: 0.8 },
+  ],
+});
 
-  it("propose AtoutBiodiv-place à un projet de réaménagement de centre-bourg", () => {
-    const proposes = questionnairesProposes(
-      projet({
-        thematiques: [{ label: "Végétalisation d'espaces publics", score: 0.95 }],
-        sites: [{ label: "Place ou centre-bourg", score: 0.9 }],
-        interventions: [{ label: "Aménagement urbain et restructuration", score: 0.9 }],
-      }),
-    );
+// Classification réelle du projet « Ceci est une friche » (staging).
+const FRICHE_REELLE = projet({
+  thematiques: [
+    { label: "Mutabilité, changement de fonction d'un bâtiment ou d'un site", score: 0.95 },
+    { label: "Friche", score: 0.95 },
+  ],
+  interventions: [
+    { label: "Aménagement urbain et restructuration", score: 0.85 },
+    { label: "Rénovation bâtiment", score: 0.8 },
+  ],
+});
 
-    expect(proposes[0].slug).toBe("atoutbiodiv-place");
-  });
-
-  it("propose AtoutBiodiv-piste à un projet de voie cyclable", () => {
-    const proposes = questionnairesProposes(
-      projet({
-        thematiques: [{ label: "Vélo (mobilité douce)", score: 0.95 }],
-        interventions: [{ label: "Construction sauf bâtiment (voirie, ...)", score: 0.9 }],
-      }),
-    );
-
-    expect(proposes.map((p) => p.slug)).toEqual(["atoutbiodiv-piste"]);
-  });
-
-  it("propose AtoutBiodiv-solaire à un projet de panneaux solaires sur une école", () => {
-    const proposes = questionnairesProposes(
-      projet({
-        thematiques: [{ label: "Agrivoltaïsme, panneaux solaires sur le bâti", score: 0.95 }],
-        sites: [{ label: "Ecole", score: 0.95 }],
-      }),
-    );
-
-    expect(proposes[0].slug).toBe("atoutbiodiv-solaire");
-  });
-
-  it("ne propose rien à un projet hors sujet (piscine)", () => {
-    // Le projet partage pourtant une intervention (« Rénovation bâtiment ») avec deux
-    // questionnaires : c'est le SEUIL qui l'écarte, pas l'absence totale de recouvrement.
-    // Un simple test d'intersection non vide aurait proposé AtoutBiodiv à tort.
-    const scoresProjet = projet({
-      sites: [{ label: "Piscine", score: 0.95 }],
-      interventions: [{ label: "Rénovation bâtiment", score: 0.9 }],
+describe("Éligibilité des questionnaires (règle par étiquette)", () => {
+  describe("Sur les projets réels de staging", () => {
+    it("propose AtoutBiodiv-salle au projet de salle des fêtes", () => {
+      expect(proposes(SALLE_REELLE)).toEqual(["atoutbiodiv-salle"]);
     });
 
-    expect(questionnairesProposes(scoresProjet)).toEqual([]);
-
-    const tousLesScores = matching.match(scoresProjet, classifications, QUESTIONNAIRES.length);
-    expect(tousLesScores.some((m) => m.normalizedScore > 0)).toBe(true);
-    expect(Math.max(...tousLesScores.map((m) => m.normalizedScore))).toBeLessThan(SEUIL_ELIGIBILITE);
-  });
-
-  it("ne propose rien à un projet sans aucun recouvrement", () => {
-    expect(questionnairesProposes(projet({ sites: [{ label: "Barrage", score: 0.95 }] }))).toEqual([]);
-  });
-
-  it("ne propose rien à un projet non classifié", () => {
-    expect(questionnairesProposes(projet({}))).toEqual([]);
-  });
-
-  it("ignore les étiquettes du projet sous le seuil de confiance de 0.8", () => {
-    // Une classification LLM peu sûre ne doit pas déclencher un questionnaire.
-    const peuSur = projet({
-      sites: [{ label: "Salle des fêtes, salle associative, pôle musical", score: 0.5 }],
+    it("propose AtoutBiodiv-place au projet d'espace commercial, qui EST une place", () => {
+      // LA RÉGRESSION À VERROUILLER. Ce projet porte « Place ou centre-bourg » à 0,82. Avec le
+      // score normalisé, il obtenait 0,11 — sous le seuil — et le questionnaire était écarté,
+      // uniquement parce que sa classification est riche sur les autres axes.
+      expect(proposes(COMMERCIAL_REEL)).toEqual(["atoutbiodiv-place"]);
     });
 
-    expect(questionnairesProposes(peuSur)).toEqual([]);
+    it("ne propose rien au projet de friche", () => {
+      expect(proposes(FRICHE_REELLE)).toEqual([]);
+    });
   });
 
-  it("peut proposer plusieurs questionnaires à un projet à cheval sur deux domaines", () => {
-    // Réaménagement d'une place AVEC végétalisation d'école adjacente : les deux
-    // questionnaires sont légitimes, et l'API les renvoie tous les deux.
-    const proposes = questionnairesProposes(
-      projet({
-        thematiques: [
-          { label: "Végétalisation d'espaces publics", score: 0.95 },
-          { label: "Agrivoltaïsme, panneaux solaires sur le bâti", score: 0.9 },
-        ],
-        sites: [
-          { label: "Place ou centre-bourg", score: 0.9 },
-          { label: "Ecole", score: 0.9 },
-        ],
-      }),
-    );
+  describe("Seuil de confiance", () => {
+    it("ignore une étiquette dont le job LLM n'est pas sûr", () => {
+      // Même seuil que pour les aides : en dessous, le modèle hésite, on n'agit pas dessus.
+      expect(proposes(projet({ sites: [{ label: "Place ou centre-bourg", score: SEUIL_CONFIANCE - 0.01 }] }))).toEqual(
+        [],
+      );
 
-    expect(proposes.length).toBeGreaterThanOrEqual(2);
-    expect(proposes.map((p) => p.slug)).toEqual(expect.arrayContaining(["atoutbiodiv-place", "atoutbiodiv-solaire"]));
+      expect(proposes(projet({ sites: [{ label: "Place ou centre-bourg", score: SEUIL_CONFIANCE }] }))).toEqual([
+        "atoutbiodiv-place",
+      ]);
+    });
   });
 
-  it("trie par score décroissant : le questionnaire le plus pertinent d'abord", () => {
-    const proposes = questionnairesProposes(
-      projet({
-        thematiques: [{ label: "Végétalisation d'espaces publics", score: 0.95 }],
-        sites: [
-          { label: "Place ou centre-bourg", score: 0.95 },
-          { label: "Ecole", score: 0.85 },
-        ],
-      }),
-    );
+  describe("Conjonction, sur AtoutBiodiv-solaire", () => {
+    const SOLAIRE = { label: "Agrivoltaïsme, panneaux solaires sur le bâti", score: 0.95 };
+    const ECOLE = { label: "Ecole", score: 0.95 };
 
-    const scores = proposes.map((p) => p.score);
-    expect(scores).toEqual([...scores].sort((a, b) => b - a));
+    it("exige les DEUX étiquettes : école ET solaire", () => {
+      expect(proposes(projet({ thematiques: [SOLAIRE], sites: [ECOLE] }))).toEqual(["atoutbiodiv-solaire"]);
+    });
+
+    it("n'attrape pas n'importe quelle installation solaire", () => {
+      expect(proposes(projet({ thematiques: [SOLAIRE] }))).toEqual([]);
+    });
+
+    it("n'attrape pas n'importe quel projet d'école", () => {
+      expect(proposes(projet({ sites: [ECOLE] }))).toEqual([]);
+    });
+
+    it("dit LAQUELLE des deux étiquettes manque", () => {
+      const requises = QUESTIONNAIRES.find((q) => q.slug === "atoutbiodiv-solaire")!.etiquettesRequises;
+
+      // « il manque la thématique X » se corrige. « score 0,11 » ne se corrige pas.
+      expect(etiquettesManquantes(projet({ sites: [ECOLE] }), requises)).toEqual([
+        { axe: "thematiques", label: "Agrivoltaïsme, panneaux solaires sur le bâti" },
+      ]);
+    });
+  });
+
+  describe("Projet non classifié", () => {
+    it("ne propose aucun questionnaire", () => {
+      // Le garde qui compte vraiment est ailleurs (content/index.ts refuse de démarrer si un
+      // questionnaire n'exige AUCUNE étiquette — une conjonction vide est vraie, il serait alors
+      // proposé à tout le monde). Ici on vérifie l'autre bout : un projet vide ne matche rien.
+      expect(proposes(projet({}))).toEqual([]);
+    });
   });
 });

--- a/api/src/questionnaires/questionnaire-contract.spec.ts
+++ b/api/src/questionnaires/questionnaire-contract.spec.ts
@@ -5,7 +5,7 @@ const def = (): QuestionnaireDef => ({
   version: 1,
   source: { nom: "Test" },
   banniere: { titre: "T", sousTitre: "ST" },
-  classification: { thematiques: [], sites: [], interventions: [] },
+  etiquettesRequises: { thematiques: [], sites: [], interventions: [] },
   questions: [
     {
       id: "q1",

--- a/api/src/questionnaires/questionnaire-contract.ts
+++ b/api/src/questionnaires/questionnaire-contract.ts
@@ -1,4 +1,4 @@
-import { AideClassification } from "@/aides/dto/aides.dto";
+import type { EtiquettesRequises } from "./content/classification";
 
 // ============================================================
 // Contrat des questionnaires spécialisés
@@ -116,12 +116,11 @@ export interface RecommandationsFichier {
 
 export interface QuestionnaireDef extends QuestionnaireFichier {
   /**
-   * Classification du questionnaire sur les trois axes (thématiques, sites, interventions),
-   * dans les MÊMES taxonomies fermées que les projets et les aides. C'est elle qui alimente
-   * le score de matching qui décide de l'éligibilité. Détenue par Communs, pas par le
-   * partenaire. NE SORT JAMAIS DE L'API.
+   * Étiquettes qui DÉFINISSENT le questionnaire, dans les taxonomies fermées du schéma commun.
+   * Le projet doit TOUTES les porter (confiance ≥ SEUIL_CONFIANCE) pour que le questionnaire lui
+   * soit proposé. Détenues par Communs, pas par le partenaire. NE SORTENT JAMAIS DE L'API.
    */
-  classification: AideClassification;
+  etiquettesRequises: EtiquettesRequises;
   recommandations: RecommandationDef[];
 }
 

--- a/api/src/questionnaires/questionnaires.module.ts
+++ b/api/src/questionnaires/questionnaires.module.ts
@@ -1,7 +1,6 @@
 import { Module } from "@nestjs/common";
 import { DatabaseModule } from "@database/database.module";
 import { ProjetsModule } from "@projets/projets.module";
-import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { QuestionnairesController } from "./questionnaires.controller";
 import { QuestionnairesService } from "./questionnaires.service";
 
@@ -13,7 +12,6 @@ import { QuestionnairesService } from "./questionnaires.service";
     // Le moteur de matching est fourni ici plutôt qu'importé depuis AidesModule : il est
     // sans état (seule dépendance : le logger), et importer AidesModule entraînerait ses
     // files BullMQ et son cron de synchronisation quotidienne, dont on n'a aucun besoin.
-    AidesMatchingService,
   ],
   // Exporté : la source de recommandations « questionnaire » consomme le même état
   // (éligibilité + réponses réconciliées), pour éviter d'en avoir deux définitions.

--- a/api/src/questionnaires/questionnaires.service.ts
+++ b/api/src/questionnaires/questionnaires.service.ts
@@ -4,9 +4,9 @@ import { DatabaseService } from "@database/database.service";
 import { projetQuestionnaireReponses } from "@database/schema";
 import { ProjetResponse } from "@projets/dto/projet.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
-import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { AideClassification } from "@/aides/dto/aides.dto";
 import { QUESTIONNAIRES } from "./content";
+import { SEUIL_CONFIANCE, type EtiquettesRequises } from "./content/classification";
 import { calculerStatut, reconcilierReponses, type QuestionnaireDef } from "./questionnaire-contract";
 import { ProjetQuestionnairesResponse, QuestionnaireResponse } from "./dto/questionnaire.dto";
 
@@ -14,27 +14,41 @@ import { ProjetQuestionnairesResponse, QuestionnaireResponse } from "./dto/quest
 export interface QuestionnaireEtat {
   def: QuestionnaireDef;
   reponses: Record<string, string>;
-  /** Score de pertinence normalisé [0, 1] du questionnaire pour ce projet. Interne — n'est pas exposé. */
-  score: number;
 }
 
 /**
- * Score normalisé minimal pour qu'un questionnaire soit proposé. Même échelle que le
- * `cutoff` des aides (AidesController) : normalizedScore = score / score maximal théorique
- * du projet, donc 1.0 = le questionnaire couvre parfaitement toutes les étiquettes du projet.
+ * Le projet porte-t-il TOUTES les étiquettes qui définissent ce questionnaire ?
  *
- * 0.3 est délibérément permissif : un questionnaire est une invitation à réfléchir, pas une
- * aide qu'on propose à tort. Un faux positif coûte un onglet ignoré ; un faux négatif coûte
- * une opportunité de biodiversité jamais vue.
+ * C'est un CRITÈRE, pas un score. Un questionnaire n'est pas une aide : une aide ressemble plus
+ * ou moins à un projet, un score a du sens ; un questionnaire, lui, s'applique ou ne s'applique
+ * pas — c'est une salle des fêtes, ou ce n'en est pas une.
+ *
+ * Le score de matching a été essayé et il échoue ici pour une raison structurelle : il normalise
+ * par le maximum du PROJET. Deux projets portant tous deux « Place ou centre-bourg » obtenaient
+ * 1,00 et 0,11 selon que leur classification était pauvre ou riche — le second était écarté alors
+ * qu'il est bel et bien une place. Un critère ne doit pas dépendre de la largeur de la
+ * classification d'à côté.
+ *
+ * Exporté : le back-office rejoue la même fonction pour expliquer POURQUOI un questionnaire n'est
+ * pas proposé (quelle étiquette manque). Une seule définition de l'éligibilité, jamais deux.
  */
-export const SEUIL_ELIGIBILITE = 0.3;
+export function etiquettesManquantes(
+  scoresProjet: AideClassification,
+  requises: EtiquettesRequises,
+): { axe: keyof EtiquettesRequises; label: string }[] {
+  const porte = (axe: keyof EtiquettesRequises, label: string) =>
+    scoresProjet[axe].some((e) => e.label === label && e.score >= SEUIL_CONFIANCE);
+
+  return (["thematiques", "sites", "interventions"] as const).flatMap((axe) =>
+    requises[axe].filter((label) => !porte(axe, label)).map((label) => ({ axe, label })),
+  );
+}
 
 @Injectable()
 export class QuestionnairesService {
   constructor(
     private readonly dbService: DatabaseService,
     private readonly getProjetsService: GetProjetsService,
-    private readonly matchingService: AidesMatchingService,
   ) {}
 
   /**
@@ -56,35 +70,25 @@ export class QuestionnairesService {
       .from(projetQuestionnaireReponses)
       .where(eq(projetQuestionnaireReponses.projetId, projetId));
 
-    const etats = eligibles.map(({ def, score }) => {
+    const etats = eligibles.map((def) => {
       const ligne = lignes.find((l) => l.slug === def.slug);
-      return { def, score, reponses: reconcilierReponses(def, ligne?.reponses ?? {}) };
+      return { def, reponses: reconcilierReponses(def, ligne?.reponses ?? {}) };
     });
 
     return { projet, etats };
   }
 
   /**
-   * Éligibilité par SCORE, avec le moteur de matching des aides : le questionnaire est
-   * classifié sur les mêmes trois axes qu'un projet et qu'une aide (thématiques 0.45, sites
-   * 0.35, interventions 0.20), et son score normalisé contre la classification du projet
-   * décide s'il est proposé.
-   *
-   * Un projet non encore classifié (classificationScores absent — le job LLM n'a pas tourné)
-   * ne se voit proposer aucun questionnaire. Contrairement aux aides, on ne renvoie pas 202 :
-   * la spec impose une liste vide en 200 pour un projet non éligible, et un questionnaire
+   * Un projet non encore classifié (le job LLM n'a pas tourné) ne se voit proposer aucun
+   * questionnaire : on ne sait rien de lui, on n'a donc rien à lui demander. Contrairement aux
+   * aides, on ne renvoie pas 202 — la spec impose une liste vide en 200, et un questionnaire
    * n'est pas un contenu qu'on fait attendre.
    */
-  private questionnairesEligibles(projet: ProjetResponse): { def: QuestionnaireDef; score: number }[] {
+  private questionnairesEligibles(projet: ProjetResponse): QuestionnaireDef[] {
     const scoresProjet = projet.classificationScores;
     if (!scoresProjet) return [];
 
-    const parSlug = new Map<string, AideClassification>(QUESTIONNAIRES.map((q) => [q.slug, q.classification]));
-
-    return this.matchingService
-      .match(scoresProjet, parSlug, QUESTIONNAIRES.length)
-      .filter((m) => m.normalizedScore >= SEUIL_ELIGIBILITE)
-      .map((m) => ({ def: questionnaireRequis(m.idAt), score: m.normalizedScore }));
+    return QUESTIONNAIRES.filter((def) => etiquettesManquantes(scoresProjet, def.etiquettesRequises).length === 0);
   }
 
   async findForProjet(projetId: string): Promise<ProjetQuestionnairesResponse> {
@@ -167,11 +171,4 @@ export class QuestionnairesService {
       reponses,
     };
   }
-}
-
-/** Le moteur ne renvoie que des clés issues du registre : un slug absent serait un bug interne. */
-function questionnaireRequis(slug: string): QuestionnaireDef {
-  const def = QUESTIONNAIRES.find((q) => q.slug === slug);
-  if (!def) throw new Error(`Questionnaire "${slug}" absent du registre alors que le matching l'a retourné`);
-  return def;
 }

--- a/api/test/admin.e2e-spec.ts
+++ b/api/test/admin.e2e-spec.ts
@@ -69,55 +69,57 @@ describe("Back-office (e2e)", () => {
   });
 
   describe("GET /admin/contenu", () => {
-    it("expose les conditions et la classification d'éligibilité — l'inverse du contrat public", async () => {
+    it("expose les conditions et les étiquettes d'éligibilité — l'inverse du contrat public", async () => {
       const { body } = await appeler<{
         questionnaires: {
           slug: string;
-          classification: AideClassification;
+          etiquettesRequises: { sites: string[] };
           recommandations: { condition: unknown }[];
         }[];
-        seuils: { eligibilite: number; pertinence: number };
+        seuils: { pertinence: number };
       }>("GET", "/admin/contenu");
 
       const salle = body.questionnaires.find((q) => q.slug === "atoutbiodiv-salle")!;
 
-      expect(salle.classification.sites.map((s) => s.label)).toContain(
-        "Salle des fêtes, salle associative, pôle musical",
-      );
+      expect(salle.etiquettesRequises.sites).toContain("Salle des fêtes, salle associative, pôle musical");
       expect(salle.recommandations.every((r) => r.condition !== undefined)).toBe(true);
-      expect(body.seuils.eligibilite).toBeGreaterThan(0);
+      expect(body.seuils.pertinence).toBeGreaterThan(0);
     });
   });
 
   describe("POST /admin/simuler", () => {
-    it("simule sur un projet RÉEL et renvoie TOUS les candidats, y compris sous le seuil", async () => {
+    it("renvoie TOUS les questionnaires, proposés comme non proposés", async () => {
       const projetId = await creerProjet(SALLE);
 
       const { status, body } = await appeler<{
-        questionnaires: { slug: string; score: number; retenu: boolean }[];
+        questionnaires: { slug: string; retenu: boolean }[];
       }>("POST", "/admin/simuler", { projetId });
 
       expect(status).toBe(200);
-      // Les 4 questionnaires sont rendus, pas seulement le retenu : sans la distribution
-      // complète, on ne peut pas régler le seuil.
+      // Les 4 sont rendus, pas seulement le retenu : n'afficher que les retenus ne dirait pas
+      // POURQUOI les autres sont absents, et c'est justement ce qu'on vient chercher ici.
       expect(body.questionnaires).toHaveLength(4);
 
       const retenus = body.questionnaires.filter((q) => q.retenu);
       expect(retenus.map((q) => q.slug)).toEqual(["atoutbiodiv-salle"]);
-      expect(body.questionnaires.every((q) => typeof q.score === "number")).toBe(true);
     });
 
-    it("explique le score par les étiquettes partagées avec le projet", async () => {
+    it("dit QUELLE étiquette manque à un questionnaire non proposé", async () => {
       const projetId = await creerProjet(SALLE);
 
       const { body } = await appeler<{
-        questionnaires: { slug: string; etiquettesCommunes: { sites: string[] } }[];
+        questionnaires: { slug: string; retenu: boolean; etiquettesManquantes: { axe: string; label: string }[] }[];
       }>("POST", "/admin/simuler", { projetId });
 
-      const salle = body.questionnaires.find((q) => q.slug === "atoutbiodiv-salle")!;
+      const parSlug = new Map(body.questionnaires.map((q) => [q.slug, q]));
 
-      // Un score de 0,9 sans justification est un chiffre opaque. C'est ça qui le rend actionnable.
-      expect(salle.etiquettesCommunes.sites).toContain("Salle des fêtes, salle associative, pôle musical");
+      // Le proposé n'a rien qui manque — c'est la définition même de l'éligibilité.
+      expect(parSlug.get("atoutbiodiv-salle")!.etiquettesManquantes).toEqual([]);
+
+      // « il manque le lieu Place ou centre-bourg » se corrige. « score 0,11 » ne se corrige pas.
+      expect(parSlug.get("atoutbiodiv-place")!.etiquettesManquantes).toEqual([
+        { axe: "sites", label: "Place ou centre-bourg" },
+      ]);
     });
 
     it("simule l'effet de réponses SANS les enregistrer", async () => {

--- a/back-office/src/App.tsx
+++ b/back-office/src/App.tsx
@@ -148,10 +148,7 @@ export default function App() {
                         </div>
                       )}
 
-                      <Questionnaires
-                        questionnaires={simulation.questionnaires}
-                        seuil={simulation.seuils.eligibilite}
-                      />
+                      <Questionnaires questionnaires={simulation.questionnaires} />
                       <Services services={simulation.services} seuilApi={simulation.seuils.pertinence} />
                     </>
                   )}

--- a/back-office/src/components/Questionnaires.tsx
+++ b/back-office/src/components/Questionnaires.tsx
@@ -1,20 +1,29 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
-import { Etiquettes } from "./Etiquettes";
 import type { QuestionnaireSimule } from "../types";
 
+const LIBELLE_AXE: Record<string, string> = {
+  thematiques: "thématique",
+  sites: "lieu",
+  interventions: "modalité",
+};
+
 /**
- * Les questionnaires confrontés au projet, TOUS rendus — y compris ceux sous le seuil.
+ * Les questionnaires confrontés au projet, TOUS rendus — proposés comme non proposés.
  *
- * Ne montrer que les retenus empêcherait de voir les quasi-retenus, qui sont précisément ceux
- * qui disent si le seuil est bien posé. Un questionnaire à 0,29 sous un seuil de 0,30 est une
- * information ; son absence n'en est pas une.
+ * L'éligibilité est un CRITÈRE, pas un score : on affiche donc ce qui MANQUE au projet, jamais un
+ * chiffre. « non proposé, score 0,11 » n'apprend rien et ne se corrige pas. « il manque le lieu
+ * Place ou centre-bourg » dit exactement quoi regarder : soit la classification du projet est
+ * fausse, soit le questionnaire vise autre chose.
  */
-export function Questionnaires({ questionnaires, seuil }: { questionnaires: QuestionnaireSimule[]; seuil: number }) {
+export function Questionnaires({ questionnaires }: { questionnaires: QuestionnaireSimule[] }) {
   return (
     <section className={fr.cx("fr-mt-6w")}>
       <h2 className={fr.cx("fr-h4")}>Questionnaires</h2>
-      <p className={fr.cx("fr-text--sm")}>Seuil d&apos;éligibilité : {seuil.toFixed(2)}</p>
+      <p className={fr.cx("fr-text--sm")}>
+        Un questionnaire est proposé si le projet porte <strong>toutes</strong> ses étiquettes définissantes, avec une
+        confiance ≥ 0,80.
+      </p>
 
       {questionnaires.map((q) => {
         const declenchees = q.recommandations.filter((r) => r.declenchee);
@@ -26,13 +35,21 @@ export function Questionnaires({ questionnaires, seuil }: { questionnaires: Ques
                 <h3 className={fr.cx("fr-card__title", "fr-h6", "fr-mb-1w")}>
                   {q.slug}{" "}
                   <Badge severity={q.retenu ? "success" : "warning"} noIcon small>
-                    {q.score.toFixed(2)} — {q.retenu ? "proposé" : "non proposé"}
+                    {q.retenu ? "proposé" : "non proposé"}
                   </Badge>
                 </h3>
 
-                <div className={fr.cx("fr-mb-1w")}>
-                  <Etiquettes communes={q.etiquettesCommunes} />
-                </div>
+                {q.etiquettesManquantes.length > 0 && (
+                  <p className={fr.cx("fr-text--sm", "fr-mb-1w")}>
+                    Il manque au projet :{" "}
+                    {q.etiquettesManquantes.map((e, i) => (
+                      <span key={`${e.axe}-${e.label}`}>
+                        {i > 0 && ", "}
+                        <strong>{e.label}</strong> <span className={fr.cx("fr-text--xs")}>({LIBELLE_AXE[e.axe]})</span>
+                      </span>
+                    ))}
+                  </p>
+                )}
 
                 <p className={fr.cx("fr-text--xs", "fr-mb-0")}>
                   statut : {q.statut} — {q.recommandations.length} recommandation

--- a/back-office/src/types.ts
+++ b/back-office/src/types.ts
@@ -18,8 +18,13 @@ export type Classification = Record<Axe, EtiquetteScoree[]>;
 export type EtiquettesCommunes = Record<Axe, string[]>;
 
 export interface Seuils {
-  eligibilite: number;
   pertinence: number;
+}
+
+/** Une étiquette que le projet ne porte PAS — c'est ce qui explique un questionnaire non proposé. */
+export interface EtiquetteManquante {
+  axe: Axe;
+  label: string;
 }
 
 export interface RecommandationSimulee {
@@ -31,9 +36,9 @@ export interface RecommandationSimulee {
 
 export interface QuestionnaireSimule {
   slug: string;
-  score: number;
   retenu: boolean;
-  etiquettesCommunes: EtiquettesCommunes;
+  /** Vide = proposé. Sinon, exactement ce qui manque au projet. */
+  etiquettesManquantes: EtiquetteManquante[];
   statut: "non_commence" | "en_cours" | "termine";
   reponses: Record<string, string>;
   recommandations: RecommandationSimulee[];
@@ -83,7 +88,7 @@ export interface QuestionnaireContenu {
   slug: string;
   libelle: string;
   version: number;
-  classification: Classification;
+  etiquettesRequises: Record<Axe, string[]>;
   questions: { id: string; libelle: string; options: { id: string; libelle: string }[] }[];
   recommandations: { id: string; titre: string; condition: unknown }[];
 }


### PR DESCRIPTION
Un questionnaire n'est pas une aide. Une aide **ressemble** plus ou moins à un projet : un score a du sens. Un questionnaire, lui, s'applique ou ne s'applique pas — c'est une salle des fêtes, ou ce n'en est pas une.

## Le score échouait pour une raison structurelle

Il normalise par le maximum du **projet**. Vérifié sur staging via `/admin/simuler`, sur deux projets qui portent **tous deux** l'étiquette « Place ou centre-bourg » :

| Projet | Étiquette « Place ou centre-bourg » | Score obtenu | Verdict |
|---|---|---|---|
| Salle des fêtes *(classification pauvre)* | — | 1,00 sur son propre questionnaire | proposé |
| **Création d'un espace commercial** *(classification riche)* | **0,82 — c'est une place** | **0,11** | **écarté à tort** |

Le second est bel et bien une place. Il était écarté **uniquement parce qu'il est bien classifié sur les autres axes** : son maximum est élevé, donc un questionnaire qui ne matche qu'un lieu n'en couvre qu'une fraction. Un critère ne doit pas dépendre de la largeur de la classification d'à côté.

## La règle

Le projet doit porter **toutes** les étiquettes définissantes du questionnaire, avec une confiance ≥ 0,8 (le même seuil que les aides — en dessous, le job LLM hésite, on n'agit pas dessus).

| Questionnaire | Étiquettes requises |
|---|---|
| `atoutbiodiv-salle` | lieu « Salle des fêtes, salle associative, pôle musical » |
| `atoutbiodiv-place` | lieu « Place ou centre-bourg » |
| `atoutbiodiv-piste` | thématique « Voie douce, piste cyclable » |
| `atoutbiodiv-solaire` | thématique « Agrivoltaïsme, panneaux solaires sur le bâti » **ET** lieu « Ecole » |

**Toutes**, et non au moins une. Sur `atoutbiodiv-solaire`, « école » seule attraperait n'importe quel projet d'école, et « solaire » seul n'importe quelle installation photovoltaïque. C'est la conjonction qui définit le questionnaire.

Les classifications sont aussi **resserrées** : chaque questionnaire ne porte plus que sur ce qui le **définit**, plus sur ce qui lui est adjacent (« Végétalisation d'espaces publics », « Rénovation bâtiment »…). Ces étiquettes connexes faisaient remonter le questionnaire « salle des fêtes » sur des projets qui n'en étaient pas.

## Bénéfice secondaire, et il est gros

On peut dire **pourquoi** un questionnaire n'est pas proposé : « il manque au projet le lieu *Place ou centre-bourg* ».

Ça se corrige — soit la classification du projet est fausse, soit le questionnaire vise autre chose. « Score 0,11 » ne se corrigeait pas. Le back-office affiche donc les étiquettes manquantes, plus un chiffre.

## Garde-fou ajouté

Un questionnaire qui n'exigerait **aucune** étiquette serait proposé à **tous** les projets : une conjonction vide est vraie. Le chargeur refuse désormais de démarrer dans ce cas. C'est contre-intuitif, donc c'est testé.

## Bandeaux

Les quatre titres étaient identiques et génériques (« Optimisez le potentiel biodiversité de votre projet »). Ils nomment désormais la nature du projet — « …de votre projet **de salle des fêtes ou de salle polyvalente** » — pour que la collectivité reconnaisse son projet et comprenne pourquoi on le lui propose.

⚠️ **Contenu partenaire** : ces JSON appartiennent à AtoutBiodiv. La formulation doit leur être soumise.

## Tests

528 unitaires, 53 e2e. Les tests d'éligibilité sont ancrés sur les classifications **réelles** de trois projets de staging, telles que le job LLM les a produites — pas sur des cas composés à la main, qui sont trop propres et disent ce qu'on veut entendre. Le cas « espace commercial » verrouille la régression décrite plus haut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)