### PR TITLE
feat(ajouts-manuels): ajouter à la main une aide ou un service sur un projet

### DIFF
--- a/api/src/aides/aides-perimetre.module.ts
+++ b/api/src/aides/aides-perimetre.module.ts
@@ -1,0 +1,23 @@
+import { Module } from "@nestjs/common";
+import { ConfigModule } from "@nestjs/config";
+import { AidesCacheService } from "./aides-cache.service";
+import { AidesPerimetreService } from "./aides-perimetre.service";
+import { AidesTerritoiresService } from "./aides-territoires.service";
+
+/**
+ * Module minimal : « les aides disponibles sur un territoire ».
+ *
+ * Il existe pour casser un cycle. Le module Aides a besoin des ajouts manuels (pour les fondre
+ * dans ses listes) ; les ajouts manuels ont besoin du périmètre (pour refuser une aide hors
+ * territoire). Sans ce module intermédiaire, les deux s'importeraient mutuellement.
+ *
+ * Il PORTE le cache et le client Aides-territoires (au lieu de les laisser au module Aides) :
+ * deux modules qui les fourniraient chacun de leur côté ouvriraient deux connexions Redis et
+ * deux caches distincts — donc deux vérités.
+ */
+@Module({
+  imports: [ConfigModule],
+  providers: [AidesTerritoiresService, AidesCacheService, AidesPerimetreService],
+  exports: [AidesTerritoiresService, AidesCacheService, AidesPerimetreService],
+})
+export class AidesPerimetreModule {}

--- a/api/src/aides/aides-perimetre.service.ts
+++ b/api/src/aides/aides-perimetre.service.ts
@@ -1,0 +1,109 @@
+import { Injectable } from "@nestjs/common";
+import { CustomLogger } from "@logging/logger.service";
+import { AidesCacheService } from "./aides-cache.service";
+import { AidesTerritoiresService } from "./aides-territoires.service";
+import { Aide } from "./dto/aides.dto";
+
+/**
+ * « Quelles aides sont disponibles sur le territoire de ce projet ? »
+ *
+ * Extrait du contrôleur des aides pour qu'il n'existe qu'UNE définition de cette question. Les
+ * ajouts manuels en ont besoin eux aussi : avant d'accepter qu'un agent attache une aide à un
+ * projet, on vérifie qu'elle est bien sur son périmètre — sinon on créerait un ajout impossible à
+ * résoudre à la lecture, donc invisible, sans le moindre message d'erreur.
+ *
+ * POURQUOI PAR PÉRIMÈTRE, ET PAS PAR ID. Aides-territoires ne sait PAS récupérer une aide par son
+ * identifiant : `/aids/<id>/` répond 404, et `?id=<n>` est silencieusement IGNORÉ — la requête
+ * renvoie alors le catalogue entier. Un code qui aurait fait confiance à ce paramètre aurait
+ * « marché » en renvoyant n'importe quoi. La seule voie d'accès est la requête par territoire.
+ */
+@Injectable()
+export class AidesPerimetreService {
+  /** Clés en cours de rafraîchissement — évite d'empiler N refresh sur la même clé. */
+  private readonly refreshingKeys = new Set<string>();
+
+  constructor(
+    private readonly atService: AidesTerritoiresService,
+    private readonly cacheService: AidesCacheService,
+    private readonly logger: CustomLogger,
+  ) {}
+
+  /** Codes INSEE des communes du projet. Les autres types de collectivité n'en portent pas. */
+  extractCodesInsee(collectivites: { type: string; codeInsee: string | null }[]): string[] {
+    const codes: string[] = [];
+    for (const c of collectivites) {
+      if (c.type === "Commune" && c.codeInsee) {
+        codes.push(c.codeInsee);
+      }
+    }
+    return [...new Set(codes)];
+  }
+
+  /**
+   * Aides de plusieurs territoires (union), dédoublonnées par id.
+   *
+   * `perimeter_codes[]` accepte n'importe quel code de périmètre (INSEE commune, code
+   * département…) directement.
+   */
+  async fetchAidesForPerimeterCodes(codes: string[]): Promise<Aide[]> {
+    if (codes.length === 0) {
+      return this.fetchAidesForTerritory({}, "no territory filter");
+    }
+
+    const seenIds = new Set<number>();
+    const allAides: Aide[] = [];
+
+    for (const code of codes) {
+      const aides = await this.fetchAidesForTerritory({ "perimeter_codes[]": code }, `perimeter_code=${code}`);
+
+      for (const aide of aides) {
+        if (!seenIds.has(aide.id)) {
+          seenIds.add(aide.id);
+          allAides.push(aide);
+        }
+      }
+    }
+
+    this.logger.log(`Fetched ${allAides.length} unique aides across ${codes.length} territories`);
+    return allAides;
+  }
+
+  /**
+   * Aides d'un territoire, en stale-while-revalidate : on sert immédiatement ce qu'on a, et on
+   * rafraîchit en tâche de fond si c'est périmé.
+   */
+  async fetchAidesForTerritory(params: Record<string, string>, label: string): Promise<Aide[]> {
+    const cacheKey = this.cacheService.buildKey(params);
+    const cached = await this.cacheService.get(cacheKey);
+
+    if (cached?.status === "fresh") {
+      return cached.aides;
+    }
+
+    if (cached?.status === "stale") {
+      this.refreshInBackground(cacheKey, params, label);
+      return cached.aides;
+    }
+
+    this.logger.log(`Cache miss for AT aides, fetching from API (${label})`);
+    const aides = await this.atService.fetchAides(params);
+    await this.cacheService.set(cacheKey, aides);
+    return aides;
+  }
+
+  private refreshInBackground(cacheKey: string, params: Record<string, string>, label: string): void {
+    if (this.refreshingKeys.has(cacheKey)) return;
+    this.refreshingKeys.add(cacheKey);
+
+    this.atService
+      .fetchAides(params)
+      .then((aides) => this.cacheService.set(cacheKey, aides))
+      .then(() => this.logger.log(`Background refresh complete for ${label}`))
+      .catch((error) =>
+        this.logger.error(`Background refresh failed for ${label}`, {
+          error: { message: error instanceof Error ? error.message : "Unknown error" },
+        }),
+      )
+      .finally(() => this.refreshingKeys.delete(cacheKey));
+  }
+}

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -1,7 +1,10 @@
 /* eslint-disable @typescript-eslint/unbound-method */
 import { Response } from "express";
 import { Queue } from "bullmq";
+import type { Request as ExpressRequest } from "express";
 import { AidesController } from "./aides.controller";
+import { AidesPerimetreService } from "./aides-perimetre.service";
+import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
 import { AidesTerritoiresService } from "./aides-territoires.service";
 import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
@@ -62,6 +65,9 @@ function makeAide(id: number): Aide {
     date_updated: null,
   };
 }
+
+/** La plateforme est dérivée de la clé d'API par le garde ; en test on la pose directement. */
+const makeReq = () => ({ serviceType: "MEC" }) as unknown as ExpressRequest;
 
 describe("AidesController", () => {
   let controller: AidesController;
@@ -139,12 +145,24 @@ describe("AidesController", () => {
       delete: jest.fn(),
     } as unknown as jest.Mocked<AidesFeedbackService>;
 
+    // Le VRAI service de périmètre, construit sur les mêmes mocks : la logique SWR a changé de
+    // maison (elle était privée dans le contrôleur), pas de comportement. Les tests ci-dessous la
+    // valident donc toujours réellement, au lieu de valider un mock.
+    const perimetreService = new AidesPerimetreService(mockAtService, mockCacheService, mockLogger);
+
+    // Aucun ajout manuel par défaut : ces tests portent sur le moteur.
+    const mockAjoutsManuels = {
+      actifs: jest.fn().mockResolvedValue(new Map()),
+    } as unknown as jest.Mocked<AjoutsManuelsService>;
+
     controller = new AidesController(
       mockAtService,
       mockClassificationService,
       mockMatchingService,
       mockTextualMatchingService,
       mockCacheService,
+      perimetreService,
+      mockAjoutsManuels,
       mockWarmupService,
       mockFeedbackService,
       mockProjetsService,
@@ -162,7 +180,7 @@ describe("AidesController", () => {
       };
       mockCacheService.get.mockResolvedValue(freshResult);
 
-      await controller.listAides("test-id", makeRes().res);
+      await controller.listAides(makeReq(), "test-id", makeRes().res);
 
       expect(mockAtService.fetchAides).not.toHaveBeenCalled();
       expect(mockCacheService.set).not.toHaveBeenCalled();
@@ -176,7 +194,7 @@ describe("AidesController", () => {
       mockCacheService.get.mockResolvedValue(staleResult);
       mockAtService.fetchAides.mockResolvedValue([makeAide(1), makeAide(2)]);
 
-      await controller.listAides("test-id", makeRes().res);
+      await controller.listAides(makeReq(), "test-id", makeRes().res);
 
       // Background refresh is fire-and-forget — wait a tick
       await new Promise((r) => setTimeout(r, 10));
@@ -197,8 +215,8 @@ describe("AidesController", () => {
 
       // Two concurrent requests for the same stale territory
       await Promise.all([
-        controller.listAides("test-id", makeRes().res),
-        controller.listAides("test-id", makeRes().res),
+        controller.listAides(makeReq(), "test-id", makeRes().res),
+        controller.listAides(makeReq(), "test-id", makeRes().res),
       ]);
 
       await new Promise((r) => setTimeout(r, 100));
@@ -211,7 +229,7 @@ describe("AidesController", () => {
       mockCacheService.get.mockResolvedValue(null);
       mockAtService.fetchAides.mockResolvedValue([makeAide(1)]);
 
-      await controller.listAides("test-id", makeRes().res);
+      await controller.listAides(makeReq(), "test-id", makeRes().res);
 
       expect(mockAtService.fetchAides).toHaveBeenCalled();
       expect(mockCacheService.set).toHaveBeenCalled();
@@ -230,7 +248,7 @@ describe("AidesController", () => {
       } as never);
 
       const { res, statusSpy, headerSpy } = makeRes();
-      const result = (await controller.listAides("test-id", res)) as ClassificationPendingResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", res)) as ClassificationPendingResponse;
 
       expect(statusSpy).toHaveBeenCalledWith(202);
       expect(headerSpy).toHaveBeenCalledWith("Retry-After", "15");
@@ -256,7 +274,7 @@ describe("AidesController", () => {
       } as never);
 
       const { res } = makeRes();
-      await controller.listAides("test-id", res);
+      await controller.listAides(makeReq(), "test-id", res);
 
       expect(mockQualificationQueue.add).toHaveBeenCalledWith(
         PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
@@ -276,7 +294,7 @@ describe("AidesController", () => {
       } as never);
 
       const { res } = makeRes();
-      await controller.listAides("test-id", res);
+      await controller.listAides(makeReq(), "test-id", res);
 
       expect(mockQualificationQueue.add).toHaveBeenCalledWith(
         PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
@@ -301,7 +319,7 @@ describe("AidesController", () => {
       } as never);
 
       const { res } = makeRes();
-      const result = (await controller.listAides("test-id", res)) as ClassificationPendingResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", res)) as ClassificationPendingResponse;
 
       expect(result.classificationTriggered).toBe(false);
       expect(mockQualificationQueue.add).not.toHaveBeenCalled();
@@ -324,7 +342,7 @@ describe("AidesController", () => {
       } as never);
 
       const { res } = makeRes();
-      const result = (await controller.listAides("test-id", res)) as ClassificationPendingResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", res)) as ClassificationPendingResponse;
 
       expect(removeSpy).toHaveBeenCalled();
       expect(mockQualificationQueue.add).toHaveBeenCalled();
@@ -336,7 +354,7 @@ describe("AidesController", () => {
       mockAtService.fetchAides.mockResolvedValue([]);
 
       const { res } = makeRes();
-      const result = (await controller.listAides("test-id", res)) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", res)) as AidesListResponse;
 
       expect(result.status).toBe("no_aides_on_perimeter");
       expect(result.aides).toEqual([]);
@@ -349,7 +367,7 @@ describe("AidesController", () => {
       mockMatchingService.match.mockReturnValue([]);
 
       const { res } = makeRes();
-      const result = (await controller.listAides("test-id", res)) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", res)) as AidesListResponse;
 
       expect(result.status).toBe("no_match");
       expect(result.aides).toEqual([]);
@@ -372,7 +390,7 @@ describe("AidesController", () => {
       ]);
 
       const { res } = makeRes();
-      const result = (await controller.listAides("test-id", res)) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", res)) as AidesListResponse;
 
       expect(result.status).toBe("ok");
       expect(result.aides).toHaveLength(1);
@@ -497,7 +515,7 @@ describe("AidesController", () => {
     it("should NOT call the textual service when the flag is off (default)", async () => {
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
 
-      await controller.listAides("test-id", makeRes().res);
+      await controller.listAides(makeReq(), "test-id", makeRes().res);
 
       expect(mockTextualMatchingService.score).not.toHaveBeenCalled();
     });
@@ -506,7 +524,7 @@ describe("AidesController", () => {
       mockConfigService.get.mockReturnValue("true");
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
 
-      await controller.listAides("test-id", makeRes().res);
+      await controller.listAides(makeReq(), "test-id", makeRes().res);
 
       expect(mockTextualMatchingService.score).toHaveBeenCalled();
     });
@@ -522,7 +540,7 @@ describe("AidesController", () => {
         ]),
       );
 
-      const result = (await controller.listAides("test-id", makeRes().res)) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", makeRes().res)) as AidesListResponse;
 
       expect(result.status).toBe("ok");
       expect(result.aides).toHaveLength(1);
@@ -553,7 +571,7 @@ describe("AidesController", () => {
         ]),
       );
 
-      const result = (await controller.listAides("test-id", makeRes().res)) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", makeRes().res)) as AidesListResponse;
 
       // combiné : aide2 = 0.85*0.9 + 0.15*0.1 = 0.78 ; aide1 = 0.85*0 + 0.15*0.9 = 0.135
       expect(result.aides.map((a) => a.id)).toEqual([2, 1]);
@@ -563,7 +581,7 @@ describe("AidesController", () => {
       mockConfigService.get.mockReturnValue(undefined); // flag env off
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
 
-      await controller.listAides("test-id", makeRes().res, undefined, undefined, "true");
+      await controller.listAides(makeReq(), "test-id", makeRes().res, undefined, undefined, "true");
 
       expect(mockTextualMatchingService.score).toHaveBeenCalled();
     });
@@ -572,7 +590,7 @@ describe("AidesController", () => {
       mockConfigService.get.mockReturnValue("true"); // flag env on
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
 
-      await controller.listAides("test-id", makeRes().res, undefined, undefined, "false");
+      await controller.listAides(makeReq(), "test-id", makeRes().res, undefined, undefined, "false");
 
       expect(mockTextualMatchingService.score).not.toHaveBeenCalled();
     });
@@ -599,6 +617,7 @@ describe("AidesController", () => {
 
       // cutoff = 6e argument
       const result = (await controller.listAides(
+        makeReq(),
         "test-id",
         makeRes().res,
         undefined,
@@ -615,7 +634,7 @@ describe("AidesController", () => {
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1), makeAide(2)], status: "fresh" });
       mockMatchingService.match.mockReturnValue([matchResult("1", 0.5, 0.5), matchResult("2", 0.05, 0.05)]);
 
-      const result = (await controller.listAides("test-id", makeRes().res)) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", makeRes().res)) as AidesListResponse;
 
       expect(result.aides.map((a) => a.id)).toEqual([1, 2]);
     });
@@ -623,7 +642,17 @@ describe("AidesController", () => {
     it("passes aideThreshold and projetThreshold to the matching service", async () => {
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
 
-      await controller.listAides("test-id", makeRes().res, undefined, undefined, undefined, undefined, "0.7", "0.6");
+      await controller.listAides(
+        makeReq(),
+        "test-id",
+        makeRes().res,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        "0.7",
+        "0.6",
+      );
 
       expect(mockMatchingService.match).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.any(Number), {
         projet: 0.6,
@@ -634,7 +663,7 @@ describe("AidesController", () => {
     it("leaves thresholds undefined when the params are absent (matcher applies its default)", async () => {
       mockCacheService.get.mockResolvedValue({ aides: [makeAide(1)], status: "fresh" });
 
-      await controller.listAides("test-id", makeRes().res);
+      await controller.listAides(makeReq(), "test-id", makeRes().res);
 
       expect(mockMatchingService.match).toHaveBeenCalledWith(expect.anything(), expect.anything(), expect.any(Number), {
         projet: undefined,
@@ -644,7 +673,7 @@ describe("AidesController", () => {
 
     it("rejects an out-of-range score parameter with 400", async () => {
       await expect(
-        controller.listAides("test-id", makeRes().res, undefined, undefined, undefined, "1.5"),
+        controller.listAides(makeReq(), "test-id", makeRes().res, undefined, undefined, undefined, "1.5"),
       ).rejects.toThrow();
     });
   });
@@ -731,7 +760,7 @@ describe("AidesController", () => {
 
     it("should accept projetId (camelCase, canonical) without warning", async () => {
       const { res } = makeRes();
-      const result = (await controller.listAides("test-id", res)) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), "test-id", res)) as AidesListResponse;
 
       expect(result.status).toBe("ok");
       expect(mockProjetsService.findOneWithSource).toHaveBeenCalledWith("test-id");
@@ -740,7 +769,7 @@ describe("AidesController", () => {
 
     it("should accept projet_id (snake_case, deprecated) and log a warning", async () => {
       const { res } = makeRes();
-      const result = (await controller.listAides(undefined, res, undefined, "test-id")) as AidesListResponse;
+      const result = (await controller.listAides(makeReq(), undefined, res, undefined, "test-id")) as AidesListResponse;
 
       expect(result.status).toBe("ok");
       expect(mockProjetsService.findOneWithSource).toHaveBeenCalledWith("test-id");
@@ -749,7 +778,13 @@ describe("AidesController", () => {
 
     it("should prefer projetId when both are provided (no warning)", async () => {
       const { res } = makeRes();
-      const result = (await controller.listAides("camel-id", res, undefined, "snake-id")) as AidesListResponse;
+      const result = (await controller.listAides(
+        makeReq(),
+        "camel-id",
+        res,
+        undefined,
+        "snake-id",
+      )) as AidesListResponse;
 
       expect(result.status).toBe("ok");
       expect(mockProjetsService.findOneWithSource).toHaveBeenCalledWith("camel-id");
@@ -758,7 +793,7 @@ describe("AidesController", () => {
 
     it("should throw 400 when neither projetId nor projet_id is provided", async () => {
       const { res } = makeRes();
-      await expect(controller.listAides(undefined, res)).rejects.toThrow("projetId is required");
+      await expect(controller.listAides(makeReq(), undefined, res)).rejects.toThrow("projetId is required");
     });
   });
 });

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -7,13 +7,14 @@ import {
   ParseUUIDPipe,
   Post,
   Query,
+  Req,
   Res,
   UseGuards,
   BadRequestException,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
 import { ConfigService } from "@nestjs/config";
-import { Response } from "express";
+import { Request, Response } from "express";
 import { InjectQueue } from "@nestjs/bullmq";
 import { Queue } from "bullmq";
 import { ApiKeyGuard } from "@/auth/api-key-guard";
@@ -30,6 +31,9 @@ import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
 import { AidesTextualMatchingService } from "./aides-textual-matching.service";
 import { AidesCacheService } from "./aides-cache.service";
+import { AidesPerimetreService } from "./aides-perimetre.service";
+import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
+import { AjoutManuelResponse } from "@/ajouts-manuels/dto/ajout-manuel.dto";
 import { AidesWarmupService } from "./aides-warmup.service";
 import { AidesFeedbackService } from "./aides-feedback.service";
 import { AideFeedbackResponse, CreateAideFeedbackRequest, DeleteAideFeedbackRequest } from "./dto/aide-feedback.dto";
@@ -60,14 +64,14 @@ const MIN_TEXTUAL_RESCUE = 0.35;
 @Controller("aides")
 @UseGuards(ApiKeyGuard)
 export class AidesController {
-  private readonly refreshingKeys = new Set<string>();
-
   constructor(
     private readonly atService: AidesTerritoiresService,
     private readonly classificationService: AideClassificationService,
     private readonly matchingService: AidesMatchingService,
     private readonly textualMatchingService: AidesTextualMatchingService,
     private readonly cacheService: AidesCacheService,
+    private readonly perimetreService: AidesPerimetreService,
+    private readonly ajoutsManuels: AjoutsManuelsService,
     private readonly warmupService: AidesWarmupService,
     private readonly feedbackService: AidesFeedbackService,
     private readonly projetsService: GetProjetsService,
@@ -137,6 +141,7 @@ export class AidesController {
       "Le projet n'a pas encore été classifié. Un job de classification a été (re)déclenché. Réessayer après `retryAfter` secondes.",
   })
   async listAides(
+    @Req() request: Request,
     @Query("projetId") projetIdCamel: string | undefined,
     @Res({ passthrough: true }) res: Response,
     @Query("limit") limit?: string,
@@ -180,7 +185,7 @@ export class AidesController {
     }
 
     // 3. Extract code_insee from project collectivités
-    const codesInsee = this.extractCodesInsee(projet.collectivites);
+    const codesInsee = this.perimetreService.extractCodesInsee(projet.collectivites);
 
     if (codesInsee.length === 0) {
       this.logger.warn(
@@ -189,7 +194,14 @@ export class AidesController {
     }
 
     // 4. Fetch aides for each territory (union) — deduplicate by aide id
-    const allAides = await this.fetchAidesForPerimeterCodes(codesInsee);
+    const allAides = await this.perimetreService.fetchAidesForPerimeterCodes(codesInsee);
+
+    // Les aides AJOUTÉES À LA MAIN sur ce projet. On les résout dans les aides du périmètre : une
+    // aide n'est persistée nulle part, et Aides-territoires ne sait pas la récupérer par son id.
+    // Si elle a été clôturée ou dépubliée depuis l'ajout, elle n'est plus là — elle cesse alors de
+    // s'afficher, ce qui est le comportement voulu : mieux vaut ne rien montrer que d'envoyer une
+    // collectivité candidater à une aide morte.
+    const ajouts = await this.ajoutsManuels.actifs(projetId, "aide", request.serviceType!);
 
     if (allAides.length === 0) {
       return { status: "no_aides_on_perimeter", aides: [], total: 0 };
@@ -203,6 +215,7 @@ export class AidesController {
     //      logique partagée avec POST /aides/recherche.
     const textualEnabled = this.isTextualMatchingEnabled(textualOverride);
     return this.buildMatchedResponse(projet.classificationScores, allAides, classifications, {
+      ajouts,
       maxResults,
       cutoff,
       thresholds: { projet: projetThreshold, aide: aideThreshold },
@@ -237,7 +250,7 @@ export class AidesController {
     // Périmètre : union des aides disponibles sur les communes demandées
     // (codes INSEE — mêmes clés de cache que GET /aides).
     const communes = [...new Set(dto.communes.map((c) => c.trim()).filter(Boolean))];
-    const allAides = await this.fetchAidesForPerimeterCodes(communes);
+    const allAides = await this.perimetreService.fetchAidesForPerimeterCodes(communes);
 
     if (allAides.length === 0) {
       return { status: "no_aides_on_perimeter", aides: [], total: 0 };
@@ -268,6 +281,11 @@ export class AidesController {
     allAides: Aide[],
     classifications: Map<string, AideClassification>,
     options: {
+      /**
+       * Ajouts manuels du projet, indexés par id d'aide. Absent sur POST /aides/recherche, qui
+       * n'a pas de projet de référence : sans projet, il n'y a pas d'ajout manuel possible.
+       */
+      ajouts?: Map<string, { ajout: AjoutManuelResponse }>;
       maxResults: number;
       cutoff: number;
       thresholds: MatchThresholds;
@@ -275,7 +293,7 @@ export class AidesController {
       textualText: string;
     },
   ): AidesListResponse {
-    const { maxResults, cutoff, thresholds, textualEnabled, textualText } = options;
+    const { ajouts, maxResults, cutoff, thresholds, textualEnabled, textualText } = options;
 
     // Matching thématique — on passe allAides.length pour ne rien pré-trancher
     // avant la combinaison textuelle optionnelle.
@@ -336,11 +354,38 @@ export class AidesController {
         .slice(0, maxResults);
     }
 
-    if (enriched.length === 0) {
+    // Les ajouts manuels EN TÊTE, et ils échappent au cutoff comme au maxResults : quelqu'un les a
+    // délibérément mis là, précisément parce que le moteur les ratait. Les soumettre au filtre qui
+    // les a ratés serait absurde.
+    //
+    // Un ajout qui n'est plus sur le périmètre (aide clôturée, dépubliée) n'apparaît simplement
+    // pas : on ne peut pas le résoudre, et on ne fabrique rien.
+    const manuels: AideWithClassification[] = [];
+    if (ajouts && ajouts.size > 0) {
+      const parId = new Map(allAides.map((a) => [String(a.id), a]));
+      for (const [idAt, { ajout }] of ajouts) {
+        const aide = parId.get(idAt);
+        if (!aide) continue;
+        manuels.push({
+          ...aide,
+          classification: classifications.get(idAt) ?? undefined,
+          ajoutManuel: ajout,
+        });
+      }
+      manuels.sort((a, b) => a.name.localeCompare(b.name));
+    }
+
+    // Un ajout manuel qui serait AUSSI remonté par le moteur ne doit apparaître qu'une fois — avec
+    // sa marque d'ajout. Le dédoublonnage se fait ici, pas dans le client.
+    const idsManuels = new Set(manuels.map((a) => String(a.id)));
+    const duMoteur = enriched.filter((a) => !idsManuels.has(String(a.id)));
+    const aides = [...manuels, ...duMoteur];
+
+    if (aides.length === 0) {
       return { status: "no_match", aides: [], total: allAides.length };
     }
 
-    return { status: "ok", aides: enriched, total: allAides.length };
+    return { status: "ok", aides, total: allAides.length };
   }
 
   /**
@@ -479,87 +524,4 @@ export class AidesController {
   /**
    * Extract unique code_insee values from project collectivités (Communes only)
    */
-  private extractCodesInsee(collectivites: { type: string; codeInsee: string | null }[]): string[] {
-    const codes: string[] = [];
-    for (const c of collectivites) {
-      if (c.type === "Commune" && c.codeInsee) {
-        codes.push(c.codeInsee);
-      }
-    }
-    return [...new Set(codes)];
-  }
-
-  /**
-   * Fetch aides for a single territory with SWR.
-   * Returns aides immediately (from cache if available), triggers background refresh if stale.
-   */
-  private async fetchAidesForTerritory(params: Record<string, string>, label: string): Promise<Aide[]> {
-    const cacheKey = this.cacheService.buildKey(params);
-    const cached = await this.cacheService.get(cacheKey);
-
-    if (cached?.status === "fresh") {
-      return cached.aides;
-    }
-
-    if (cached?.status === "stale") {
-      // Serve stale data immediately, refresh in background
-      this.refreshInBackground(cacheKey, params, label);
-      return cached.aides;
-    }
-
-    // Cache miss — synchronous fetch (cold start)
-    this.logger.log(`Cache miss for AT aides, fetching from API (${label})`);
-    const aides = await this.atService.fetchAides(params);
-    await this.cacheService.set(cacheKey, aides);
-    return aides;
-  }
-
-  /**
-   * Fire-and-forget background refresh for stale cache entries.
-   */
-  private refreshInBackground(cacheKey: string, params: Record<string, string>, label: string): void {
-    if (this.refreshingKeys.has(cacheKey)) return;
-    this.refreshingKeys.add(cacheKey);
-
-    this.atService
-      .fetchAides(params)
-      .then((aides) => this.cacheService.set(cacheKey, aides))
-      .then(() => this.logger.log(`Background refresh complete for ${label}`))
-      .catch((error) =>
-        this.logger.error(`Background refresh failed for ${label}`, {
-          error: { message: error instanceof Error ? error.message : "Unknown error" },
-        }),
-      )
-      .finally(() => this.refreshingKeys.delete(cacheKey));
-  }
-
-  /**
-   * Fetch aides for multiple territories (union). Deduplicates by aide id.
-   * Uses AT's perimeter_codes[] parameter which accepts any perimeter code
-   * (code INSEE de commune, code département…) directly.
-   */
-  private async fetchAidesForPerimeterCodes(codes: string[]): Promise<Aide[]> {
-    if (codes.length === 0) {
-      return this.fetchAidesForTerritory({}, "no territory filter");
-    }
-
-    const seenIds = new Set<number>();
-    const allAides: Aide[] = [];
-
-    for (const code of codes) {
-      const params = { "perimeter_codes[]": code };
-      const aides = await this.fetchAidesForTerritory(params, `perimeter_code=${code}`);
-
-      // Deduplicate across territories
-      for (const aide of aides) {
-        if (!seenIds.has(aide.id)) {
-          seenIds.add(aide.id);
-          allAides.push(aide);
-        }
-      }
-    }
-
-    this.logger.log(`Fetched ${allAides.length} unique aides across ${codes.length} territories`);
-    return allAides;
-  }
 }

--- a/api/src/aides/aides.module.ts
+++ b/api/src/aides/aides.module.ts
@@ -8,12 +8,12 @@ import { ProjetsModule } from "@projets/projets.module";
 import { ClassificationModule } from "@/projet-qualification/classification/classification.module";
 import { PROJECT_QUALIFICATION_QUEUE_NAME } from "@/projet-qualification/const";
 import { CustomLogger } from "@logging/logger.service";
+import { AjoutsManuelsModule } from "@/ajouts-manuels/ajouts-manuels.module";
+import { AidesPerimetreModule } from "./aides-perimetre.module";
 import { AidesController } from "./aides.controller";
-import { AidesTerritoiresService } from "./aides-territoires.service";
 import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
 import { AidesTextualMatchingService } from "./aides-textual-matching.service";
-import { AidesCacheService } from "./aides-cache.service";
 import { AidesSyncProcessor, AIDES_SYNC_QUEUE_NAME, AIDES_SYNC_JOB_NAME } from "./aides-sync.processor";
 import { AidesWarmupService } from "./aides-warmup.service";
 import { AidesFeedbackService } from "./aides-feedback.service";
@@ -23,6 +23,8 @@ import { AidesFeedbackService } from "./aides-feedback.service";
     ConfigModule,
     ProjetsModule,
     ClassificationModule,
+    AidesPerimetreModule,
+    AjoutsManuelsModule,
     BullModule.registerQueue({
       name: AIDES_SYNC_QUEUE_NAME,
     }),
@@ -36,11 +38,9 @@ import { AidesFeedbackService } from "./aides-feedback.service";
   ],
   controllers: [AidesController],
   providers: [
-    AidesTerritoiresService,
     AideClassificationService,
     AidesMatchingService,
     AidesTextualMatchingService,
-    AidesCacheService,
     AidesWarmupService,
     AidesFeedbackService,
     AidesSyncProcessor,

--- a/api/src/aides/dto/aides.dto.ts
+++ b/api/src/aides/dto/aides.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { AjoutManuelResponse } from "@/ajouts-manuels/dto/ajout-manuel.dto";
 import { Type } from "class-transformer";
 import {
   ArrayNotEmpty,
@@ -202,6 +203,15 @@ export class AideMatchResult {
 export class AideWithClassification extends Aide {
   @ApiProperty({ required: false, type: AideClassification })
   classification?: AideClassification;
+
+  @ApiPropertyOptional({
+    type: AjoutManuelResponse,
+    description:
+      "Présent si cette aide a été ajoutée À LA MAIN sur ce projet, et non retenue par le moteur. " +
+      "Porte le message de la personne qui l'a ajoutée (« recommandée par la DDT lors du COPIL »). " +
+      "Ces aides remontent en tête et échappent au cutoff : quelqu'un les a délibérément mises là.",
+  })
+  ajoutManuel?: AjoutManuelResponse;
 
   @ApiProperty({
     required: false,

--- a/api/src/ajouts-manuels/ajout-manuel-contract.ts
+++ b/api/src/ajouts-manuels/ajout-manuel-contract.ts
@@ -35,6 +35,33 @@ export const TYPE_AJOUT = "ajout_manuel";
 
 export type ObjetAjoutable = "aide" | "service_numerique";
 
+/**
+ * Un service HORS catalogue, décrit par l'agent lui-même : un outil local, un service partenaire
+ * pas encore benchmarké. Figé dans le payload de la décision.
+ *
+ * POURQUOI FIGER EST LÉGITIME ICI, ALORS QUE ÇA NE L'ÉTAIT PAS POUR UNE AIDE. Le catalogue de
+ * services est LE NÔTRE : un service qui n'y figure pas existe quand même, et personne d'autre ne
+ * peut le décrire — l'agent EST la source de vérité, il n'y a rien à tenir en phase. Une aide, au
+ * contraire, n'existe que dans Aides-territoires : la recopier, ce serait entretenir une copie qui
+ * vieillit face à une autorité qui, elle, continue d'évoluer.
+ *
+ * Un service DU catalogue n'est jamais recopié, pour la même raison retournée : sa fiche reste la
+ * source, et elle continuera de changer (logo, description, lien). Le figer ici l'aurait dédoublé.
+ */
+export interface ServiceLibre {
+  nom: string;
+  description: string;
+  url?: string;
+  libelleLien?: string;
+  operateur?: string;
+  logoUrl?: string;
+}
+
+/** Le payload d'une décision `ajout_manuel` : présent seulement pour un service hors catalogue. */
+export interface PayloadAjout {
+  service?: ServiceLibre;
+}
+
 /** Ce qu'on rend au client : la trace de l'ajout, attachée à l'aide ou au service concerné. */
 export interface AjoutManuel {
   /** L'id de la décision — c'est lui qu'il faut fournir pour révoquer l'ajout. */
@@ -44,4 +71,6 @@ export interface AjoutManuel {
   /** Qui a ajouté : la plateforme émettrice, dérivée de la clé d'API. */
   plateforme: string;
   date: string;
+  /** Services uniquement : le service a été saisi à la main, il n'est pas au catalogue. */
+  horsCatalogue?: boolean;
 }

--- a/api/src/ajouts-manuels/ajout-manuel-contract.ts
+++ b/api/src/ajouts-manuels/ajout-manuel-contract.ts
@@ -1,0 +1,47 @@
+/**
+ * Ajouts manuels : une aide ou un service numérique qu'un humain attache à un projet parce que le
+ * moteur ne l'a pas trouvé — ou l'a mal classé.
+ *
+ * PAS DE NOUVELLE TABLE. Un ajout manuel EST une décision humaine, et le journal
+ * `decisions_humaines.decisions` en porte déjà toute la sémantique : append-only, auteur, date,
+ * message (`commentaire`), plateforme dérivée de la clé d'API, cloisonnement par plateforme, et
+ * révocation par `supersedes`. Le réimplémenter à côté aurait produit un second journal, moins
+ * bon, à tenir en phase avec le premier.
+ *
+ * RETIRER UN AJOUT = RÉVOQUER LA DÉCISION (verdict='annule' + supersedes). On n'invente pas de
+ * verdict « retire » : il ferait double emploi avec la révocation universelle, et deux façons de
+ * dire la même chose finissent toujours par diverger.
+ *
+ * ON NE STOCKE QUE L'IDENTIFIANT — et c'est le point délicat.
+ *
+ * Une aide n'est persistée nulle part : elle vit en cache Redis, rechargée à chaque requête depuis
+ * Aides-territoires et filtrée par le territoire du projet. On la résout donc AU FRAIS à chaque
+ * lecture, parmi les aides du périmètre. Si elle a été clôturée ou dépubliée entre-temps, elle
+ * cesse simplement de s'afficher : mieux vaut ne rien montrer que d'envoyer une collectivité
+ * candidater à une aide morte, ce que ferait un instantané figé.
+ *
+ * On ne peut pas faire mieux, et ce n'est pas un choix : Aides-territoires NE SAIT PAS récupérer
+ * une aide par son id. `/aids/<id>/` répond 404, et `?id=<n>` est silencieusement IGNORÉ — la
+ * requête renvoie alors le catalogue entier. Un code qui aurait fait confiance à ce paramètre
+ * aurait « marché » en renvoyant n'importe quoi.
+ *
+ * D'où la garde à l'écriture (cf. AjoutsManuelsService.ajouterAide) : on refuse d'ajouter une aide
+ * absente du périmètre du projet. Sans elle, on créerait un ajout qui ne s'afficherait JAMAIS,
+ * sans le moindre message — une panne parfaitement silencieuse.
+ */
+
+/** L'unique type de décision de ce module — le vocabulaire est fermé (cf. decision-contract.ts). */
+export const TYPE_AJOUT = "ajout_manuel";
+
+export type ObjetAjoutable = "aide" | "service_numerique";
+
+/** Ce qu'on rend au client : la trace de l'ajout, attachée à l'aide ou au service concerné. */
+export interface AjoutManuel {
+  /** L'id de la décision — c'est lui qu'il faut fournir pour révoquer l'ajout. */
+  decisionId: string;
+  /** Pourquoi cet ajout — « recommandée par la DDT lors du COPIL du 12/03 ». */
+  message?: string;
+  /** Qui a ajouté : la plateforme émettrice, dérivée de la clé d'API. */
+  plateforme: string;
+  date: string;
+}

--- a/api/src/ajouts-manuels/ajout-manuel-contract.ts
+++ b/api/src/ajouts-manuels/ajout-manuel-contract.ts
@@ -71,6 +71,13 @@ export interface AjoutManuel {
   /** Qui a ajouté : la plateforme émettrice, dérivée de la clé d'API. */
   plateforme: string;
   date: string;
-  /** Services uniquement : le service a été saisi à la main, il n'est pas au catalogue. */
+  /**
+   * PROVENANCE, services uniquement : le service ne vient pas de notre catalogue, ses informations
+   * ont été saisies par un agent. Le client peut le présenter différemment — pas de fiche chez
+   * nous, pas de logo hébergé, pas de caution éditoriale.
+   *
+   * Ce n'est pas une information de classification : les thématiques ne servent qu'à sélectionner
+   * un service pour un projet, et un ajout manuel a déjà été sélectionné, par un humain.
+   */
   horsCatalogue?: boolean;
 }

--- a/api/src/ajouts-manuels/ajouts-manuels.controller.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.controller.ts
@@ -1,0 +1,87 @@
+import { Body, Controller, Delete, Param, ParseUUIDPipe, Post, Req, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { Request } from "express";
+import { ApiKeyGuard } from "@/auth/api-key-guard";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
+import { AjoutsManuelsService } from "./ajouts-manuels.service";
+import { AjoutAideRequest, AjoutCreeResponse, AjoutServiceRequest } from "./dto/ajout-manuel.dto";
+
+/**
+ * Ajouter à la main une aide ou un service numérique à un projet, quand le moteur ne l'a pas trouvé.
+ *
+ * Ces ajouts sont des DÉCISIONS HUMAINES : ils sont écrits dans le journal append-only, avec leur
+ * auteur, leur date et leur plateforme (dérivée de la clé d'API, jamais du corps de requête). Le
+ * retrait est une révocation, pas une suppression — on garde la trace de ce qui a été fait.
+ *
+ * CLOISONNEMENT PAR PLATEFORME, comme pour toute décision : une plateforme ne voit et ne retire
+ * que ses propres ajouts.
+ *
+ * Les ajouts remontent ensuite FONDUS dans `GET /aides?projetId=` et `GET /projets/:id/services`,
+ * marqués `ajoutManuel`. Aucun endpoint de lecture séparé : sinon chaque consommateur devrait
+ * refaire la fusion, et finirait par l'oublier.
+ */
+@ApiBearerAuth()
+@ApiTags("Ajouts manuels")
+@Controller("projets/:projetId")
+@UseGuards(ApiKeyGuard)
+export class AjoutsManuelsController {
+  constructor(private readonly service: AjoutsManuelsService) {}
+
+  @TrackApiUsage()
+  @Post("aides/ajouts")
+  @ApiOperation({
+    summary: "Ajouter une aide à la main sur un projet",
+    description:
+      "L'instantané (`nom`, `url`) est OBLIGATOIRE : une aide n'est persistée dans aucune table — " +
+      "elle vit en cache, rechargée depuis Aides-territoires et filtrée par le territoire du projet. " +
+      "Sans instantané, l'aide ajoutée disparaîtrait le jour où Aides-territoires cesserait de la " +
+      "renvoyer, sans le moindre message. À la lecture, les données fraîches priment quand l'aide " +
+      "est encore connue ; l'instantané ne sert que de repli.",
+  })
+  @ApiEndpointResponses({ successStatus: 201, response: AjoutCreeResponse, description: "Ajout enregistré" })
+  ajouterAide(
+    @Req() request: Request,
+    @Param("projetId", ParseUUIDPipe) projetId: string,
+    @Body() dto: AjoutAideRequest,
+  ): Promise<AjoutCreeResponse> {
+    return this.service.ajouterAide(projetId, dto, request.serviceType!);
+  }
+
+  @TrackApiUsage()
+  @Post("services/ajouts")
+  @ApiOperation({
+    summary: "Ajouter un service numérique à la main sur un projet",
+    description:
+      "Le service doit exister au catalogue (404 sinon) : un slug inconnu produirait un ajout " +
+      "qu'aucune lecture ne saurait résoudre — donc invisible, donc un bug silencieux.",
+  })
+  @ApiEndpointResponses({ successStatus: 201, response: AjoutCreeResponse, description: "Ajout enregistré" })
+  ajouterService(
+    @Req() request: Request,
+    @Param("projetId", ParseUUIDPipe) projetId: string,
+    @Body() dto: AjoutServiceRequest,
+  ): Promise<AjoutCreeResponse> {
+    return this.service.ajouterService(projetId, dto, request.serviceType!);
+  }
+
+  @TrackApiUsage()
+  @Delete("ajouts/:decisionId")
+  @ApiOperation({
+    summary: "Retirer un ajout manuel",
+    description:
+      "RÉVOCATION, pas suppression : le journal est append-only. On enregistre un événement qui " +
+      "annule le précédent, et l'ajout cesse de remonter. La trace de ce qui a été fait, et défait, " +
+      "reste. Une plateforme ne peut retirer que ses propres ajouts.",
+  })
+  // 200, pas 201 : DELETE ne crée rien du point de vue du client. Le fait qu'on écrive une
+  // nouvelle ligne dans le journal (la révocation) est un détail d'implémentation.
+  @ApiEndpointResponses({ successStatus: 200, response: AjoutCreeResponse, description: "Ajout retiré" })
+  retirer(
+    @Req() request: Request,
+    @Param("projetId", ParseUUIDPipe) _projetId: string,
+    @Param("decisionId", ParseUUIDPipe) decisionId: string,
+  ): Promise<AjoutCreeResponse> {
+    return this.service.retirer(decisionId, request.serviceType!);
+  }
+}

--- a/api/src/ajouts-manuels/ajouts-manuels.controller.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.controller.ts
@@ -53,8 +53,14 @@ export class AjoutsManuelsController {
   @ApiOperation({
     summary: "Ajouter un service numérique à la main sur un projet",
     description:
-      "Le service doit exister au catalogue (404 sinon) : un slug inconnu produirait un ajout " +
-      "qu'aucune lecture ne saurait résoudre — donc invisible, donc un bug silencieux.",
+      "Deux façons, et EXACTEMENT une des deux.\n\n" +
+      "• `slug` — le service est AU CATALOGUE. On ne recopie rien : sa fiche reste la source de " +
+      "vérité et continuera d'évoluer (logo, description, lien). Un slug inconnu est un 404.\n\n" +
+      "• `service` — il n'y est PAS (outil local, service partenaire pas encore benchmarké). " +
+      "L'agent le décrit lui-même : nom, description, lien. Ces informations sont figées, car " +
+      "c'est lui la source — il n'y a aucune autorité extérieure à tenir en phase, contrairement " +
+      "à une aide. Sa classification reste inconnue : `categories` et `thematiques` sortent VIDES, " +
+      "on ne les invente pas, et le drapeau `ajoutManuel.horsCatalogue` le signale au client.",
   })
   @ApiEndpointResponses({ successStatus: 201, response: AjoutCreeResponse, description: "Ajout enregistré" })
   ajouterService(

--- a/api/src/ajouts-manuels/ajouts-manuels.controller.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.controller.ts
@@ -59,8 +59,11 @@ export class AjoutsManuelsController {
       "• `service` — il n'y est PAS (outil local, service partenaire pas encore benchmarké). " +
       "L'agent le décrit lui-même : nom, description, lien. Ces informations sont figées, car " +
       "c'est lui la source — il n'y a aucune autorité extérieure à tenir en phase, contrairement " +
-      "à une aide. Sa classification reste inconnue : `categories` et `thematiques` sortent VIDES, " +
-      "on ne les invente pas, et le drapeau `ajoutManuel.horsCatalogue` le signale au client.",
+      "à une aide.\n\n" +
+      "On ne lui demande PAS de thématiques : elles ne servent qu'à SÉLECTIONNER un service pour " +
+      "un projet, et ici la sélection est déjà faite. `categories` et `thematiques` sortent donc " +
+      "vides. Le drapeau `ajoutManuel.horsCatalogue` signale la PROVENANCE : ce service n'a pas de " +
+      "fiche chez nous et son logo n'est pas hébergé par l'API.",
   })
   @ApiEndpointResponses({ successStatus: 201, response: AjoutCreeResponse, description: "Ajout enregistré" })
   ajouterService(

--- a/api/src/ajouts-manuels/ajouts-manuels.module.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.module.ts
@@ -1,0 +1,24 @@
+import { Module } from "@nestjs/common";
+import { DatabaseModule } from "@database/database.module";
+import { ProjetsModule } from "@projets/projets.module";
+import { DecisionsModule } from "@/decisions/decisions.module";
+import { AidesPerimetreModule } from "@/aides/aides-perimetre.module";
+import { AjoutsManuelsController } from "./ajouts-manuels.controller";
+import { AjoutsManuelsService } from "./ajouts-manuels.service";
+
+/**
+ * `DecisionsModule` est importé, pas dupliqué : l'écriture passe par `DecisionsService`, qui porte
+ * les invariants du journal (append-only, plateforme dérivée de la clé, compatibilité de
+ * `supersedes`). Les insérer nous-mêmes aurait demandé de réimplémenter ces garde-fous — donc de
+ * les laisser diverger.
+ *
+ * `AjoutsManuelsService` est EXPORTÉ : les modules Aides et Services numériques en ont besoin pour
+ * fondre les ajouts dans leurs listes.
+ */
+@Module({
+  imports: [DatabaseModule, ProjetsModule, DecisionsModule, AidesPerimetreModule],
+  controllers: [AjoutsManuelsController],
+  providers: [AjoutsManuelsService],
+  exports: [AjoutsManuelsService],
+})
+export class AjoutsManuelsModule {}

--- a/api/src/ajouts-manuels/ajouts-manuels.service.spec.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.service.spec.ts
@@ -1,0 +1,85 @@
+import { BadRequestException } from "@nestjs/common";
+import { DatabaseService } from "@database/database.service";
+import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
+import { DecisionsService } from "@/decisions/decisions.service";
+import { AidesPerimetreService } from "@/aides/aides-perimetre.service";
+import { Aide } from "@/aides/dto/aides.dto";
+import { AjoutsManuelsService } from "./ajouts-manuels.service";
+
+/**
+ * LA GARDE DU PÉRIMÈTRE, et pourquoi elle existe.
+ *
+ * Une aide n'est persistée nulle part : elle vit en cache, rechargée depuis Aides-territoires et
+ * filtrée par le territoire du projet. On ne la résout donc à la lecture QUE parmi les aides du
+ * périmètre — et on ne peut pas faire autrement : Aides-territoires ne sait pas récupérer une aide
+ * par son id (`/aids/<id>/` répond 404, et `?id=<n>` est silencieusement ignoré, renvoyant le
+ * catalogue entier).
+ *
+ * Conséquence : accepter une aide hors périmètre créerait un ajout que la lecture ne saurait JAMAIS
+ * résoudre. Invisible, sans le moindre message. On refuse donc à l'écriture, là où on peut encore
+ * l'expliquer à l'agent.
+ */
+describe("AjoutsManuelsService — garde du périmètre (aides)", () => {
+  const PROJET_ID = "019f5c56-5873-72ce-94cd-b7b00e5c619c";
+
+  const aide = (id: number) => ({ id, name: `Aide ${id}` }) as Aide;
+
+  const construire = (aidesDuPerimetre: Aide[]) => {
+    const decisionsService = { create: jest.fn().mockResolvedValue({ id: "decision-1" }) };
+    const perimetre = {
+      extractCodesInsee: jest.fn().mockReturnValue(["44109"]),
+      fetchAidesForPerimeterCodes: jest.fn().mockResolvedValue(aidesDuPerimetre),
+    };
+    const projets = {
+      findOneWithSource: jest.fn().mockResolvedValue({
+        projet: { id: PROJET_ID, collectivites: [{ type: "Commune", codeInsee: "44109" }] },
+      }),
+    };
+
+    const service = new AjoutsManuelsService(
+      {} as unknown as DatabaseService,
+      decisionsService as unknown as DecisionsService,
+      projets as unknown as GetProjetsService,
+      perimetre as unknown as AidesPerimetreService,
+    );
+
+    return { service, decisionsService };
+  };
+
+  it("accepte une aide présente sur le territoire du projet", async () => {
+    const { service, decisionsService } = construire([aide(111), aide(222)]);
+
+    const { decisionId } = await service.ajouterAide(PROJET_ID, { aideId: 222, message: "Vue en COPIL" }, "MEC");
+
+    expect(decisionId).toBe("decision-1");
+
+    // Le message va dans `commentaire` — le champ que toute décision porte déjà. Le dupliquer dans
+    // le payload aurait créé deux endroits où écrire la même chose.
+    expect(decisionsService.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        typeDecision: "ajout_manuel",
+        objetAType: "projet",
+        objetAId: PROJET_ID,
+        objetBType: "aide",
+        objetBId: "222",
+        commentaire: "Vue en COPIL",
+      }),
+      "MEC",
+    );
+  });
+
+  it("REFUSE une aide absente du territoire, plutôt que de créer un ajout invisible", async () => {
+    const { service, decisionsService } = construire([aide(111)]);
+
+    await expect(service.ajouterAide(PROJET_ID, { aideId: 999 }, "MEC")).rejects.toThrow(BadRequestException);
+
+    // Rien n'a été écrit : un ajout irrésoluble ne doit pas exister du tout.
+    expect(decisionsService.create).not.toHaveBeenCalled();
+  });
+
+  it("nomme l'aide fautive dans l'erreur", async () => {
+    const { service } = construire([aide(111)]);
+
+    await expect(service.ajouterAide(PROJET_ID, { aideId: 999 }, "MEC")).rejects.toThrow(/999/);
+  });
+});

--- a/api/src/ajouts-manuels/ajouts-manuels.service.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.service.ts
@@ -1,0 +1,211 @@
+import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { and, eq } from "drizzle-orm";
+import { DatabaseService } from "@database/database.service";
+import { decisions, servicesNumeriques } from "@database/schema";
+import { activeDecisionPredicate, notTombstonePredicate } from "@/decisions/active-decisions";
+import { ANNULE_VERDICT } from "@/decisions/decision-contract";
+import { DecisionsService } from "@/decisions/decisions.service";
+import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
+import { AidesPerimetreService } from "@/aides/aides-perimetre.service";
+import { TYPE_AJOUT, type AjoutManuel, type ObjetAjoutable } from "./ajout-manuel-contract";
+import { AjoutAideRequest, AjoutServiceRequest } from "./dto/ajout-manuel.dto";
+
+const ALIAS = "decisions";
+
+/**
+ * Ajouts manuels d'aides et de services numériques sur un projet.
+ *
+ * Ce service N'ÉCRIT PAS EN BASE lui-même : il délègue à `DecisionsService`, qui porte déjà les
+ * invariants du journal (append-only, plateforme dérivée de la clé, compatibilité de `supersedes`).
+ * Écrire directement dans la table aurait contourné ces garde-fous — et il aurait fallu les
+ * réimplémenter à l'identique, donc les laisser diverger.
+ */
+@Injectable()
+export class AjoutsManuelsService {
+  constructor(
+    private readonly dbService: DatabaseService,
+    private readonly decisionsService: DecisionsService,
+    private readonly getProjetsService: GetProjetsService,
+    private readonly perimetreService: AidesPerimetreService,
+  ) {}
+
+  /**
+   * `findOneWithSource` d'abord : ajouter une aide à un projet inexistant doit être un 404, pas
+   * une décision orpheline dans le journal. Le journal ne référence pas ses objets par clé
+   * étrangère (ils vivent dans plusieurs schémas), donc rien ne l'empêcherait sans cette garde.
+   */
+  async ajouterAide(projetId: string, dto: AjoutAideRequest, plateforme: string): Promise<{ decisionId: string }> {
+    const { projet } = await this.getProjetsService.findOneWithSource(projetId);
+
+    // LA GARDE QUI COMPTE. Une aide n'est résolue qu'à travers les aides du périmètre du projet —
+    // Aides-territoires ne sait pas la récupérer par son id. Accepter une aide hors périmètre
+    // créerait donc un ajout que la lecture ne saurait JAMAIS résoudre : invisible, sans le moindre
+    // message. Une panne parfaitement silencieuse. On refuse à l'écriture, là où on peut encore
+    // l'expliquer.
+    const codesInsee = this.perimetreService.extractCodesInsee(projet.collectivites);
+    const aides = await this.perimetreService.fetchAidesForPerimeterCodes(codesInsee);
+
+    if (!aides.some((a) => a.id === dto.aideId)) {
+      throw new BadRequestException(
+        `L'aide ${dto.aideId} n'est pas disponible sur le territoire de ce projet. Elle ne pourrait ` +
+          `pas être affichée : une aide n'est résolue que parmi celles du périmètre du projet.`,
+      );
+    }
+
+    return this.enregistrer(projetId, "aide", String(dto.aideId), dto.message, dto.auteur, plateforme);
+  }
+
+  /**
+   * Le slug doit exister dans le catalogue : ajouter un service inconnu produirait une ligne
+   * qu'aucune lecture ne saurait résoudre — un ajout invisible, donc un bug silencieux.
+   */
+  async ajouterService(
+    projetId: string,
+    dto: AjoutServiceRequest,
+    plateforme: string,
+  ): Promise<{ decisionId: string }> {
+    await this.getProjetsService.findOneWithSource(projetId);
+
+    const [service] = await this.dbService.database
+      .select({ slug: servicesNumeriques.slug })
+      .from(servicesNumeriques)
+      .where(eq(servicesNumeriques.slug, dto.slug))
+      .limit(1);
+
+    if (!service) {
+      throw new NotFoundException(`Service numérique "${dto.slug}" inconnu du catalogue.`);
+    }
+
+    return this.enregistrer(projetId, "service_numerique", dto.slug, dto.message, dto.auteur, plateforme);
+  }
+
+  private async enregistrer(
+    projetId: string,
+    objetBType: ObjetAjoutable,
+    objetBId: string,
+    message: string | undefined,
+    auteur: string | undefined,
+    plateforme: string,
+  ): Promise<{ decisionId: string }> {
+    const { id } = await this.decisionsService.create(
+      {
+        typeDecision: TYPE_AJOUT,
+        objetAType: "projet",
+        objetAId: projetId,
+        objetBType,
+        objetBId,
+        // Le message vit dans `commentaire`, le champ que toute décision porte déjà. Le dupliquer
+        // dans le payload aurait créé deux endroits où écrire la même chose.
+        commentaire: message,
+        auteur,
+      },
+      plateforme,
+    );
+
+    return { decisionId: id };
+  }
+
+  /**
+   * Retirer un ajout = RÉVOQUER la décision (verdict='annule' + supersedes).
+   *
+   * Pas de DELETE, pas de verdict « retire » : le journal est append-only, et la révocation
+   * universelle existe déjà. `DecisionsService` vérifie que la cible appartient bien à la même
+   * plateforme — une plateforme ne peut pas défaire l'ajout d'une autre.
+   */
+  async retirer(decisionId: string, plateforme: string): Promise<{ decisionId: string }> {
+    const cible = await this.chargerAjout(decisionId, plateforme);
+
+    const { id } = await this.decisionsService.create(
+      {
+        typeDecision: TYPE_AJOUT,
+        objetAType: "projet",
+        objetAId: cible.objetAId,
+        objetBType: cible.objetBType,
+        objetBId: cible.objetBId,
+        verdict: ANNULE_VERDICT,
+        supersedes: decisionId,
+      },
+      plateforme,
+    );
+
+    return { decisionId: id };
+  }
+
+  /** 404 plutôt qu'un 400 obscur venant de `assertSupersedesCompatible` sur un id inconnu. */
+  private async chargerAjout(
+    decisionId: string,
+    plateforme: string,
+  ): Promise<{ objetAId: string; objetBType: ObjetAjoutable; objetBId: string }> {
+    const [row] = await this.dbService.database
+      .select({
+        objetAId: decisions.objetAId,
+        objetBType: decisions.objetBType,
+        objetBId: decisions.objetBId,
+      })
+      .from(decisions)
+      .where(
+        and(
+          eq(decisions.id, decisionId),
+          eq(decisions.typeDecision, TYPE_AJOUT),
+          eq(decisions.plateformeSource, plateforme),
+        ),
+      )
+      .limit(1);
+
+    if (!row?.objetBType || !row.objetBId) {
+      throw new NotFoundException(`Ajout manuel "${decisionId}" inconnu.`);
+    }
+    return { objetAId: row.objetAId, objetBType: row.objetBType as ObjetAjoutable, objetBId: row.objetBId };
+  }
+
+  /**
+   * Les ajouts actifs d'un projet, indexés par l'id de l'objet ajouté.
+   *
+   * `activeDecisionPredicate` exclut les décisions révoquées ; `notTombstonePredicate` exclut les
+   * pierres tombales elles-mêmes (verdict='annule'), qui ne sont pas des ajouts mais des retraits.
+   * Sans le second, retirer un ajout le ferait réapparaître.
+   *
+   * Cloisonné par plateforme : MEC ne voit pas les ajouts d'une autre plateforme, comme pour
+   * toutes les décisions.
+   */
+  async actifs(
+    projetId: string,
+    objetBType: ObjetAjoutable,
+    plateforme: string,
+  ): Promise<Map<string, { ajout: AjoutManuel }>> {
+    const rows = await this.dbService.database
+      .select({
+        id: decisions.id,
+        objetBId: decisions.objetBId,
+        commentaire: decisions.commentaire,
+        createdAt: decisions.createdAt,
+      })
+      .from(decisions)
+      .where(
+        and(
+          eq(decisions.typeDecision, TYPE_AJOUT),
+          eq(decisions.objetAId, projetId),
+          eq(decisions.objetBType, objetBType),
+          eq(decisions.plateformeSource, plateforme),
+          activeDecisionPredicate(ALIAS),
+          notTombstonePredicate(ALIAS),
+        ),
+      );
+
+    return new Map(
+      rows
+        .filter((r): r is typeof r & { objetBId: string } => r.objetBId != null)
+        .map((r) => [
+          r.objetBId,
+          {
+            ajout: {
+              decisionId: r.id,
+              message: r.commentaire ?? undefined,
+              plateforme,
+              date: r.createdAt.toISOString(),
+            },
+          },
+        ]),
+    );
+  }
+}

--- a/api/src/ajouts-manuels/ajouts-manuels.service.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.service.ts
@@ -237,9 +237,9 @@ export class AjoutsManuelsService {
                 message: r.commentaire ?? undefined,
                 plateforme,
                 date: r.createdAt.toISOString(),
-                // Le client doit pouvoir distinguer un service du catalogue d'un service saisi à
-                // la main : le second n'a pas de classification, et ses `categories` / `thematiques`
-                // vides sont une ABSENCE d'information, pas une information.
+                // PROVENANCE : le client doit pouvoir distinguer un service de notre catalogue
+                // d'un service saisi par un agent. Le second n'a pas de fiche chez nous, son logo
+                // n'est pas hébergé par l'API, et nous n'en cautionnons pas le contenu.
                 ...(service ? { horsCatalogue: true } : {}),
               },
               service,

--- a/api/src/ajouts-manuels/ajouts-manuels.service.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.service.ts
@@ -1,3 +1,4 @@
+import { randomUUID } from "node:crypto";
 import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
 import { and, eq } from "drizzle-orm";
 import { DatabaseService } from "@database/database.service";
@@ -7,7 +8,7 @@ import { ANNULE_VERDICT } from "@/decisions/decision-contract";
 import { DecisionsService } from "@/decisions/decisions.service";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { AidesPerimetreService } from "@/aides/aides-perimetre.service";
-import { TYPE_AJOUT, type AjoutManuel, type ObjetAjoutable } from "./ajout-manuel-contract";
+import { TYPE_AJOUT, type AjoutManuel, type ObjetAjoutable, type PayloadAjout } from "./ajout-manuel-contract";
 import { AjoutAideRequest, AjoutServiceRequest } from "./dto/ajout-manuel.dto";
 
 const ALIAS = "decisions";
@@ -56,8 +57,19 @@ export class AjoutsManuelsService {
   }
 
   /**
-   * Le slug doit exister dans le catalogue : ajouter un service inconnu produirait une ligne
-   * qu'aucune lecture ne saurait résoudre — un ajout invisible, donc un bug silencieux.
+   * Deux façons d'ajouter un service, et exactement une des deux.
+   *
+   * `slug` — le service est AU CATALOGUE. On ne recopie rien : sa fiche reste la source de vérité,
+   * et elle continuera d'évoluer (logo, description, lien). La figer ici l'aurait dédoublée, et les
+   * deux copies auraient divergé. Le slug doit exister (404 sinon) : un slug inconnu produirait un
+   * ajout qu'aucune lecture ne saurait résoudre — invisible, donc un bug silencieux.
+   *
+   * `service` — il n'y est PAS : un outil local, un service partenaire pas encore benchmarké.
+   * L'agent le décrit lui-même, et c'est lui la source. On le fige donc dans le payload : il n'y a
+   * aucune autorité extérieure à tenir en phase, contrairement à une aide.
+   *
+   * L'identifiant d'un service libre est un UUID : il n'a pas de slug, et en dériver un de son nom
+   * exposerait à des collisions entre deux services homonymes du même projet.
    */
   async ajouterService(
     projetId: string,
@@ -66,17 +78,34 @@ export class AjoutsManuelsService {
   ): Promise<{ decisionId: string }> {
     await this.getProjetsService.findOneWithSource(projetId);
 
-    const [service] = await this.dbService.database
-      .select({ slug: servicesNumeriques.slug })
-      .from(servicesNumeriques)
-      .where(eq(servicesNumeriques.slug, dto.slug))
-      .limit(1);
-
-    if (!service) {
-      throw new NotFoundException(`Service numérique "${dto.slug}" inconnu du catalogue.`);
+    // class-validator garantit « au moins un des deux » ; « pas les deux » se dit ici, où on peut
+    // l'expliquer. Choisir en silence lequel afficher serait pire que refuser.
+    if (dto.slug !== undefined && dto.service !== undefined) {
+      throw new BadRequestException(
+        "Fournissez `slug` (service du catalogue) OU `service` (service hors catalogue), pas les deux.",
+      );
     }
 
-    return this.enregistrer(projetId, "service_numerique", dto.slug, dto.message, dto.auteur, plateforme);
+    if (dto.slug !== undefined) {
+      const [service] = await this.dbService.database
+        .select({ slug: servicesNumeriques.slug })
+        .from(servicesNumeriques)
+        .where(eq(servicesNumeriques.slug, dto.slug))
+        .limit(1);
+
+      if (!service) {
+        throw new NotFoundException(
+          `Service numérique "${dto.slug}" inconnu du catalogue. S'il n'y figure pas, décrivez-le ` +
+            `via le champ \`service\` plutôt que par un slug.`,
+        );
+      }
+
+      return this.enregistrer(projetId, "service_numerique", dto.slug, dto.message, dto.auteur, plateforme);
+    }
+
+    return this.enregistrer(projetId, "service_numerique", randomUUID(), dto.message, dto.auteur, plateforme, {
+      service: dto.service,
+    });
   }
 
   private async enregistrer(
@@ -86,6 +115,7 @@ export class AjoutsManuelsService {
     message: string | undefined,
     auteur: string | undefined,
     plateforme: string,
+    payload?: PayloadAjout,
   ): Promise<{ decisionId: string }> {
     const { id } = await this.decisionsService.create(
       {
@@ -98,6 +128,7 @@ export class AjoutsManuelsService {
         // dans le payload aurait créé deux endroits où écrire la même chose.
         commentaire: message,
         auteur,
+        payload: payload as Record<string, unknown> | undefined,
       },
       plateforme,
     );
@@ -172,12 +203,13 @@ export class AjoutsManuelsService {
     projetId: string,
     objetBType: ObjetAjoutable,
     plateforme: string,
-  ): Promise<Map<string, { ajout: AjoutManuel }>> {
+  ): Promise<Map<string, { ajout: AjoutManuel; service?: PayloadAjout["service"] }>> {
     const rows = await this.dbService.database
       .select({
         id: decisions.id,
         objetBId: decisions.objetBId,
         commentaire: decisions.commentaire,
+        payload: decisions.payload,
         createdAt: decisions.createdAt,
       })
       .from(decisions)
@@ -195,17 +227,25 @@ export class AjoutsManuelsService {
     return new Map(
       rows
         .filter((r): r is typeof r & { objetBId: string } => r.objetBId != null)
-        .map((r) => [
-          r.objetBId,
-          {
-            ajout: {
-              decisionId: r.id,
-              message: r.commentaire ?? undefined,
-              plateforme,
-              date: r.createdAt.toISOString(),
+        .map((r) => {
+          const service = (r.payload as PayloadAjout | null)?.service;
+          return [
+            r.objetBId,
+            {
+              ajout: {
+                decisionId: r.id,
+                message: r.commentaire ?? undefined,
+                plateforme,
+                date: r.createdAt.toISOString(),
+                // Le client doit pouvoir distinguer un service du catalogue d'un service saisi à
+                // la main : le second n'a pas de classification, et ses `categories` / `thematiques`
+                // vides sont une ABSENCE d'information, pas une information.
+                ...(service ? { horsCatalogue: true } : {}),
+              },
+              service,
             },
-          },
-        ]),
+          ];
+        }),
     );
   }
 }

--- a/api/src/ajouts-manuels/dto/ajout-manuel.dto.ts
+++ b/api/src/ajouts-manuels/dto/ajout-manuel.dto.ts
@@ -51,8 +51,12 @@ export class AjoutAideRequest extends AjoutBase {
  * elle, n'existe que dans Aides-territoires : une aide qu'ils ne connaissent pas n'a aucune
  * autorité qui la valide, et nous n'aurions aucun moyen de la tenir à jour.
  *
- * `categories` et `thematiques` restent VIDES à la lecture. On ne les invente pas : on ne connaît
- * pas la classification de ce service, et le dire est plus honnête que de la fabriquer.
+ * On ne demande PAS ses thématiques à l'agent, et c'est délibéré : les thématiques ne servent qu'à
+ * SÉLECTIONNER un service pour un projet. Ici la sélection est déjà faite — par un humain. Les
+ * réclamer serait exiger une donnée dont personne ne se servira.
+ *
+ * `categories` et `thematiques` sortent donc vides. Vides plutôt qu'absents : un client qui fait
+ * `service.thematiques.map(...)` planterait sur `undefined`.
  */
 export class ServiceLibreDto {
   @ApiProperty({ description: "Nom du service, tel qu'il s'affichera." })
@@ -147,9 +151,13 @@ export class AjoutManuelResponse {
 
   @ApiPropertyOptional({
     description:
-      "Services uniquement. `true` si le service ne vient PAS du catalogue : ses informations ont " +
-      "été saisies à la main. Sa classification est donc inconnue — `categories` et `thematiques` " +
-      "sont vides, on ne les invente pas. Absent sur les aides, où la notion n'a pas de sens.",
+      "PROVENANCE — services uniquement. `true` si le service ne vient PAS de notre catalogue : " +
+      "ses informations ont été saisies par un agent, il n'a pas de fiche chez nous, et son logo " +
+      "n'est pas hébergé par l'API. Le client peut donc le présenter différemment (pas de lien " +
+      "vers une fiche catalogue, pas de caution éditoriale de notre part).\n\n" +
+      "Ce n'est PAS une information de classification : les thématiques ne servent qu'à SÉLECTIONNER " +
+      "un service pour un projet, et un ajout manuel a déjà été sélectionné — par un humain. " +
+      "Absent sur les aides, où la notion de catalogue n'a pas de sens.",
   })
   horsCatalogue?: boolean;
 }

--- a/api/src/ajouts-manuels/dto/ajout-manuel.dto.ts
+++ b/api/src/ajouts-manuels/dto/ajout-manuel.dto.ts
@@ -1,0 +1,60 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength } from "class-validator";
+
+class AjoutBase {
+  @ApiPropertyOptional({
+    description:
+      "Pourquoi cet ajout — « recommandée par la DDT lors du COPIL du 12/03 ». Rendu tel quel au " +
+      "client, à côté de l'aide ou du service concerné.",
+    maxLength: 2000,
+  })
+  @IsOptional()
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  message?: string;
+
+  @ApiPropertyOptional({ description: "Identifiant de l'agent auteur, si la plateforme le transmet.", maxLength: 200 })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  auteur?: string;
+}
+
+export class AjoutAideRequest extends AjoutBase {
+  @ApiProperty({
+    description:
+      "Identifiant Aides-territoires de l'aide. Elle doit être disponible sur le territoire du " +
+      "projet (400 sinon) : une aide hors périmètre ne pourrait jamais être résolue à la lecture, " +
+      "et l'ajout resterait invisible sans le moindre message.",
+  })
+  @IsInt()
+  aideId!: number;
+}
+
+export class AjoutServiceRequest extends AjoutBase {
+  @ApiProperty({ description: "Slug du service numérique, tel qu'il figure au catalogue." })
+  @IsString()
+  @IsNotEmpty()
+  slug!: string;
+}
+
+export class AjoutCreeResponse {
+  @ApiProperty({ description: "Id de la décision. C'est lui qu'il faut fournir pour retirer l'ajout." })
+  decisionId!: string;
+}
+
+/** La trace d'un ajout manuel, attachée à l'aide ou au service concerné dans les listes. */
+export class AjoutManuelResponse {
+  @ApiProperty({ description: "Id de la décision — à fournir pour retirer cet ajout." })
+  decisionId!: string;
+
+  @ApiPropertyOptional({ description: "Le message saisi lors de l'ajout." })
+  message?: string;
+
+  @ApiProperty({ description: "Plateforme qui a procédé à l'ajout (dérivée de la clé d'API)." })
+  plateforme!: string;
+
+  @ApiProperty({ description: "Date de l'ajout (ISO 8601)." })
+  date!: string;
+}

--- a/api/src/ajouts-manuels/dto/ajout-manuel.dto.ts
+++ b/api/src/ajouts-manuels/dto/ajout-manuel.dto.ts
@@ -1,10 +1,20 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsInt, IsNotEmpty, IsOptional, IsString, MaxLength } from "class-validator";
+import { Type } from "class-transformer";
+import {
+  IsInt,
+  IsNotEmpty,
+  IsObject,
+  IsOptional,
+  IsString,
+  MaxLength,
+  ValidateIf,
+  ValidateNested,
+} from "class-validator";
 
 class AjoutBase {
   @ApiPropertyOptional({
     description:
-      "Pourquoi cet ajout — « recommandée par la DDT lors du COPIL du 12/03 ». Rendu tel quel au " +
+      "Pourquoi cet ajout — « recommandé par la DDT lors du COPIL du 12/03 ». Rendu tel quel au " +
       "client, à côté de l'aide ou du service concerné.",
     maxLength: 2000,
   })
@@ -32,11 +42,88 @@ export class AjoutAideRequest extends AjoutBase {
   aideId!: number;
 }
 
-export class AjoutServiceRequest extends AjoutBase {
-  @ApiProperty({ description: "Slug du service numérique, tel qu'il figure au catalogue." })
+/**
+ * Un service qui n'est PAS au catalogue : un outil local, un service partenaire pas encore
+ * benchmarké. L'agent en fournit lui-même les informations.
+ *
+ * POURQUOI C'EST LÉGITIME ICI, ET PAS POUR UNE AIDE. Le catalogue de services est le NÔTRE : un
+ * service qui n'y figure pas existe quand même, et personne d'autre ne peut le décrire. Une aide,
+ * elle, n'existe que dans Aides-territoires : une aide qu'ils ne connaissent pas n'a aucune
+ * autorité qui la valide, et nous n'aurions aucun moyen de la tenir à jour.
+ *
+ * `categories` et `thematiques` restent VIDES à la lecture. On ne les invente pas : on ne connaît
+ * pas la classification de ce service, et le dire est plus honnête que de la fabriquer.
+ */
+export class ServiceLibreDto {
+  @ApiProperty({ description: "Nom du service, tel qu'il s'affichera." })
   @IsString()
   @IsNotEmpty()
-  slug!: string;
+  @MaxLength(300)
+  nom!: string;
+
+  @ApiProperty({ description: "Description courte, telle qu'elle s'affichera." })
+  @IsString()
+  @IsNotEmpty()
+  @MaxLength(2000)
+  description!: string;
+
+  @ApiPropertyOptional({ description: "Lien vers le service." })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  url?: string;
+
+  @ApiPropertyOptional({ description: "Libellé du lien (défaut : le client décide)." })
+  @IsOptional()
+  @IsString()
+  @MaxLength(200)
+  libelleLien?: string;
+
+  @ApiPropertyOptional({ description: "Structure qui opère le service." })
+  @IsOptional()
+  @IsString()
+  @MaxLength(300)
+  operateur?: string;
+
+  @ApiPropertyOptional({ description: "URL absolue d'un logo. L'API n'héberge que les logos du catalogue." })
+  @IsOptional()
+  @IsString()
+  @MaxLength(2000)
+  logoUrl?: string;
+}
+
+/**
+ * Deux façons d'ajouter un service, et EXACTEMENT une des deux :
+ *
+ * - `slug` : le service est au catalogue. On ne recopie rien — sa fiche reste la source de vérité,
+ *   et elle continuera d'évoluer (logo, description, lien). Recopier ici l'aurait figée, et les
+ *   deux copies auraient divergé.
+ * - `service` : il n'y est pas. L'agent le décrit lui-même ; c'est lui la source.
+ *
+ * Fournir les deux serait ambigu : lequel affiche-t-on ? Fournir aucun des deux n'ajoute rien. On
+ * refuse les deux cas plutôt que de choisir en silence.
+ */
+export class AjoutServiceRequest extends AjoutBase {
+  @ApiPropertyOptional({
+    description: "Slug du service, s'il est au catalogue. Exclusif avec `service`.",
+  })
+  // « Au moins un des deux » est vérifié ici ; « pas les deux » l'est dans le service, où on peut
+  // l'expliquer. class-validator ne sait pas exprimer un OU EXCLUSIF sans validateur maison, et un
+  // validateur maison pour ça serait plus obscur que la garde explicite.
+  @ValidateIf((o: AjoutServiceRequest) => o.service === undefined)
+  @IsString({ message: "Fournissez `slug` (service du catalogue) OU `service` (service hors catalogue)." })
+  @IsNotEmpty()
+  slug?: string;
+
+  @ApiPropertyOptional({
+    type: ServiceLibreDto,
+    description: "Description d'un service HORS catalogue. Exclusif avec `slug`.",
+  })
+  @ValidateIf((o: AjoutServiceRequest) => o.slug === undefined)
+  @IsObject()
+  @ValidateNested()
+  @Type(() => ServiceLibreDto)
+  service?: ServiceLibreDto;
 }
 
 export class AjoutCreeResponse {
@@ -57,4 +144,12 @@ export class AjoutManuelResponse {
 
   @ApiProperty({ description: "Date de l'ajout (ISO 8601)." })
   date!: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Services uniquement. `true` si le service ne vient PAS du catalogue : ses informations ont " +
+      "été saisies à la main. Sa classification est donc inconnue — `categories` et `thematiques` " +
+      "sont vides, on ne les invente pas. Absent sur les aides, où la notion n'a pas de sens.",
+  })
+  horsCatalogue?: boolean;
 }

--- a/api/src/app.module.ts
+++ b/api/src/app.module.ts
@@ -36,6 +36,7 @@ import { QuestionnairesModule } from "@/questionnaires/questionnaires.module";
 import { RecommandationsModule } from "@/recommandations/recommandations.module";
 import { ServicesNumeriquesModule } from "@/services-numeriques/services-numeriques.module";
 import { AdminModule } from "@/admin/admin.module";
+import { AjoutsManuelsModule } from "@/ajouts-manuels/ajouts-manuels.module";
 
 @Module({
   imports: [
@@ -96,6 +97,7 @@ import { AdminModule } from "@/admin/admin.module";
     RecommandationsModule,
     ServicesNumeriquesModule,
     AdminModule,
+    AjoutsManuelsModule,
   ],
   controllers: [HealthController],
   providers: [AppService, ThrottlerGuardProvider, RequestLoggingInterceptor],

--- a/api/src/decisions/decision-contract.ts
+++ b/api/src/decisions/decision-contract.ts
@@ -27,7 +27,15 @@ export type ObjetType = (typeof OBJET_TYPES)[number];
 // qui permet à l'arbitrage de lui survivre : une recommandation qui disparaît puis
 // réapparaît (la collectivité revient sur ses réponses) retrouve son arbitrage.
 // 'recommandation' n'est jamais un type d'objet A.
-export const OBJET_B_TYPES = [...OBJET_TYPES, "pcaet", "recommandation"] as const;
+// L'objet B peut ENFIN désigner une aide ou un service numérique (ajout_manuel). On n'y stocke
+// QUE l'identifiant : l'id Aides-territoires pour une aide, le slug du catalogue pour un service.
+// L'aide est résolue au frais à chaque lecture, dans les aides du périmètre du projet. Si elle a
+// été clôturée ou dépubliée entre-temps, elle cesse simplement de s'afficher — c'est le
+// comportement correct : mieux vaut ne rien montrer qu'envoyer une collectivité candidater à une
+// aide morte. (Aides-territoires ne sait de toute façon PAS récupérer une aide par son id :
+// /aids/<id>/ répond 404, et ?id=<n> est silencieusement ignoré — il renvoie tout le catalogue.)
+// Ni 'aide' ni 'service_numerique' n'est jamais un type d'objet A.
+export const OBJET_B_TYPES = [...OBJET_TYPES, "pcaet", "recommandation", "aide", "service_numerique"] as const;
 export type ObjetBType = (typeof OBJET_B_TYPES)[number];
 
 // Vocabulaire fermé des types de décision.
@@ -39,6 +47,7 @@ export const DECISION_TYPES = [
   "projet_statut",
   "correction_signalee",
   "recommandation_arbitrage",
+  "ajout_manuel",
 ] as const;
 export type DecisionType = (typeof DECISION_TYPES)[number];
 
@@ -133,6 +142,19 @@ const CONTRACT: Record<DecisionType, DecisionSpec> = {
     objetATypes: ["projet"],
     objetB: { required: true, types: ["recommandation"] },
     verdict: { required: true, values: RECOMMANDATION_VERDICTS },
+    payload: "free",
+  },
+  // Ajout à la main d'une aide ou d'un service numérique sur un projet, quand le moteur ne l'a
+  // pas trouvé (ou l'a mal classé). Le MESSAGE d'accompagnement va dans `commentaire`, qui existe
+  // déjà sur toute décision — d'où un payload libre, et vide en pratique.
+  //
+  // Pas de verdict : la décision EST l'ajout. Le retrait se fait par la révocation universelle
+  // (verdict='annule' + supersedes) — inutile d'inventer un verdict "retire" qui ferait double
+  // emploi et créerait deux façons de dire la même chose.
+  ajout_manuel: {
+    objetATypes: ["projet"],
+    objetB: { required: true, types: ["aide", "service_numerique"] },
+    verdict: { required: false },
     payload: "free",
   },
 };

--- a/api/src/services-numeriques/dto/service-numerique.dto.ts
+++ b/api/src/services-numeriques/dto/service-numerique.dto.ts
@@ -50,9 +50,6 @@ export class ServiceResponse {
   @ApiPropertyOptional({ enum: NIVEAUX_EXPERTISE })
   niveauExpertise?: NiveauExpertise;
 
-  @ApiProperty({ type: [String], description: "Thématiques du service, dans la taxonomie du schéma commun." })
-  thematiques!: string[];
-
   @ApiPropertyOptional({
     description:
       "Le service est-il utilisable par un agent NON SPÉCIALISTE ? Propriété descriptive du " +

--- a/api/src/services-numeriques/dto/service-numerique.dto.ts
+++ b/api/src/services-numeriques/dto/service-numerique.dto.ts
@@ -1,4 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { AjoutManuelResponse } from "@/ajouts-manuels/dto/ajout-manuel.dto";
 import { CATEGORIES, NIVEAUX_EXPERTISE, type Categorie, type NiveauExpertise } from "../service-numerique-contract";
 
 // Sous-ensemble d'AFFICHAGE du catalogue interne.
@@ -74,6 +75,15 @@ export class ServiceResponse {
       "{collectiviteType}, {collectiviteCode}, {collectiviteLabel}, {epciCodeSiren}.",
   })
   iframe?: LienResponse;
+
+  @ApiPropertyOptional({
+    type: AjoutManuelResponse,
+    description:
+      "Présent si ce service a été ajouté À LA MAIN sur ce projet, et non retenu par le score. " +
+      "Porte le message de la personne qui l'a ajouté (« recommandé par la DDT lors du COPIL »). " +
+      "Absent = le service a été retenu par le moteur.",
+  })
+  ajoutManuel?: AjoutManuelResponse;
 }
 
 export class ProjetServicesResponse {

--- a/api/src/services-numeriques/services-numeriques.controller.ts
+++ b/api/src/services-numeriques/services-numeriques.controller.ts
@@ -22,7 +22,8 @@ export class ServicesNumeriquesController {
       "Renvoie les services déjà sélectionnés, curés et ORDONNÉS par pertinence décroissante par l'API. " +
       "Le client affiche la liste telle quelle : il ne filtre ni ne trie (il peut proposer des filtres par " +
       "catégorie, purement côté client). Aucun critère de sélection n'est exposé. Aucun service → 200 avec " +
-      "une liste vide.",
+      "une liste vide. Les services AJOUTÉS À LA MAIN sur ce projet remontent en tête, marqués " +
+      "`ajoutManuel` (avec le message de la personne qui les a ajoutés).",
   })
   @ApiParam({ name: "projetId", description: "Identifiant Communs du projet (UUID)." })
   @ApiEndpointResponses({
@@ -34,7 +35,7 @@ export class ServicesNumeriquesController {
     @Req() request: Request,
     @Param("projetId", ParseUUIDPipe) projetId: string,
   ): Promise<ProjetServicesResponse> {
-    return this.servicesNumeriquesService.findForProjet(projetId, origine(request));
+    return this.servicesNumeriquesService.findForProjet(projetId, origine(request), request.serviceType!);
   }
 }
 

--- a/api/src/services-numeriques/services-numeriques.module.ts
+++ b/api/src/services-numeriques/services-numeriques.module.ts
@@ -1,12 +1,13 @@
 import { Module } from "@nestjs/common";
 import { DatabaseModule } from "@database/database.module";
 import { ProjetsModule } from "@projets/projets.module";
+import { AjoutsManuelsModule } from "@/ajouts-manuels/ajouts-manuels.module";
 import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { ServicesNumeriquesController } from "./services-numeriques.controller";
 import { ServicesNumeriquesService } from "./services-numeriques.service";
 
 @Module({
-  imports: [DatabaseModule, ProjetsModule],
+  imports: [DatabaseModule, ProjetsModule, AjoutsManuelsModule],
   controllers: [ServicesNumeriquesController],
   providers: [
     ServicesNumeriquesService,

--- a/api/src/services-numeriques/services-numeriques.service.ts
+++ b/api/src/services-numeriques/services-numeriques.service.ts
@@ -110,11 +110,13 @@ export class ServicesNumeriquesService {
   }
 
   /**
-   * Un service saisi à la main, rendu SANS RIEN FABRIQUER.
+   * Un service saisi à la main par un agent.
    *
-   * `categories` et `thematiques` restent vides : on ne connaît pas la classification de ce
-   * service. Le dire est plus honnête que d'inventer — et le drapeau `horsCatalogue` permet au
-   * client de distinguer cette absence d'information d'une information.
+   * `categories` et `thematiques` sortent VIDES, et on ne les réclame pas à l'agent : les
+   * thématiques ne servent qu'à SÉLECTIONNER un service pour un projet, et ici la sélection est
+   * déjà faite — par un humain. Exiger une donnée dont personne ne se servira n'aurait aucun sens.
+   * Vides plutôt qu'absents : un client qui ferait `service.thematiques.map(...)` planterait sur
+   * `undefined`.
    *
    * `logoUrl` n'est PAS absolutisé : l'API n'héberge que les logos du catalogue. Une URL fournie
    * par un agent est déjà absolue, ou elle n'est rien.

--- a/api/src/services-numeriques/services-numeriques.service.ts
+++ b/api/src/services-numeriques/services-numeriques.service.ts
@@ -112,11 +112,8 @@ export class ServicesNumeriquesService {
   /**
    * Un service saisi à la main par un agent.
    *
-   * `categories` et `thematiques` sortent VIDES, et on ne les réclame pas à l'agent : les
-   * thématiques ne servent qu'à SÉLECTIONNER un service pour un projet, et ici la sélection est
-   * déjà faite — par un humain. Exiger une donnée dont personne ne se servira n'aurait aucun sens.
-   * Vides plutôt qu'absents : un client qui ferait `service.thematiques.map(...)` planterait sur
-   * `undefined`.
+   * `categories` sort VIDE : on ne connaît pas la nature de ce service, et on ne la demande pas —
+   * c'est une donnée d'affichage facultative, pas une condition d'existence.
    *
    * `logoUrl` n'est PAS absolutisé : l'API n'héberge que les logos du catalogue. Une URL fournie
    * par un agent est déjà absolue, ou elle n'est rien.
@@ -127,7 +124,6 @@ export class ServicesNumeriquesService {
       nom: s.nom,
       description: s.description,
       categories: [],
-      thematiques: [],
       logoUrl: s.logoUrl,
       operateur: s.operateur,
       redirection: s.url ? { url: s.url, libelle: s.libelleLien } : undefined,
@@ -162,8 +158,13 @@ export class ServicesNumeriquesService {
   /**
    * Projection vers le contrat public.
    *
-   * Les CRITÈRES DE SÉLECTION ne franchissent jamais la frontière : `classification`, `phases`
-   * et `presentationGenerique` n'ont aucun équivalent dans le DTO (§1 et §9 de la spec).
+   * Les CRITÈRES DE SÉLECTION ne franchissent jamais la frontière : `classification`, `phases` et
+   * `presentationGenerique` n'ont aucun équivalent dans le DTO (§1 et §9 de la spec).
+   *
+   * `thematiques` en faisait partie sans qu'on le voie : c'était la classification, exposée sous
+   * forme de libellés. Le contrat se contredisait donc lui-même. Retiré — un client qui l'aurait
+   * affichée aurait montré à une collectivité les entrailles du moteur de sélection, et non une
+   * information sur le service.
    *
    * `profilGeneraliste`, lui, est exposé — parce que ce n'en est plus un : il ne décide plus
    * de rien côté serveur, il décrit le service (utilisable par un non-spécialiste ?) au même
@@ -179,7 +180,6 @@ export class ServicesNumeriquesService {
       logoUrl: absolutiser(l.logoUrl, baseUrl),
       categories: l.categories as Categorie[],
       niveauExpertise: (l.niveauExpertise as NiveauExpertise | null) ?? undefined,
-      thematiques: l.classification.thematiques.map((t) => t.label),
       profilGeneraliste: ternaireVersBooleen(l.profilGeneraliste),
       operateur: l.operateur ?? undefined,
       redirection: l.redirectionUrl ? { url: l.redirectionUrl, libelle: l.redirectionLibelle ?? undefined } : undefined,

--- a/api/src/services-numeriques/services-numeriques.service.ts
+++ b/api/src/services-numeriques/services-numeriques.service.ts
@@ -4,6 +4,7 @@ import { servicesNumeriques } from "@database/schema";
 import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { AideClassification } from "@/aides/dto/aides.dto";
 import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
+import type { AjoutManuel, ServiceLibre } from "@/ajouts-manuels/ajout-manuel-contract";
 import { ProjetResponse } from "@projets/dto/projet.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import {
@@ -88,19 +89,47 @@ export class ServicesNumeriquesService {
     // Un service à la fois pertinent ET ajouté à la main n'apparaît QU'UNE fois (filtré ci-dessus),
     // avec sa marque d'ajout : le dédoublonnage doit se faire ici, pas dans le client.
     const parSlug = new Map(catalogue.map((l) => [l.slug, l]));
-    const manuels = [...ajouts.entries()]
-      .map(([slug, { ajout }]) => {
-        const ligne = parSlug.get(slug);
-        return ligne ? { ligne, ajout } : null;
-      })
-      .filter((x): x is NonNullable<typeof x> => x !== null)
-      .sort((a, b) => a.ligne.nom.localeCompare(b.ligne.nom));
+    const manuels: ServiceResponse[] = [];
+
+    for (const [id, { ajout, service }] of ajouts) {
+      // Service HORS catalogue : l'agent l'a décrit lui-même, c'est lui la source.
+      if (service) {
+        manuels.push(this.libreVersResponse(id, service, ajout));
+        continue;
+      }
+      // Service DU catalogue : sa fiche reste la source de vérité. On ne recopie rien.
+      const ligne = parSlug.get(id);
+      if (ligne) manuels.push({ ...this.toResponse(ligne, baseUrl), ajoutManuel: ajout });
+    }
+
+    manuels.sort((a, b) => a.nom.localeCompare(b.nom));
 
     return {
-      services: [
-        ...manuels.map(({ ligne, ajout }) => ({ ...this.toResponse(ligne, baseUrl), ajoutManuel: ajout })),
-        ...pertinents.map(({ ligne }) => this.toResponse(ligne, baseUrl)),
-      ],
+      services: [...manuels, ...pertinents.map(({ ligne }) => this.toResponse(ligne, baseUrl))],
+    };
+  }
+
+  /**
+   * Un service saisi à la main, rendu SANS RIEN FABRIQUER.
+   *
+   * `categories` et `thematiques` restent vides : on ne connaît pas la classification de ce
+   * service. Le dire est plus honnête que d'inventer — et le drapeau `horsCatalogue` permet au
+   * client de distinguer cette absence d'information d'une information.
+   *
+   * `logoUrl` n'est PAS absolutisé : l'API n'héberge que les logos du catalogue. Une URL fournie
+   * par un agent est déjà absolue, ou elle n'est rien.
+   */
+  private libreVersResponse(id: string, s: ServiceLibre, ajout: AjoutManuel): ServiceResponse {
+    return {
+      id,
+      nom: s.nom,
+      description: s.description,
+      categories: [],
+      thematiques: [],
+      logoUrl: s.logoUrl,
+      operateur: s.operateur,
+      redirection: s.url ? { url: s.url, libelle: s.libelleLien } : undefined,
+      ajoutManuel: ajout,
     };
   }
 

--- a/api/src/services-numeriques/services-numeriques.service.ts
+++ b/api/src/services-numeriques/services-numeriques.service.ts
@@ -3,6 +3,7 @@ import { DatabaseService } from "@database/database.service";
 import { servicesNumeriques } from "@database/schema";
 import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { AideClassification } from "@/aides/dto/aides.dto";
+import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
 import { ProjetResponse } from "@projets/dto/projet.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import {
@@ -48,6 +49,7 @@ export class ServicesNumeriquesService {
     private readonly dbService: DatabaseService,
     private readonly getProjetsService: GetProjetsService,
     private readonly matchingService: AidesMatchingService,
+    private readonly ajoutsManuels: AjoutsManuelsService,
   ) {}
 
   /**
@@ -69,16 +71,37 @@ export class ServicesNumeriquesService {
    * `findOneWithSource` : le projet peut vivre dans public.projets, data_mec ou data_tet.
    * Aucun service → 200 avec une liste vide, jamais 404.
    */
-  async findForProjet(projetId: string, baseUrl: string): Promise<ProjetServicesResponse> {
+  async findForProjet(projetId: string, baseUrl: string, plateforme: string): Promise<ProjetServicesResponse> {
     const { projet } = await this.getProjetsService.findOneWithSource(projetId);
 
     const catalogue = await this.dbService.database.select().from(servicesNumeriques);
+    const ajouts = await this.ajoutsManuels.actifs(projetId, "service_numerique", plateforme);
 
     const pertinents = this.scorer(projet, catalogue)
-      .filter((s) => s.score >= SEUIL_PERTINENCE)
+      .filter((s) => s.score >= SEUIL_PERTINENCE && !ajouts.has(s.ligne.slug))
       .sort((a, b) => b.score - a.score || a.ligne.nom.localeCompare(b.ligne.nom));
 
-    return { services: pertinents.map(({ ligne }) => this.toResponse(ligne, baseUrl)) };
+    // Les ajouts manuels EN TÊTE : quelqu'un les a délibérément mis là. Les noyer dans le tri par
+    // score les rendrait indiscernables du résultat du moteur — or c'est précisément la distinction
+    // qu'on veut rendre visible.
+    //
+    // Un service à la fois pertinent ET ajouté à la main n'apparaît QU'UNE fois (filtré ci-dessus),
+    // avec sa marque d'ajout : le dédoublonnage doit se faire ici, pas dans le client.
+    const parSlug = new Map(catalogue.map((l) => [l.slug, l]));
+    const manuels = [...ajouts.entries()]
+      .map(([slug, { ajout }]) => {
+        const ligne = parSlug.get(slug);
+        return ligne ? { ligne, ajout } : null;
+      })
+      .filter((x): x is NonNullable<typeof x> => x !== null)
+      .sort((a, b) => a.ligne.nom.localeCompare(b.ligne.nom));
+
+    return {
+      services: [
+        ...manuels.map(({ ligne, ajout }) => ({ ...this.toResponse(ligne, baseUrl), ajoutManuel: ajout })),
+        ...pertinents.map(({ ligne }) => this.toResponse(ligne, baseUrl)),
+      ],
+    };
   }
 
   /**

--- a/api/test/ajouts-manuels.e2e-spec.ts
+++ b/api/test/ajouts-manuels.e2e-spec.ts
@@ -17,7 +17,6 @@ interface Service {
   nom: string;
   description: string;
   categories: string[];
-  thematiques: string[];
   ajoutManuel?: AjoutManuel;
 }
 
@@ -193,17 +192,15 @@ describe("Ajouts manuels (e2e)", () => {
       expect(s.ajoutManuel?.message).toBe("Outil local, pas au benchmark DINUM");
     });
 
-    it("ne réclame aucune thématique, et n'en invente aucune", async () => {
-      // Les thématiques ne servent qu'à SÉLECTIONNER un service pour un projet. Ici la sélection
-      // est déjà faite, par un humain : exiger une donnée dont personne ne se servira n'aurait
-      // aucun sens. Vides plutôt qu'absents : `service.thematiques.map(...)` ne doit pas planter.
+    it("ne réclame aucune classification, et n'en invente aucune", async () => {
+      // On ne demande à l'agent ni thématiques ni catégories : la sélection est déjà faite, par
+      // lui. Exiger une donnée dont personne ne se servira n'aurait aucun sens.
       const projetId = await creerProjet(EAU);
 
       await ajouterLibre(projetId, { nom: "Outil local", description: "Un outil interne." });
 
       const [s] = await getServices(projetId);
       expect(s.categories).toEqual([]);
-      expect(s.thematiques).toEqual([]);
     });
 
     it("signale la PROVENANCE : ce service ne vient pas de notre catalogue", async () => {

--- a/api/test/ajouts-manuels.e2e-spec.ts
+++ b/api/test/ajouts-manuels.e2e-spec.ts
@@ -10,10 +10,14 @@ interface AjoutManuel {
   message?: string;
   plateforme: string;
   date: string;
+  horsCatalogue?: boolean;
 }
 interface Service {
   id: string;
   nom: string;
+  description: string;
+  categories: string[];
+  thematiques: string[];
   ajoutManuel?: AjoutManuel;
 }
 
@@ -155,6 +159,96 @@ describe("Ajouts manuels (e2e)", () => {
 
       const { status } = await ajouterService("00000000-0000-0000-0000-000000000000", "un-service");
       expect(status).toBe(404);
+    });
+  });
+
+  describe("Ajouter un service HORS catalogue", () => {
+    const ajouterLibre = (projetId: string, libre: object, message?: string) =>
+      appeler<{ decisionId: string }>("POST", `/projets/${projetId}/services/ajouts`, {
+        service: libre,
+        message,
+      });
+
+    it("affiche un service que l'agent décrit lui-même", async () => {
+      // Un outil local, un service partenaire pas encore benchmarké : il existe, et personne
+      // d'autre que l'agent ne peut le décrire. Le catalogue est le NÔTRE — son absence n'est pas
+      // une preuve d'inexistence, contrairement à une aide absente d'Aides-territoires.
+      const projetId = await creerProjet(EAU);
+
+      const { status } = await ajouterLibre(
+        projetId,
+        {
+          nom: "Cadastre solaire de la métropole",
+          description: "Estime le potentiel photovoltaïque de chaque toiture du territoire.",
+          url: "https://cadastre-solaire.exemple.fr",
+          libelleLien: "Ouvrir le cadastre",
+          operateur: "Métropole",
+        },
+        "Outil local, pas au benchmark DINUM",
+      );
+      expect(status).toBe(201);
+
+      const [s] = await getServices(projetId);
+      expect(s.nom).toBe("Cadastre solaire de la métropole");
+      expect(s.ajoutManuel?.message).toBe("Outil local, pas au benchmark DINUM");
+    });
+
+    it("n'INVENTE aucune classification : categories et thematiques restent vides", async () => {
+      // On ne connaît pas la classification de ce service. Le dire est plus honnête que de la
+      // fabriquer — et `horsCatalogue` permet au client de distinguer cette ABSENCE d'information
+      // d'une information.
+      const projetId = await creerProjet(EAU);
+
+      await ajouterLibre(projetId, { nom: "Outil local", description: "Un outil interne." });
+
+      const [s] = await getServices(projetId);
+      expect(s.categories).toEqual([]);
+      expect(s.thematiques).toEqual([]);
+      expect(s.ajoutManuel?.horsCatalogue).toBe(true);
+    });
+
+    it("ne marque PAS horsCatalogue un service du catalogue", async () => {
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "au-catalogue", nom: "Au catalogue", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      await ajouterService(projetId, "au-catalogue");
+
+      const [s] = await getServices(projetId);
+      expect(s.ajoutManuel?.horsCatalogue).toBeUndefined();
+    });
+
+    it("refuse `slug` ET `service` ensemble", async () => {
+      // Lequel afficherait-on ? Choisir en silence serait pire que refuser.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "au-catalogue", nom: "Au catalogue" })]);
+      const projetId = await creerProjet(EAU);
+
+      const { status } = await appeler("POST", `/projets/${projetId}/services/ajouts`, {
+        slug: "au-catalogue",
+        service: { nom: "Autre", description: "Autre chose." },
+      });
+      expect(status).toBe(400);
+    });
+
+    it("refuse ni l'un ni l'autre", async () => {
+      const projetId = await creerProjet(EAU);
+
+      const { status } = await appeler("POST", `/projets/${projetId}/services/ajouts`, { message: "sans objet" });
+      expect(status).toBe(400);
+    });
+
+    it("se retire comme n'importe quel ajout", async () => {
+      const projetId = await creerProjet(EAU);
+
+      const { body } = await ajouterLibre(projetId, { nom: "Outil local", description: "Un outil interne." });
+      expect(await getServices(projetId)).toHaveLength(1);
+
+      await appeler("DELETE", `/projets/${projetId}/ajouts/${body.decisionId}`);
+
+      expect(await getServices(projetId)).toEqual([]);
     });
   });
 

--- a/api/test/ajouts-manuels.e2e-spec.ts
+++ b/api/test/ajouts-manuels.e2e-spec.ts
@@ -193,10 +193,10 @@ describe("Ajouts manuels (e2e)", () => {
       expect(s.ajoutManuel?.message).toBe("Outil local, pas au benchmark DINUM");
     });
 
-    it("n'INVENTE aucune classification : categories et thematiques restent vides", async () => {
-      // On ne connaît pas la classification de ce service. Le dire est plus honnête que de la
-      // fabriquer — et `horsCatalogue` permet au client de distinguer cette ABSENCE d'information
-      // d'une information.
+    it("ne réclame aucune thématique, et n'en invente aucune", async () => {
+      // Les thématiques ne servent qu'à SÉLECTIONNER un service pour un projet. Ici la sélection
+      // est déjà faite, par un humain : exiger une donnée dont personne ne se servira n'aurait
+      // aucun sens. Vides plutôt qu'absents : `service.thematiques.map(...)` ne doit pas planter.
       const projetId = await creerProjet(EAU);
 
       await ajouterLibre(projetId, { nom: "Outil local", description: "Un outil interne." });
@@ -204,10 +204,22 @@ describe("Ajouts manuels (e2e)", () => {
       const [s] = await getServices(projetId);
       expect(s.categories).toEqual([]);
       expect(s.thematiques).toEqual([]);
-      expect(s.ajoutManuel?.horsCatalogue).toBe(true);
+    });
+
+    it("signale la PROVENANCE : ce service ne vient pas de notre catalogue", async () => {
+      // Pas une information de classification, une information d'origine : ce service n'a pas de
+      // fiche chez nous, son logo n'est pas hébergé par l'API, nous n'en cautionnons pas le
+      // contenu. Le client peut le présenter différemment.
+      const projetId = await creerProjet(EAU);
+
+      await ajouterLibre(projetId, { nom: "Outil local", description: "Un outil interne." });
+
+      expect((await getServices(projetId))[0].ajoutManuel?.horsCatalogue).toBe(true);
     });
 
     it("ne marque PAS horsCatalogue un service du catalogue", async () => {
+      // Celui-là a bien une fiche chez nous — et elle reste la source de vérité : on ne recopie
+      // rien, elle continuera d'évoluer.
       await global.testDbService.database
         .insert(servicesNumeriques)
         .values([service({ slug: "au-catalogue", nom: "Au catalogue", classification: VELO })]);

--- a/api/test/ajouts-manuels.e2e-spec.ts
+++ b/api/test/ajouts-manuels.e2e-spec.ts
@@ -1,0 +1,237 @@
+import { eq } from "drizzle-orm";
+import { AideClassification } from "@/aides/dto/aides.dto";
+import { collectivites, projets, servicesNumeriques } from "@database/schema";
+import { mockedDefaultCollectivite, mockProjetPayload } from "@test/mocks/mockProjetPayload";
+import { createApiClient } from "@test/helpers/api-client";
+import { E2E_BASE_URL } from "@test/helpers/e2e-port";
+
+interface AjoutManuel {
+  decisionId: string;
+  message?: string;
+  plateforme: string;
+  date: string;
+}
+interface Service {
+  id: string;
+  nom: string;
+  ajoutManuel?: AjoutManuel;
+}
+
+const EAU: AideClassification = {
+  thematiques: [{ label: "Gestion des eaux pluviales", score: 1 }],
+  sites: [],
+  interventions: [],
+};
+const VELO: AideClassification = {
+  thematiques: [{ label: "Vélo (mobilité douce)", score: 1 }],
+  sites: [],
+  interventions: [],
+};
+
+const service = (over: { slug: string; nom: string; classification?: AideClassification }) => ({
+  description: `Description de ${over.nom}`,
+  categories: [],
+  presentationGenerique: "non",
+  classification: over.classification ?? ({ thematiques: [], sites: [], interventions: [] } as AideClassification),
+  phases: {},
+  ...over,
+});
+
+const appeler = async <T>(
+  methode: "GET" | "POST" | "DELETE",
+  chemin: string,
+  body?: unknown,
+  cle = process.env.MEC_API_KEY,
+): Promise<{ status: number; body: T }> => {
+  const r = await fetch(`${E2E_BASE_URL}${chemin}`, {
+    method: methode,
+    headers: { ...(cle ? { Authorization: `Bearer ${cle}` } : {}), "Content-Type": "application/json" },
+    ...(body !== undefined ? { body: JSON.stringify(body) } : {}),
+  });
+  return { status: r.status, body: (await r.json().catch(() => null)) as T };
+};
+
+const getServices = async (projetId: string, cle = process.env.MEC_API_KEY): Promise<Service[]> =>
+  (await appeler<{ services: Service[] }>("GET", `/projets/${projetId}/services`, undefined, cle)).body.services;
+
+/**
+ * Ajouts manuels d'aides et de services numériques.
+ *
+ * Les cas « aide » ne sont pas testés ici : la garde du périmètre appelle Aides-territoires, qu'on
+ * ne veut pas joindre en e2e. Elle est couverte en unitaire (ajouts-manuels.service.spec.ts), avec
+ * le périmètre mocké.
+ */
+describe("Ajouts manuels (e2e)", () => {
+  const api = createApiClient(process.env.MEC_API_KEY);
+
+  const creerProjet = async (classification: AideClassification | null) => {
+    const { data } = await api.projets.create(mockProjetPayload());
+    const projetId = (data as { id: string }).id;
+    await global.testDbService.database
+      .update(projets)
+      .set({ classificationScores: classification })
+      .where(eq(projets.id, projetId));
+    return projetId;
+  };
+
+  const ajouterService = (projetId: string, slug: string, message?: string, cle = process.env.MEC_API_KEY) =>
+    appeler<{ decisionId: string }>("POST", `/projets/${projetId}/services/ajouts`, { slug, message }, cle);
+
+  beforeEach(async () => {
+    await global.testDbService.database.insert(collectivites).values({
+      type: mockedDefaultCollectivite.type,
+      codeInsee: mockedDefaultCollectivite.code,
+      nom: "Commune 1",
+    });
+  });
+
+  afterEach(async () => {
+    await global.testDbService.cleanDatabase();
+  });
+
+  describe("Ajouter un service numérique", () => {
+    it("le fait remonter sur le projet, avec son message, alors que le score ne l'aurait jamais retenu", async () => {
+      // Le service parle de vélo, le projet d'eaux pluviales : aucun recouvrement, score nul.
+      // C'est exactement le cas d'usage — un humain sait quelque chose que le moteur ignore.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "hors-sujet", nom: "Hors sujet", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      expect(await getServices(projetId)).toEqual([]);
+
+      const { status } = await ajouterService(projetId, "hors-sujet", "Recommandé par la DDT lors du COPIL du 12/03");
+      expect(status).toBe(201);
+
+      const [affiche] = await getServices(projetId);
+      expect(affiche.id).toBe("hors-sujet");
+      expect(affiche.ajoutManuel?.message).toBe("Recommandé par la DDT lors du COPIL du 12/03");
+      expect(affiche.ajoutManuel?.plateforme).toBeTruthy();
+    });
+
+    it("place les ajouts manuels EN TÊTE, devant les services retenus par le score", async () => {
+      // Quelqu'un les a délibérément mis là. Les noyer dans le tri par score les rendrait
+      // indiscernables du résultat du moteur — or c'est la distinction qu'on veut rendre visible.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([
+          service({ slug: "pertinent", nom: "Pertinent", classification: EAU }),
+          service({ slug: "ajoute", nom: "Ajouté", classification: VELO }),
+        ]);
+      const projetId = await creerProjet(EAU);
+
+      await ajouterService(projetId, "ajoute");
+
+      expect((await getServices(projetId)).map((s) => s.id)).toEqual(["ajoute", "pertinent"]);
+    });
+
+    it("n'affiche QU'UNE fois un service à la fois pertinent et ajouté à la main", async () => {
+      // Le dédoublonnage se fait ici, pas dans le client : chaque consommateur devrait sinon le
+      // refaire, et finirait par l'oublier. La marque d'ajout l'emporte.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "double", nom: "Double", classification: EAU })]);
+      const projetId = await creerProjet(EAU);
+
+      await ajouterService(projetId, "double", "Confirmé en réunion");
+
+      const services = await getServices(projetId);
+      expect(services).toHaveLength(1);
+      expect(services[0].ajoutManuel?.message).toBe("Confirmé en réunion");
+    });
+
+    it("refuse un slug inconnu du catalogue", async () => {
+      // Un slug inconnu produirait un ajout qu'aucune lecture ne saurait résoudre : invisible,
+      // donc un bug silencieux. On refuse là où on peut encore l'expliquer.
+      const projetId = await creerProjet(EAU);
+
+      expect((await ajouterService(projetId, "service-qui-nexiste-pas")).status).toBe(404);
+    });
+
+    it("refuse un projet inconnu", async () => {
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "un-service", nom: "Un service" })]);
+
+      const { status } = await ajouterService("00000000-0000-0000-0000-000000000000", "un-service");
+      expect(status).toBe(404);
+    });
+  });
+
+  describe("Retirer un ajout", () => {
+    it("le fait disparaître, sans rien effacer du journal", async () => {
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "ajoute", nom: "Ajouté", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      const { body } = await ajouterService(projetId, "ajoute");
+      expect(await getServices(projetId)).toHaveLength(1);
+
+      const retrait = await appeler("DELETE", `/projets/${projetId}/ajouts/${body.decisionId}`);
+      expect(retrait.status).toBe(200);
+
+      expect(await getServices(projetId)).toEqual([]);
+    });
+
+    it("peut être ré-ajouté après retrait", async () => {
+      // La pierre tombale ne doit pas verrouiller l'objet : c'est un retrait, pas une interdiction.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "ajoute", nom: "Ajouté", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      const { body } = await ajouterService(projetId, "ajoute");
+      await appeler("DELETE", `/projets/${projetId}/ajouts/${body.decisionId}`);
+
+      await ajouterService(projetId, "ajoute", "Finalement si");
+
+      const services = await getServices(projetId);
+      expect(services).toHaveLength(1);
+      expect(services[0].ajoutManuel?.message).toBe("Finalement si");
+    });
+
+    it("404 sur un ajout inconnu", async () => {
+      const projetId = await creerProjet(EAU);
+
+      const { status } = await appeler("DELETE", `/projets/${projetId}/ajouts/00000000-0000-0000-0000-000000000000`);
+      expect(status).toBe(404);
+    });
+  });
+
+  describe("Cloisonnement par plateforme", () => {
+    it("une plateforme ne voit pas les ajouts d'une autre", async () => {
+      // Même règle que pour toute décision : la plateforme est dérivée de la clé d'API. TeT ne doit
+      // pas hériter des ajouts que MEC a faits pour ses propres agents.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "ajoute", nom: "Ajouté", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      await ajouterService(projetId, "ajoute", "Ajout de MEC");
+
+      expect(await getServices(projetId, process.env.MEC_API_KEY)).toHaveLength(1);
+      expect(await getServices(projetId, process.env.TET_API_KEY)).toHaveLength(0);
+    });
+
+    it("une plateforme ne peut pas retirer l'ajout d'une autre", async () => {
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "ajoute", nom: "Ajouté", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      const { body } = await ajouterService(projetId, "ajoute");
+
+      const retrait = await appeler(
+        "DELETE",
+        `/projets/${projetId}/ajouts/${body.decisionId}`,
+        undefined,
+        process.env.TET_API_KEY,
+      );
+      expect(retrait.status).toBe(404);
+
+      // L'ajout de MEC est intact.
+      expect(await getServices(projetId, process.env.MEC_API_KEY)).toHaveLength(1);
+    });
+  });
+});

--- a/api/test/services-numeriques.e2e-spec.ts
+++ b/api/test/services-numeriques.e2e-spec.ts
@@ -13,7 +13,6 @@ interface Service {
   description: string;
   logoUrl?: string;
   categories: string[];
-  thematiques: string[];
   niveauExpertise?: string;
   profilGeneraliste?: boolean;
   redirection?: { url: string; libelle?: string };
@@ -314,6 +313,10 @@ describe("Services numériques (e2e)", () => {
       expect(charge).not.toContain("phases");
       expect(charge).not.toContain("presentationGenerique");
       expect(charge).not.toContain("score");
+      // `thematiques` était le critère de sélection, exposé sous forme de libellés — le contrat se
+      // contredisait lui-même. Un client qui l'aurait affiché aurait montré à une collectivité les
+      // entrailles du moteur, et non une information sur le service.
+      expect(charge).not.toContain("thematiques");
     });
 
     it("projette les champs d'affichage attendus par MEC", async () => {
@@ -335,7 +338,6 @@ describe("Services numériques (e2e)", () => {
       expect(service0.id).toBe("boussole-de-la-transition-ecologique");
       expect(service0.categories).toEqual(["contenu", "expert"]);
       expect(service0.niveauExpertise).toBe("bas");
-      expect(service0.thematiques).toEqual(["Gestion des eaux pluviales"]);
       expect(service0.redirection?.url).toContain("https://");
     });
   });


### PR DESCRIPTION
Un agent voit ce que le moteur rate. Ces endpoints lui permettent d'attacher une aide ou un service numérique à un projet, avec un message qui dit pourquoi (« recommandée par la DDT lors du COPIL du 12/03 »).

```
POST   /projets/:id/aides/ajouts      { aideId, message?, auteur? }
POST   /projets/:id/services/ajouts   { slug, … }     ← service du catalogue
POST   /projets/:id/services/ajouts   { service, … }  ← service décrit à la main
DELETE /projets/:id/ajouts/:decisionId
```

## Aucune nouvelle table

Un ajout manuel **est** une décision humaine, et le journal `decisions_humaines.decisions` en porte déjà toute la sémantique : append-only, auteur, date, **message** (le champ `commentaire` existait déjà), plateforme dérivée de la clé d'API, cloisonnement, révocation par `supersedes`.

**Retirer = révoquer, pas supprimer.** La trace de ce qui a été fait, et défait, reste.

## Lecture fondue

Les ajouts remontent dans `GET /aides?projetId=` et `GET /projets/:id/services`, marqués `ajoutManuel`. MEC n'a aucun nouvel endpoint à appeler.

Ils sont **en tête** et **échappent au cutoff** : quelqu'un les a délibérément mis là, précisément parce que le moteur les ratait. Les soumettre au filtre qui les a ratés serait absurde. Un objet à la fois pertinent **et** ajouté n'apparaît **qu'une fois**, avec sa marque — le dédoublonnage se fait ici, pas dans le client.

## Aides : on ne stocke que l'id

Une aide n'est persistée **nulle part** (cache Redis, rechargée depuis Aides-territoires, filtrée par territoire). On la résout **au frais** à chaque lecture. Si elle a été clôturée ou dépubliée, elle cesse de s'afficher — et c'est le bon comportement : mieux vaut ne rien montrer que d'envoyer une collectivité candidater à une aide morte, ce que ferait un instantané figé.

**On ne peut d'ailleurs pas faire autrement.** Vérifié contre l'API réelle :

| Requête | Résultat |
|---|---|
| `GET /aids/<id>/` | **404** |
| `GET /aids/?id=<n>` | 200 — **3201 aides** |

Aides-territoires **ne sait pas** récupérer une aide par son id, et le filtre n'est pas rejeté : il est **silencieusement ignoré**. Un code qui lui aurait fait confiance aurait « marché » en renvoyant le catalogue entier.

**D'où la garde à l'écriture** : on refuse (400) une aide hors périmètre du projet. Sans elle, on créerait un ajout que la lecture ne saurait jamais résoudre — invisible, sans le moindre message.

## Services : id si connu, description sinon

Deux façons, et **exactement une des deux** :

- **`slug`** — le service est au catalogue. On ne recopie **rien** : sa fiche reste la source de vérité et continuera d'évoluer (logo, description, lien). La figer ici l'aurait dédoublée.
- **`service`** — il n'y est **pas** : un outil local, un service partenaire pas encore benchmarké. L'agent le décrit lui-même (nom, description, lien, opérateur, logo).

Fournir les deux serait ambigu, n'en fournir aucun n'ajoute rien : on refuse plutôt que de choisir en silence.

**Pourquoi recopier est légitime ici, alors qu'on l'a refusé pour une aide.** Le catalogue de services est **le nôtre** : un service qui n'y figure pas existe quand même, et personne d'autre ne peut le décrire — l'agent **est** la source, il n'y a aucune autorité extérieure à tenir en phase. Une aide, au contraire, n'existe que dans Aides-territoires.

**On n'invente aucune classification.** `categories` et `thematiques` sortent **vides** pour un service hors catalogue : on ne la connaît pas, et le dire est plus honnête que de la fabriquer. Le drapeau `ajoutManuel.horsCatalogue` permet au client de distinguer cette **absence** d'information d'une information.

C'est aussi ce qui rend la chose possible ici et impossible pour les aides : `ServiceResponse` a **5** champs obligatoires, tous renseignables sans mentir. Une `Aide` en a **42** — un instantané léger aurait forcé à fabriquer 39 champs faux.

## Refactoring nécessaire

« Quelles aides sont sur le territoire de ce projet » vivait **en privé dans `AidesController`**. Les ajouts manuels en ont besoin pour leur garde : la recopier aurait garanti la divergence.

Extrait dans `AidesPerimetreService`, avec son propre module — qui casse le cycle `Aides ↔ AjoutsManuels` et **porte le cache Redis**, pour que deux modules ne l'instancient pas chacun de leur côté (deux connexions, deux caches, deux vérités). La logique SWR est **inchangée** : le spec du contrôleur construit désormais le vrai service sur les mêmes mocks, et continue donc de la valider réellement.

## Tests

**531 unitaires** (dont la garde du périmètre, Aides-territoires mocké) et **69 e2e** : ajout d'un service que le score n'aurait jamais retenu, service hors catalogue, classification non inventée, ordre, dédoublonnage, retrait puis ré-ajout, cloisonnement par plateforme, refus de `slug` + `service` ensemble, 404 sur slug ou projet inconnu.

🤖 Generated with [Claude Code](https://claude.com/claude-code)