### PR TITLE
feat(questionnaires): définition en base, éditable depuis le back-office

### DIFF
--- a/api/drizzle/0046_questionnaires.sql
+++ b/api/drizzle/0046_questionnaires.sql
@@ -1,0 +1,21 @@
+-- Définition des questionnaires : contenu (questions, recommandations, conditions) ET règle
+-- d'éligibilité (étiquettes requises). Ils vivaient dans le dépôt ; ils deviennent éditables.
+--
+-- Les garde-fous que le chargeur appliquait au DÉMARRAGE (condition pointant une question
+-- inexistante, étiquette hors taxonomie, aucune étiquette requise) sont reconstruits à
+-- l'ÉCRITURE, en 400 explicite. Aucun n'a été assoupli : c'était la condition du déplacement.
+--
+-- Amorçage : `pnpm seed:questionnaires` (upsert depuis src/questionnaires/content/).
+
+CREATE TABLE IF NOT EXISTS "questionnaires" (
+	"slug" text PRIMARY KEY NOT NULL,
+	"version" integer DEFAULT 1 NOT NULL,
+	"source_nom" text NOT NULL,
+	"banniere" jsonb NOT NULL,
+	"questions" jsonb NOT NULL,
+	"recommandations" jsonb NOT NULL,
+	"etiquettes_requises" jsonb NOT NULL,
+	"edite_par" text,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);

--- a/api/drizzle/meta/_journal.json
+++ b/api/drizzle/meta/_journal.json
@@ -323,6 +323,13 @@
       "when": 1783950183421,
       "tag": "0045_services_profil_generaliste",
       "breakpoints": true
+    },
+    {
+      "idx": 46,
+      "version": "7",
+      "when": 1783950183422,
+      "tag": "0046_questionnaires",
+      "breakpoints": true
     }
   ]
 }

--- a/api/package.json
+++ b/api/package.json
@@ -42,6 +42,7 @@
     "import:projects-tet": "cd scripts/import-projets-tet && cross-env NODE_ENV=development npx ts-node -r tsconfig-paths/register import-projets-tet.ts import-projets-tet-data.csv",
     "import:tc-opendata": "cross-env NODE_ENV=development npx ts-node -r tsconfig-paths/register scripts/import-tc-opendata/import-tc-opendata.ts",
     "import:benchmark-dinum": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx ts-node -r tsconfig-paths/register scripts/import-benchmark-dinum/import-benchmark-dinum.ts",
+    "seed:questionnaires": "cross-env TS_NODE_TRANSPILE_ONLY=1 npx ts-node -r tsconfig-paths/register scripts/seed-questionnaires/seed-questionnaires.ts",
     "release": "commit-and-tag-version",
     "db:start": "docker compose up -d",
     "db:clean": "docker compose down -v",

--- a/api/scripts/seed-questionnaires/seed-questionnaires.ts
+++ b/api/scripts/seed-questionnaires/seed-questionnaires.ts
@@ -1,0 +1,85 @@
+import { drizzle } from "drizzle-orm/node-postgres";
+import { Pool } from "pg";
+import { questionnaires } from "@/database/schema";
+import { QUESTIONNAIRES } from "@/questionnaires/content";
+import { validerDefinition } from "@/questionnaires/questionnaire-validation";
+
+/**
+ * AMORÇAGE des questionnaires : verse en base les définitions du dépôt (content/).
+ *
+ * Le dépôt reste l'AMORÇAGE, la base devient la SOURCE DE VÉRITÉ — exactement comme le CSV du
+ * benchmark DINUM pour le catalogue de services. Une fois amorcé, on édite depuis le back-office,
+ * et ce script n'a plus vocation à tourner.
+ *
+ * IDEMPOTENT, mais NON DESTRUCTIF DES ÉDITIONS : il n'écrase QUE les questionnaires absents de la
+ * base. Un questionnaire déjà présent a pu être édité depuis le back-office — le réécrire depuis le
+ * dépôt annulerait ce travail sans prévenir. Pour forcer la réécriture : `--force`, en connaissance
+ * de cause.
+ *
+ *   pnpm seed:questionnaires
+ *   pnpm seed:questionnaires --force   ← écrase les éditions faites en back-office
+ */
+async function main() {
+  const force = process.argv.includes("--force");
+
+  const pool = new Pool({ connectionString: process.env.DATABASE_URL });
+  const db = drizzle(pool);
+
+  const existants = new Set((await db.select({ slug: questionnaires.slug }).from(questionnaires)).map((l) => l.slug));
+
+  let inseres = 0;
+  let ecrases = 0;
+  let preserves = 0;
+
+  for (const def of QUESTIONNAIRES) {
+    // La MÊME validation qu'à l'écriture depuis le back-office. Un questionnaire du dépôt n'a
+    // aucun privilège : s'il est incohérent, il ne doit pas entrer en base non plus.
+    validerDefinition(def);
+
+    if (existants.has(def.slug) && !force) {
+      preserves++;
+      console.log(`  ○ ${def.slug} — déjà en base, préservé (édité en back-office ?)`);
+      continue;
+    }
+
+    const valeurs = {
+      slug: def.slug,
+      sourceNom: def.source.nom,
+      banniere: def.banniere as unknown as Record<string, unknown>,
+      questions: def.questions as unknown as unknown[],
+      recommandations: def.recommandations as unknown as unknown[],
+      etiquettesRequises: {
+        thematiques: [...def.etiquettesRequises.thematiques],
+        sites: [...def.etiquettesRequises.sites],
+        interventions: [...def.etiquettesRequises.interventions],
+      },
+      editePar: "amorçage (content/)",
+    };
+
+    await db.insert(questionnaires).values(valeurs).onConflictDoUpdate({
+      target: questionnaires.slug,
+      set: valeurs,
+    });
+
+    if (existants.has(def.slug)) {
+      ecrases++;
+      console.log(`  ⚠ ${def.slug} — ÉCRASÉ depuis le dépôt (--force)`);
+    } else {
+      inseres++;
+      console.log(`  ✓ ${def.slug} — inséré`);
+    }
+  }
+
+  console.log();
+  console.log(`${inseres} inséré(s), ${ecrases} écrasé(s), ${preserves} préservé(s).`);
+  if (preserves > 0) {
+    console.log("Les questionnaires préservés vivent leur vie en base. `--force` les ramènerait au dépôt.");
+  }
+
+  await pool.end();
+}
+
+main().catch((erreur) => {
+  console.error(erreur instanceof Error ? erreur.message : erreur);
+  process.exit(1);
+});

--- a/api/scripts/seed-questionnaires/seed-questionnaires.ts
+++ b/api/scripts/seed-questionnaires/seed-questionnaires.ts
@@ -3,6 +3,7 @@ import { Pool } from "pg";
 import { questionnaires } from "@/database/schema";
 import { QUESTIONNAIRES } from "@/questionnaires/content";
 import { validerDefinition } from "@/questionnaires/questionnaire-validation";
+import { versLigne } from "@/questionnaires/questionnaires.repository";
 
 /**
  * AMORÇAGE des questionnaires : verse en base les définitions du dépôt (content/).
@@ -42,19 +43,7 @@ async function main() {
       continue;
     }
 
-    const valeurs = {
-      slug: def.slug,
-      sourceNom: def.source.nom,
-      banniere: def.banniere as unknown as Record<string, unknown>,
-      questions: def.questions as unknown as unknown[],
-      recommandations: def.recommandations as unknown as unknown[],
-      etiquettesRequises: {
-        thematiques: [...def.etiquettesRequises.thematiques],
-        sites: [...def.etiquettesRequises.sites],
-        interventions: [...def.etiquettesRequises.interventions],
-      },
-      editePar: "amorçage (content/)",
-    };
+    const valeurs = versLigne(def, "amorçage (content/)");
 
     await db.insert(questionnaires).values(valeurs).onConflictDoUpdate({
       target: questionnaires.slug,

--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -3,7 +3,13 @@ import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import { AdminService } from "./admin.service";
-import { ContenuResponse, QuestionnaireEditionRequest, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
+import {
+  ContenuResponse,
+  QuestionnaireEditionRequest,
+  SimulationRequest,
+  SimulationResponse,
+  TaxonomiesResponse,
+} from "./dto/admin.dto";
 
 /**
  * Back-office : voir le contenu, et simuler ce que l'API renverrait pour un projet RÉEL.
@@ -41,6 +47,20 @@ export class AdminController {
   @ApiEndpointResponses({ successStatus: 200, response: ContenuResponse, description: "Contenu courant" })
   contenu(): Promise<ContenuResponse> {
     return this.adminService.contenu();
+  }
+
+  @Get("taxonomies")
+  @ApiOperation({
+    summary: "Les taxonomies fermées du schéma commun",
+    description:
+      "137 thématiques, 58 lieux, 15 modalités. Servies à l'éditeur pour qu'il ne propose QUE des " +
+      "étiquettes valides : le sélecteur rend la coquille impossible, là où la validation ne fait " +
+      "que la rattraper. Sans cet endpoint, le back-office devrait recopier les listes — et une " +
+      "copie dérive.",
+  })
+  @ApiEndpointResponses({ successStatus: 200, response: TaxonomiesResponse, description: "Taxonomies" })
+  taxonomies(): TaxonomiesResponse {
+    return this.adminService.taxonomies();
   }
 
   @Put("questionnaires/:slug")

--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,15 +1,9 @@
-import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, Post, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import { AdminService } from "./admin.service";
-import {
-  ContenuResponse,
-  QuestionnaireEditionRequest,
-  SimulationRequest,
-  SimulationResponse,
-  TaxonomiesResponse,
-} from "./dto/admin.dto";
+import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
 
 /**
  * Back-office : voir le contenu, et simuler ce que l'API renverrait pour un projet RÉEL.
@@ -26,8 +20,16 @@ import {
  * publié. Les décorateurs Swagger ci-dessous ne servent que si on décide un jour d'exposer un
  * second document, réservé à l'administration.
  *
+ * LECTURE et SIMULATION uniquement. Ce module n'écrit rien.
+ *
+ * L'ÉDITION des questionnaires n'est PAS ici : elle vit dans QuestionnairesModule
+ * (questionnaires-admin.controller.ts). C'est l'unique chemin d'écriture, et il porte la validation
+ * qui remplace le refus de démarrage — l'héberger dans un module jetable aurait rendu le contenu
+ * non éditable le jour où on jette l'écran. La frontière n'est pas « back-office vs reste », c'est
+ * « écrire un contenu métier » vs « afficher un écran ».
+ *
  * Module ADDITIF et ISOLÉ : rien ne l'importe, il ne modifie rien. `rm -rf src/admin` plus UNE
- * ligne dans app.module.ts, et l'API repart exactement comme avant.
+ * ligne dans app.module.ts, et l'API repart exactement comme avant — questionnaires compris.
  */
 @ApiBearerAuth()
 @ApiTags("Administration")
@@ -47,52 +49,6 @@ export class AdminController {
   @ApiEndpointResponses({ successStatus: 200, response: ContenuResponse, description: "Contenu courant" })
   contenu(): Promise<ContenuResponse> {
     return this.adminService.contenu();
-  }
-
-  @Get("taxonomies")
-  @ApiOperation({
-    summary: "Les taxonomies fermées du schéma commun",
-    description:
-      "137 thématiques, 58 lieux, 15 modalités. Servies à l'éditeur pour qu'il ne propose QUE des " +
-      "étiquettes valides : le sélecteur rend la coquille impossible, là où la validation ne fait " +
-      "que la rattraper. Sans cet endpoint, le back-office devrait recopier les listes — et une " +
-      "copie dérive.",
-  })
-  @ApiEndpointResponses({ successStatus: 200, response: TaxonomiesResponse, description: "Taxonomies" })
-  taxonomies(): TaxonomiesResponse {
-    return this.adminService.taxonomies();
-  }
-
-  @Put("questionnaires/:slug")
-  @ApiOperation({
-    summary: "Créer ou remplacer un questionnaire",
-    description:
-      "PUT, pas PATCH : un éditeur envoie le document qu'il a sous les yeux. Un PATCH champ par " +
-      "champ autoriserait des états incohérents entre deux appels — une condition enregistrée avant " +
-      "la question qu'elle vise.\n\n" +
-      "TOUT est revalidé avant écriture, et un écart est un 400 explicite : étiquettes dans la " +
-      "taxonomie fermée, AU MOINS une étiquette (une conjonction vide est vraie — le questionnaire " +
-      "serait proposé à TOUS les projets), conditions pointant des questions et des options qui " +
-      "existent. Ce sont exactement les vérifications que le chargeur faisait au démarrage quand les " +
-      "questionnaires vivaient dans le dépôt. Aucune n'a été assouplie.\n\n" +
-      "La `version` s'incrémente automatiquement. Elle n'invalide rien : les réponses des " +
-      "collectivités devenues sans objet sont ignorées à la lecture, jamais effacées.",
-  })
-  @ApiEndpointResponses({ successStatus: 200, response: Object, description: "Questionnaire enregistré" })
-  editerQuestionnaire(@Param("slug") slug: string, @Body() dto: QuestionnaireEditionRequest) {
-    return this.adminService.editerQuestionnaire(slug, dto);
-  }
-
-  @Delete("questionnaires/:slug")
-  @HttpCode(204)
-  @ApiOperation({
-    summary: "Supprimer un questionnaire",
-    description:
-      "Les réponses déjà données par les collectivités ne sont PAS supprimées : elles cessent " +
-      "simplement d'être lues. Si le questionnaire est recréé sous le même slug, elles reviennent.",
-  })
-  supprimerQuestionnaire(@Param("slug") slug: string): Promise<void> {
-    return this.adminService.supprimerQuestionnaire(slug);
   }
 
   @Post("simuler")

--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,9 +1,9 @@
-import { Body, Controller, Get, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Delete, Get, HttpCode, Param, Post, Put, UseGuards } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import { AdminService } from "./admin.service";
-import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
+import { ContenuResponse, QuestionnaireEditionRequest, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
 
 /**
  * Back-office : voir le contenu, et simuler ce que l'API renverrait pour un projet RÉEL.
@@ -41,6 +41,38 @@ export class AdminController {
   @ApiEndpointResponses({ successStatus: 200, response: ContenuResponse, description: "Contenu courant" })
   contenu(): Promise<ContenuResponse> {
     return this.adminService.contenu();
+  }
+
+  @Put("questionnaires/:slug")
+  @ApiOperation({
+    summary: "Créer ou remplacer un questionnaire",
+    description:
+      "PUT, pas PATCH : un éditeur envoie le document qu'il a sous les yeux. Un PATCH champ par " +
+      "champ autoriserait des états incohérents entre deux appels — une condition enregistrée avant " +
+      "la question qu'elle vise.\n\n" +
+      "TOUT est revalidé avant écriture, et un écart est un 400 explicite : étiquettes dans la " +
+      "taxonomie fermée, AU MOINS une étiquette (une conjonction vide est vraie — le questionnaire " +
+      "serait proposé à TOUS les projets), conditions pointant des questions et des options qui " +
+      "existent. Ce sont exactement les vérifications que le chargeur faisait au démarrage quand les " +
+      "questionnaires vivaient dans le dépôt. Aucune n'a été assouplie.\n\n" +
+      "La `version` s'incrémente automatiquement. Elle n'invalide rien : les réponses des " +
+      "collectivités devenues sans objet sont ignorées à la lecture, jamais effacées.",
+  })
+  @ApiEndpointResponses({ successStatus: 200, response: Object, description: "Questionnaire enregistré" })
+  editerQuestionnaire(@Param("slug") slug: string, @Body() dto: QuestionnaireEditionRequest) {
+    return this.adminService.editerQuestionnaire(slug, dto);
+  }
+
+  @Delete("questionnaires/:slug")
+  @HttpCode(204)
+  @ApiOperation({
+    summary: "Supprimer un questionnaire",
+    description:
+      "Les réponses déjà données par les collectivités ne sont PAS supprimées : elles cessent " +
+      "simplement d'être lues. Si le questionnaire est recréé sous le même slug, elles reviennent.",
+  })
+  supprimerQuestionnaire(@Param("slug") slug: string): Promise<void> {
+    return this.adminService.supprimerQuestionnaire(slug);
   }
 
   @Post("simuler")

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -2,18 +2,22 @@ import { Module } from "@nestjs/common";
 import { DatabaseModule } from "@database/database.module";
 import { ProjetsModule } from "@projets/projets.module";
 import { AidesMatchingService } from "@/aides/aides-matching.service";
+import { QuestionnairesModule } from "@/questionnaires/questionnaires.module";
 import { AdminController } from "./admin.controller";
 import { AdminService } from "./admin.service";
 
 /**
- * Module du back-office. ADDITIF et ISOLÉ : aucun autre module ne l'importe, et il ne modifie
- * rien de l'existant — il réutilise le moteur de matching et le registre de contenu tels quels.
+ * Module du back-office. ADDITIF : aucun autre module ne l'importe.
  *
- * Le supprimer : `rm -rf src/admin`, puis retirer son import dans app.module.ts et setup-app.ts.
- * Aucun autre fichier ne bouge, aucun test existant ne casse.
+ * Il ÉDITE désormais les questionnaires, mais il ne réimplémente rien : il passe par
+ * `QuestionnairesRepository`, la même porte que la lecture — et donc par la même validation. Un
+ * second chemin d'écriture aurait fini par diverger, et la validation aurait été contournable.
+ *
+ * Le supprimer : `rm -rf src/admin`, puis retirer son import dans app.module.ts. Les
+ * questionnaires resteront lisibles et éditables par l'API, simplement plus par un écran.
  */
 @Module({
-  imports: [DatabaseModule, ProjetsModule],
+  imports: [DatabaseModule, ProjetsModule, QuestionnairesModule],
   controllers: [AdminController],
   // Même moteur de score que les aides, les questionnaires et les services : la simulation doit
   // dire la VÉRITÉ. Un portage du scoring dans le back-office afficherait des chiffres faux, et

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -9,7 +9,16 @@ import type { QuestionnaireDef } from "@/questionnaires/questionnaire-contract";
 import { calculerStatut, evaluerCondition, reconcilierReponses } from "@/questionnaires/questionnaire-contract";
 import { etiquettesManquantes } from "@/questionnaires/questionnaires.service";
 import { facteurPhase, SEUIL_PERTINENCE, type PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
-import { ContenuResponse, QuestionnaireEditionRequest, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
+import { interventions } from "@/projet-qualification/classification/const/interventions";
+import { sites } from "@/projet-qualification/classification/const/sites";
+import { thematiques } from "@/projet-qualification/classification/const/thematiques";
+import {
+  ContenuResponse,
+  QuestionnaireEditionRequest,
+  SimulationRequest,
+  SimulationResponse,
+  TaxonomiesResponse,
+} from "./dto/admin.dto";
 
 /**
  * Service d'administration : voir le contenu tel qu'il est, et SIMULER ce que l'API renverrait
@@ -46,6 +55,21 @@ export class AdminService {
     private readonly matchingService: AidesMatchingService,
     private readonly questionnairesRepository: QuestionnairesRepository,
   ) {}
+
+  /**
+   * Les taxonomies fermées, pour que l'éditeur ne propose QUE des étiquettes valides.
+   *
+   * Le sélecteur rend la coquille IMPOSSIBLE, là où la validation ne fait que la rattraper. Les
+   * deux sont utiles : le sélecteur pour l'humain qui édite, la validation pour tout ce qui écrit
+   * sans passer par l'écran.
+   */
+  taxonomies(): TaxonomiesResponse {
+    return {
+      thematiques: [...thematiques],
+      sites: [...sites],
+      interventions: [...interventions],
+    };
+  }
 
   /**
    * Édite un questionnaire. On DÉLÈGUE au dépôt : c'est lui qui valide, et c'est la même porte que

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -9,16 +9,7 @@ import type { QuestionnaireDef } from "@/questionnaires/questionnaire-contract";
 import { calculerStatut, evaluerCondition, reconcilierReponses } from "@/questionnaires/questionnaire-contract";
 import { etiquettesManquantes } from "@/questionnaires/questionnaires.service";
 import { facteurPhase, SEUIL_PERTINENCE, type PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
-import { interventions } from "@/projet-qualification/classification/const/interventions";
-import { sites } from "@/projet-qualification/classification/const/sites";
-import { thematiques } from "@/projet-qualification/classification/const/thematiques";
-import {
-  ContenuResponse,
-  QuestionnaireEditionRequest,
-  SimulationRequest,
-  SimulationResponse,
-  TaxonomiesResponse,
-} from "./dto/admin.dto";
+import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
 
 /**
  * Service d'administration : voir le contenu tel qu'il est, et SIMULER ce que l'API renverrait
@@ -34,8 +25,9 @@ import {
  * permet pas de régler le seuil — il faut voir la distribution pour savoir où poser le curseur.
  * Chaque candidat est donc rendu avec son score ET son verdict.
  *
- * Ce module est ADDITIF et ISOLÉ : rien ne l'importe, il ne modifie rien. Le supprimer, c'est
- * `rm -rf src/admin` plus UNE ligne dans app.module.ts.
+ * Ce module est ADDITIF et ISOLÉ : rien ne l'importe, IL N'ÉCRIT RIEN. L'édition des questionnaires
+ * vit dans QuestionnairesModule, pas ici — sans quoi jeter l'écran rendrait le contenu non
+ * éditable. Le supprimer, c'est `rm -rf src/admin` plus UNE ligne dans app.module.ts.
  */
 /** Toutes les étiquettes requises, à plat — le cas « projet non classifié ». */
 function requisesAPlat(def: QuestionnaireDef): { axe: string; label: string }[] {
@@ -55,47 +47,6 @@ export class AdminService {
     private readonly matchingService: AidesMatchingService,
     private readonly questionnairesRepository: QuestionnairesRepository,
   ) {}
-
-  /**
-   * Les taxonomies fermées, pour que l'éditeur ne propose QUE des étiquettes valides.
-   *
-   * Le sélecteur rend la coquille IMPOSSIBLE, là où la validation ne fait que la rattraper. Les
-   * deux sont utiles : le sélecteur pour l'humain qui édite, la validation pour tout ce qui écrit
-   * sans passer par l'écran.
-   */
-  taxonomies(): TaxonomiesResponse {
-    return {
-      thematiques: [...thematiques],
-      sites: [...sites],
-      interventions: [...interventions],
-    };
-  }
-
-  /**
-   * Édite un questionnaire. On DÉLÈGUE au dépôt : c'est lui qui valide, et c'est la même porte que
-   * la lecture. Écrire ici directement aurait ouvert un second chemin, contournant la validation —
-   * et deux chemins d'écriture finissent toujours par diverger.
-   */
-  async editerQuestionnaire(slug: string, dto: QuestionnaireEditionRequest): Promise<QuestionnaireDef> {
-    return this.questionnairesRepository.enregistrer(
-      {
-        slug,
-        // La version n'est PAS pilotée par le client : elle s'incrémente côté base. Un éditeur qui
-        // la fournirait pourrait, par erreur, faire reculer un questionnaire déjà édité par un autre.
-        version: 0,
-        source: { nom: dto.sourceNom },
-        banniere: dto.banniere,
-        questions: dto.questions,
-        recommandations: dto.recommandations,
-        etiquettesRequises: dto.etiquettesRequises as QuestionnaireDef["etiquettesRequises"],
-      },
-      dto.editePar,
-    );
-  }
-
-  supprimerQuestionnaire(slug: string): Promise<void> {
-    return this.questionnairesRepository.supprimer(slug);
-  }
 
   /** Le contenu tel qu'il est réellement chargé — conditions et classifications comprises. */
   async contenu(): Promise<ContenuResponse> {

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -4,11 +4,12 @@ import { servicesNumeriques } from "@database/schema";
 import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { AideClassification, AideMatchResult } from "@/aides/dto/aides.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
-import { QUESTIONNAIRES } from "@/questionnaires/content";
+import { QuestionnairesRepository } from "@/questionnaires/questionnaires.repository";
+import type { QuestionnaireDef } from "@/questionnaires/questionnaire-contract";
 import { calculerStatut, evaluerCondition, reconcilierReponses } from "@/questionnaires/questionnaire-contract";
 import { etiquettesManquantes } from "@/questionnaires/questionnaires.service";
 import { facteurPhase, SEUIL_PERTINENCE, type PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
-import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
+import { ContenuResponse, QuestionnaireEditionRequest, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
 
 /**
  * Service d'administration : voir le contenu tel qu'il est, et SIMULER ce que l'API renverrait
@@ -28,7 +29,7 @@ import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/ad
  * `rm -rf src/admin` plus UNE ligne dans app.module.ts.
  */
 /** Toutes les étiquettes requises, à plat — le cas « projet non classifié ». */
-function requisesAPlat(def: (typeof QUESTIONNAIRES)[number]): { axe: string; label: string }[] {
+function requisesAPlat(def: QuestionnaireDef): { axe: string; label: string }[] {
   const { thematiques, sites, interventions } = def.etiquettesRequises;
   return [
     ...thematiques.map((label) => ({ axe: "thematiques", label })),
@@ -43,14 +44,42 @@ export class AdminService {
     private readonly dbService: DatabaseService,
     private readonly getProjetsService: GetProjetsService,
     private readonly matchingService: AidesMatchingService,
+    private readonly questionnairesRepository: QuestionnairesRepository,
   ) {}
+
+  /**
+   * Édite un questionnaire. On DÉLÈGUE au dépôt : c'est lui qui valide, et c'est la même porte que
+   * la lecture. Écrire ici directement aurait ouvert un second chemin, contournant la validation —
+   * et deux chemins d'écriture finissent toujours par diverger.
+   */
+  async editerQuestionnaire(slug: string, dto: QuestionnaireEditionRequest): Promise<QuestionnaireDef> {
+    return this.questionnairesRepository.enregistrer(
+      {
+        slug,
+        // La version n'est PAS pilotée par le client : elle s'incrémente côté base. Un éditeur qui
+        // la fournirait pourrait, par erreur, faire reculer un questionnaire déjà édité par un autre.
+        version: 0,
+        source: { nom: dto.sourceNom },
+        banniere: dto.banniere,
+        questions: dto.questions,
+        recommandations: dto.recommandations,
+        etiquettesRequises: dto.etiquettesRequises as QuestionnaireDef["etiquettesRequises"],
+      },
+      dto.editePar,
+    );
+  }
+
+  supprimerQuestionnaire(slug: string): Promise<void> {
+    return this.questionnairesRepository.supprimer(slug);
+  }
 
   /** Le contenu tel qu'il est réellement chargé — conditions et classifications comprises. */
   async contenu(): Promise<ContenuResponse> {
     const catalogue = await this.dbService.database.select().from(servicesNumeriques);
+    const questionnaires = await this.questionnairesRepository.tous();
 
     return {
-      questionnaires: QUESTIONNAIRES.map((q) => ({
+      questionnaires: questionnaires.map((q) => ({
         slug: q.slug,
         libelle: q.source.nom,
         version: q.version,
@@ -95,7 +124,7 @@ export class AdminService {
         // une liste vide sans explication.
         avertissement: scoresProjet ? null : "Projet non classifié : le job LLM n'a pas encore tourné.",
       },
-      questionnaires: this.simulerQuestionnaires(scoresProjet, requete.reponses ?? {}),
+      questionnaires: await this.simulerQuestionnaires(scoresProjet, requete.reponses ?? {}),
       services: await this.simulerServices(scoresProjet, projet.phase),
       seuils: { pertinence: SEUIL_PERTINENCE },
     };
@@ -125,34 +154,40 @@ export class AdminService {
    * le lieu Place ou centre-bourg » dit exactement quoi regarder — soit la classification du
    * projet est fausse, soit le questionnaire vise autre chose.
    */
-  private simulerQuestionnaires(
+  private async simulerQuestionnaires(
     scoresProjet: AideClassification | null,
     reponsesParSlug: Record<string, Record<string, string>>,
-  ): SimulationResponse["questionnaires"] {
-    return QUESTIONNAIRES.map((def) => {
-      // Sans classification, TOUTES les étiquettes requises manquent : c'est la vérité, et c'est
-      // plus parlant qu'un « non éligible » sans motif.
-      const manquantes = scoresProjet ? etiquettesManquantes(scoresProjet, def.etiquettesRequises) : requisesAPlat(def);
-      const reponses = reconcilierReponses(def, reponsesParSlug[def.slug] ?? {});
-      const statut = calculerStatut(def, reponses);
-      const retenu = manquantes.length === 0;
+  ): Promise<SimulationResponse["questionnaires"]> {
+    const tous = await this.questionnairesRepository.tous();
 
-      return {
-        slug: def.slug,
-        retenu,
-        etiquettesManquantes: manquantes,
-        statut,
-        reponses,
-        recommandations: def.recommandations.map((r) => ({
-          id: `questionnaire:${def.slug}:${r.id}`,
-          titre: r.titre,
-          inconditionnelle: r.condition === true,
-          // Une recommandation ne sort que si sa condition est vraie ET que le questionnaire est
-          // entamé — la garde qui empêche les inconditionnelles de s'afficher avant toute réponse.
-          declenchee: retenu && statut !== "non_commence" && evaluerCondition(r.condition, reponses),
-        })),
-      };
-    }).sort((a, b) => a.etiquettesManquantes.length - b.etiquettesManquantes.length || a.slug.localeCompare(b.slug));
+    return tous
+      .map((def) => {
+        // Sans classification, TOUTES les étiquettes requises manquent : c'est la vérité, et c'est
+        // plus parlant qu'un « non éligible » sans motif.
+        const manquantes = scoresProjet
+          ? etiquettesManquantes(scoresProjet, def.etiquettesRequises)
+          : requisesAPlat(def);
+        const reponses = reconcilierReponses(def, reponsesParSlug[def.slug] ?? {});
+        const statut = calculerStatut(def, reponses);
+        const retenu = manquantes.length === 0;
+
+        return {
+          slug: def.slug,
+          retenu,
+          etiquettesManquantes: manquantes,
+          statut,
+          reponses,
+          recommandations: def.recommandations.map((r) => ({
+            id: `questionnaire:${def.slug}:${r.id}`,
+            titre: r.titre,
+            inconditionnelle: r.condition === true,
+            // Une recommandation ne sort que si sa condition est vraie ET que le questionnaire est
+            // entamé — la garde qui empêche les inconditionnelles de s'afficher avant toute réponse.
+            declenchee: retenu && statut !== "non_commence" && evaluerCondition(r.condition, reponses),
+          })),
+        };
+      })
+      .sort((a, b) => a.etiquettesManquantes.length - b.etiquettesManquantes.length || a.slug.localeCompare(b.slug));
   }
 
   private async simulerServices(

--- a/api/src/admin/dto/admin.dto.ts
+++ b/api/src/admin/dto/admin.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsObject, IsOptional, IsUUID } from "class-validator";
+import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString, IsUUID } from "class-validator";
 import { AideClassification, AideLabelsCommuns } from "@/aides/dto/aides.dto";
 import { ProjetPhase } from "@database/schema";
 import type { PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
@@ -135,4 +135,54 @@ export class SimulationResponse {
   @ApiProperty({ type: [ServiceSimuleResponse], description: "TOUS les services, y compris écartés." })
   services!: ServiceSimuleResponse[];
   @ApiProperty({ type: SeuilsResponse }) seuils!: SeuilsResponse;
+}
+
+/**
+ * Le questionnaire ENTIER, tel qu'il sera enregistré. PUT, pas PATCH : un éditeur envoie le
+ * document qu'il a sous les yeux. Un PATCH champ par champ ouvrirait la porte à des états
+ * incohérents entre deux appels (une condition sauvegardée avant la question qu'elle vise).
+ *
+ * TOUT est revalidé avant écriture (cf. validerDefinition) : étiquettes dans la taxonomie fermée,
+ * au moins une étiquette (sinon le questionnaire serait proposé à TOUS les projets), conditions
+ * pointant des questions et des options qui existent. Ce sont EXACTEMENT les vérifications que le
+ * chargeur faisait au démarrage quand les questionnaires vivaient dans le dépôt. Aucune n'a été
+ * assouplie : c'était la condition pour les rendre éditables.
+ */
+export class QuestionnaireEditionRequest {
+  @ApiProperty({ description: "Nom du partenaire qui fournit le contenu (« AtoutBiodiv »)." })
+  @IsString()
+  @IsNotEmpty()
+  sourceNom!: string;
+
+  @ApiProperty({ type: Object, description: "Bandeau : { icone, titre, sousTitre }." })
+  @IsObject()
+  banniere!: BanniereDef;
+
+  @ApiProperty({ type: [Object], description: "Questions et leurs options." })
+  @IsArray()
+  questions!: QuestionDef[];
+
+  @ApiProperty({
+    type: [Object],
+    description:
+      "Recommandations AVEC leurs conditions. Une condition qui pointe une question ou une option " +
+      "inexistante est refusée (400) : la recommandation ne s'afficherait jamais, et l'erreur " +
+      "serait autrement indétectable.",
+  })
+  @IsArray()
+  recommandations!: RecommandationDef[];
+
+  @ApiProperty({
+    type: Object,
+    description:
+      "Étiquettes que le projet doit TOUTES porter. Au moins une est exigée : une conjonction vide " +
+      "est vraie, le questionnaire serait proposé à TOUS les projets.",
+  })
+  @IsObject()
+  etiquettesRequises!: { thematiques: string[]; sites: string[]; interventions: string[] };
+
+  @ApiPropertyOptional({ description: "Qui édite — pour la traçabilité." })
+  @IsOptional()
+  @IsString()
+  editePar?: string;
 }

--- a/api/src/admin/dto/admin.dto.ts
+++ b/api/src/admin/dto/admin.dto.ts
@@ -1,5 +1,5 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString, IsUUID } from "class-validator";
+import { IsObject, IsOptional, IsUUID } from "class-validator";
 import { AideClassification, AideLabelsCommuns } from "@/aides/dto/aides.dto";
 import { ProjetPhase } from "@database/schema";
 import type { PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
@@ -135,75 +135,4 @@ export class SimulationResponse {
   @ApiProperty({ type: [ServiceSimuleResponse], description: "TOUS les services, y compris écartés." })
   services!: ServiceSimuleResponse[];
   @ApiProperty({ type: SeuilsResponse }) seuils!: SeuilsResponse;
-}
-
-/**
- * Le questionnaire ENTIER, tel qu'il sera enregistré. PUT, pas PATCH : un éditeur envoie le
- * document qu'il a sous les yeux. Un PATCH champ par champ ouvrirait la porte à des états
- * incohérents entre deux appels (une condition sauvegardée avant la question qu'elle vise).
- *
- * TOUT est revalidé avant écriture (cf. validerDefinition) : étiquettes dans la taxonomie fermée,
- * au moins une étiquette (sinon le questionnaire serait proposé à TOUS les projets), conditions
- * pointant des questions et des options qui existent. Ce sont EXACTEMENT les vérifications que le
- * chargeur faisait au démarrage quand les questionnaires vivaient dans le dépôt. Aucune n'a été
- * assouplie : c'était la condition pour les rendre éditables.
- */
-export class QuestionnaireEditionRequest {
-  @ApiProperty({ description: "Nom du partenaire qui fournit le contenu (« AtoutBiodiv »)." })
-  @IsString()
-  @IsNotEmpty()
-  sourceNom!: string;
-
-  @ApiProperty({ type: Object, description: "Bandeau : { icone, titre, sousTitre }." })
-  @IsObject()
-  banniere!: BanniereDef;
-
-  @ApiProperty({ type: [Object], description: "Questions et leurs options." })
-  @IsArray()
-  questions!: QuestionDef[];
-
-  @ApiProperty({
-    type: [Object],
-    description:
-      "Recommandations AVEC leurs conditions. Une condition qui pointe une question ou une option " +
-      "inexistante est refusée (400) : la recommandation ne s'afficherait jamais, et l'erreur " +
-      "serait autrement indétectable.",
-  })
-  @IsArray()
-  recommandations!: RecommandationDef[];
-
-  @ApiProperty({
-    type: Object,
-    description:
-      "Étiquettes que le projet doit TOUTES porter. Au moins une est exigée : une conjonction vide " +
-      "est vraie, le questionnaire serait proposé à TOUS les projets.",
-  })
-  @IsObject()
-  etiquettesRequises!: { thematiques: string[]; sites: string[]; interventions: string[] };
-
-  @ApiPropertyOptional({ description: "Qui édite — pour la traçabilité." })
-  @IsOptional()
-  @IsString()
-  editePar?: string;
-}
-
-/**
- * Les taxonomies FERMÉES du schéma commun, servies à l'éditeur.
- *
- * Sans elles, le back-office devrait recopier les 137 thématiques, 58 lieux et 15 modalités — et
- * une copie dérive. On réintroduirait exactement la coquille que la validation vient d'éliminer,
- * mais du côté du client, où personne ne la verrait.
- *
- * L'éditeur ne propose donc QUE des étiquettes valides : le sélecteur rend la faute impossible,
- * plutôt que de la rattraper après coup.
- */
-export class TaxonomiesResponse {
-  @ApiProperty({ type: [String], description: "Les 137 thématiques." })
-  thematiques!: string[];
-
-  @ApiProperty({ type: [String], description: "Les 58 lieux." })
-  sites!: string[];
-
-  @ApiProperty({ type: [String], description: "Les 15 modalités d'intervention." })
-  interventions!: string[];
 }

--- a/api/src/admin/dto/admin.dto.ts
+++ b/api/src/admin/dto/admin.dto.ts
@@ -186,3 +186,24 @@ export class QuestionnaireEditionRequest {
   @IsString()
   editePar?: string;
 }
+
+/**
+ * Les taxonomies FERMÉES du schéma commun, servies à l'éditeur.
+ *
+ * Sans elles, le back-office devrait recopier les 137 thématiques, 58 lieux et 15 modalités — et
+ * une copie dérive. On réintroduirait exactement la coquille que la validation vient d'éliminer,
+ * mais du côté du client, où personne ne la verrait.
+ *
+ * L'éditeur ne propose donc QUE des étiquettes valides : le sélecteur rend la faute impossible,
+ * plutôt que de la rattraper après coup.
+ */
+export class TaxonomiesResponse {
+  @ApiProperty({ type: [String], description: "Les 137 thématiques." })
+  thematiques!: string[];
+
+  @ApiProperty({ type: [String], description: "Les 58 lieux." })
+  sites!: string[];
+
+  @ApiProperty({ type: [String], description: "Les 15 modalités d'intervention." })
+  interventions!: string[];
+}

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -33,7 +33,7 @@ import { AidesTextualMatchingService } from "./aides-textual-matching.service";
 import { AidesCacheService } from "./aides-cache.service";
 import { AidesPerimetreService } from "./aides-perimetre.service";
 import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
-import { AjoutManuelResponse } from "@/ajouts-manuels/dto/ajout-manuel.dto";
+import { fondreAjouts } from "@/ajouts-manuels/fondre-ajouts";
 import { AidesWarmupService } from "./aides-warmup.service";
 import { AidesFeedbackService } from "./aides-feedback.service";
 import { AideFeedbackResponse, CreateAideFeedbackRequest, DeleteAideFeedbackRequest } from "./dto/aide-feedback.dto";
@@ -214,14 +214,32 @@ export class AidesController {
     // 6-7. Matching thématique (+ textuel optionnel), enrichissement et tri —
     //      logique partagée avec POST /aides/recherche.
     const textualEnabled = this.isTextualMatchingEnabled(textualOverride);
-    return this.buildMatchedResponse(projet.classificationScores, allAides, classifications, {
-      ajouts,
+    const reponse = this.buildMatchedResponse(projet.classificationScores, allAides, classifications, {
       maxResults,
       cutoff,
       thresholds: { projet: projetThreshold, aide: aideThreshold },
       textualEnabled,
       textualText: `${projet.nom} ${projet.description ?? ""}`,
     });
+
+    // La fusion s'applique SUR le résultat du moteur, pas dedans : le moteur reste un pur
+    // scoreur/classeur, que POST /aides/recherche partage sans rien savoir des ajouts manuels.
+    const parId = new Map(allAides.map((a) => [String(a.id), a]));
+    const aides = fondreAjouts<AideWithClassification>({
+      ajouts,
+      resoudre: (idAt, ajout) => {
+        const aide = parId.get(idAt);
+        // Aide clôturée ou dépubliée depuis l'ajout : on ne sait plus la résoudre, et on ne
+        // fabrique rien. Mieux vaut ne rien montrer qu'envoyer candidater à une aide morte.
+        return aide ? { ...aide, classification: classifications.get(idAt), ajoutManuel: ajout } : undefined;
+      },
+      duMoteur: reponse.aides,
+      idDe: (a) => String(a.id),
+      nomDe: (a) => a.name,
+    });
+
+    if (aides.length === 0) return { status: "no_match", aides: [], total: allAides.length };
+    return { status: "ok", aides, total: allAides.length };
   }
 
   @TrackApiUsage()
@@ -281,11 +299,6 @@ export class AidesController {
     allAides: Aide[],
     classifications: Map<string, AideClassification>,
     options: {
-      /**
-       * Ajouts manuels du projet, indexés par id d'aide. Absent sur POST /aides/recherche, qui
-       * n'a pas de projet de référence : sans projet, il n'y a pas d'ajout manuel possible.
-       */
-      ajouts?: Map<string, { ajout: AjoutManuelResponse }>;
       maxResults: number;
       cutoff: number;
       thresholds: MatchThresholds;
@@ -293,7 +306,7 @@ export class AidesController {
       textualText: string;
     },
   ): AidesListResponse {
-    const { ajouts, maxResults, cutoff, thresholds, textualEnabled, textualText } = options;
+    const { maxResults, cutoff, thresholds, textualEnabled, textualText } = options;
 
     // Matching thématique — on passe allAides.length pour ne rien pré-trancher
     // avant la combinaison textuelle optionnelle.
@@ -354,38 +367,11 @@ export class AidesController {
         .slice(0, maxResults);
     }
 
-    // Les ajouts manuels EN TÊTE, et ils échappent au cutoff comme au maxResults : quelqu'un les a
-    // délibérément mis là, précisément parce que le moteur les ratait. Les soumettre au filtre qui
-    // les a ratés serait absurde.
-    //
-    // Un ajout qui n'est plus sur le périmètre (aide clôturée, dépubliée) n'apparaît simplement
-    // pas : on ne peut pas le résoudre, et on ne fabrique rien.
-    const manuels: AideWithClassification[] = [];
-    if (ajouts && ajouts.size > 0) {
-      const parId = new Map(allAides.map((a) => [String(a.id), a]));
-      for (const [idAt, { ajout }] of ajouts) {
-        const aide = parId.get(idAt);
-        if (!aide) continue;
-        manuels.push({
-          ...aide,
-          classification: classifications.get(idAt) ?? undefined,
-          ajoutManuel: ajout,
-        });
-      }
-      manuels.sort((a, b) => a.name.localeCompare(b.name));
-    }
-
-    // Un ajout manuel qui serait AUSSI remonté par le moteur ne doit apparaître qu'une fois — avec
-    // sa marque d'ajout. Le dédoublonnage se fait ici, pas dans le client.
-    const idsManuels = new Set(manuels.map((a) => String(a.id)));
-    const duMoteur = enriched.filter((a) => !idsManuels.has(String(a.id)));
-    const aides = [...manuels, ...duMoteur];
-
-    if (aides.length === 0) {
+    if (enriched.length === 0) {
       return { status: "no_match", aides: [], total: allAides.length };
     }
 
-    return { status: "ok", aides, total: allAides.length };
+    return { status: "ok", aides: enriched, total: allAides.length };
   }
 
   /**
@@ -520,8 +506,4 @@ export class AidesController {
   async deleteFeedback(@Body() dto: DeleteAideFeedbackRequest): Promise<void> {
     return this.feedbackService.delete(dto.projetId, dto.idAt);
   }
-
-  /**
-   * Extract unique code_insee values from project collectivités (Communes only)
-   */
 }

--- a/api/src/ajouts-manuels/fondre-ajouts.ts
+++ b/api/src/ajouts-manuels/fondre-ajouts.ts
@@ -1,0 +1,50 @@
+import type { AjoutManuel } from "./ajout-manuel-contract";
+
+/**
+ * LA POLITIQUE D'AFFICHAGE DES AJOUTS MANUELS, définie UNE FOIS.
+ *
+ * Elle s'applique à l'identique aux aides et aux services numériques :
+ *
+ *  1. Les ajouts manuels remontent EN TÊTE. Quelqu'un les a délibérément mis là.
+ *  2. Ils ÉCHAPPENT au score et au seuil — les soumettre au filtre qui les a ratés serait absurde,
+ *     puisque c'est précisément parce qu'il les ratait qu'un humain est intervenu.
+ *  3. Un objet à la fois retenu par le moteur ET ajouté à la main n'apparaît QU'UNE fois, avec sa
+ *     marque d'ajout. Le dédoublonnage se fait ici, pas dans le client : sinon chaque consommateur
+ *     devrait le refaire, et finirait par l'oublier.
+ *  4. Un ajout qu'on ne sait plus résoudre (aide clôturée, service retiré du catalogue) disparaît
+ *     simplement. On ne fabrique rien.
+ *
+ * ELLE ÉTAIT ÉCRITE DEUX FOIS, et elle avait déjà divergé : côté aides le dédoublonnage se faisait
+ * après le classement, côté services avant le scoring. Deux formes pour une seule règle, dès le
+ * premier jour. Le jour où l'on décidera de trier par date d'ajout, un seul des deux endpoints
+ * aurait changé — et rien n'aurait cassé.
+ *
+ * Ce qui varie légitimement par domaine, c'est le RÉSOLVEUR (id → objet) : la liste du périmètre
+ * pour une aide, le catalogue ou le payload pour un service. C'est le seul paramètre.
+ */
+export function fondreAjouts<T>(options: {
+  /** Les ajouts actifs du projet, indexés par identifiant d'objet. */
+  ajouts: Map<string, { ajout: AjoutManuel }>;
+  /** id → objet affichable, déjà marqué. `undefined` si l'ajout n'est plus résoluble. */
+  resoudre: (id: string, ajout: AjoutManuel) => T | undefined;
+  /** Les objets retenus par le moteur, déjà triés par pertinence. */
+  duMoteur: T[];
+  /** L'identifiant d'un objet, pour le dédoublonnage. */
+  idDe: (objet: T) => string;
+  /** Le nom d'un objet, pour trier les ajouts entre eux (le score ne les départage pas). */
+  nomDe: (objet: T) => string;
+}): T[] {
+  const { ajouts, resoudre, duMoteur, idDe, nomDe } = options;
+
+  if (ajouts.size === 0) return duMoteur;
+
+  const manuels: T[] = [];
+  for (const [id, { ajout }] of ajouts) {
+    const objet = resoudre(id, ajout);
+    if (objet) manuels.push(objet);
+  }
+  manuels.sort((a, b) => nomDe(a).localeCompare(nomDe(b)));
+
+  const idsManuels = new Set(manuels.map(idDe));
+  return [...manuels, ...duMoteur.filter((o) => !idsManuels.has(idDe(o)))];
+}

--- a/api/src/database/schema.ts
+++ b/api/src/database/schema.ts
@@ -306,6 +306,51 @@ export const projetQuestionnaireReponses = pgTable(
 );
 
 /**
+ * Définition des questionnaires — contenu ET règle d'éligibilité.
+ *
+ * ILS VIVAIENT DANS LE DÉPÔT (JSON partenaire + classification.ts). Le chargeur refusait de
+ * DÉMARRER si une condition pointait une question inexistante, si une étiquette sortait de la
+ * taxonomie, ou si un questionnaire n'exigeait aucune étiquette (il aurait alors été proposé à
+ * TOUS les projets — une conjonction vide est vraie). C'était un filet parfait : le bug ne
+ * pouvait pas atteindre la production.
+ *
+ * En base, ce filet disparaît. Il est donc INTÉGRALEMENT reconstruit à l'écriture : les mêmes
+ * vérifications, au même niveau d'exigence, rendues en 400 explicite (cf. validerDefinition).
+ * Aucune n'a été assouplie au passage — c'était la condition pour accepter ce déplacement.
+ *
+ * `version` s'incrémente à chaque édition. Elle n'invalide RIEN : `reconcilierReponses` ignore à
+ * la lecture les réponses devenues sans objet, sans réécrire la ligne stockée. Éditer un
+ * questionnaire ne détruit donc pas les réponses des collectivités.
+ *
+ * Amorcée depuis content/ (`pnpm seed:questionnaires`), comme le catalogue de services l'est
+ * depuis son CSV : le dépôt reste l'amorçage, la base devient la source de vérité.
+ */
+export const questionnaires = pgTable("questionnaires", {
+  slug: text("slug").primaryKey(),
+  version: integer("version").notNull().default(1),
+  /** Le partenaire qui fournit le contenu (« AtoutBiodiv »). */
+  sourceNom: text("source_nom").notNull(),
+  banniere: jsonb("banniere").$type<Record<string, unknown>>().notNull(),
+  questions: jsonb("questions").$type<unknown[]>().notNull(),
+  /** Recommandations AVEC leurs conditions. Ne sortent jamais de l'API. */
+  recommandations: jsonb("recommandations").$type<unknown[]>().notNull(),
+  /**
+   * Étiquettes que le projet doit TOUTES porter pour que le questionnaire lui soit proposé.
+   * Jamais vide : une conjonction vide est vraie, le questionnaire serait proposé à tout le monde.
+   */
+  etiquettesRequises: jsonb("etiquettes_requises")
+    .$type<{ thematiques: string[]; sites: string[]; interventions: string[] }>()
+    .notNull(),
+  /** Qui a édité en dernier — le back-office le transmet. */
+  editePar: text("edite_par"),
+  createdAt: timestamp("created_at", { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp("updated_at", { withTimezone: true })
+    .notNull()
+    .defaultNow()
+    .$onUpdate(() => new Date()),
+});
+
+/**
  * Catalogue des services numériques (benchmark DINUM « API Projets »).
  *
  * Table DISTINCTE de `public.services` à dessein : `services` est le catalogue du widget,

--- a/api/src/decisions/decisions.controller.ts
+++ b/api/src/decisions/decisions.controller.ts
@@ -7,6 +7,7 @@ import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
 import { DecisionsService } from "./decisions.service";
 import { CreateDecisionDto, DecisionCreatedResponse, DecisionListResponse } from "./dto/create-decision.dto";
 import { DECISION_TYPES, type DecisionType } from "./decision-contract";
+import { TYPE_AJOUT } from "@/ajouts-manuels/ajout-manuel-contract";
 
 @ApiBearerAuth()
 @ApiTags("Décisions")
@@ -30,6 +31,18 @@ export class DecisionsController {
     description: "Décision enregistrée",
   })
   create(@Req() request: Request, @Body() dto: CreateDecisionDto): Promise<DecisionCreatedResponse> {
+    // `ajout_manuel` a ses propres endpoints (/projets/:id/aides|services/ajouts), et EUX SEULS
+    // portent les gardes qui rendent l'ajout résoluble : l'aide doit être sur le périmètre du
+    // projet, le slug doit exister au catalogue. Les court-circuiter par cette porte générique
+    // produirait exactement la panne silencieuse qu'elles préviennent — un ajout enregistré, mais
+    // que la lecture ne saurait jamais résoudre, donc invisible et sans message.
+    if (dto.typeDecision === TYPE_AJOUT) {
+      throw new BadRequestException(
+        `Le type "${TYPE_AJOUT}" ne s'écrit pas ici : utilisez POST /projets/:projetId/aides/ajouts ` +
+          `ou POST /projets/:projetId/services/ajouts, qui vérifient que l'objet ajouté est bien ` +
+          `résoluble. Sans cette garde, l'ajout serait enregistré mais jamais affiché.`,
+      );
+    }
     return this.decisionsService.create(dto, request.serviceType!);
   }
 

--- a/api/src/geo/openapi-definition.yml
+++ b/api/src/geo/openapi-definition.yml
@@ -1,1518 +1,1008 @@
 {
-    "openapi": "3.0.0",
-    "x-origin": [
-        {
-            "url": "https://geo.api.gouv.fr/definition.yml",
-            "format": "swagger",
-            "version": "2.0",
-            "converter": {
-                "url": "https://github.com/mermade/oas-kit",
-                "version": "7.0.8"
-            }
-        }
+  "openapi": "3.0.0",
+  "x-origin":
+    [
+      {
+        "url": "https://geo.api.gouv.fr/definition.yml",
+        "format": "swagger",
+        "version": "2.0",
+        "converter": { "url": "https://github.com/mermade/oas-kit", "version": "7.0.8" },
+      },
     ],
-    "info": {
-        "title": "API Géo",
-        "version": "1.1"
-    },
-    "paths": {
-        "/communes": {
-            "get": {
-                "summary": "Recherche des communes",
-                "tags": [
-                    "Communes"
-                ],
-                "parameters": [
-                    {
-                        "name": "codePostal",
-                        "in": "query",
-                        "description": "Code postal associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "lat",
-                        "in": "query",
-                        "description": "Latitude (en degrés)",
-                        "schema": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    {
-                        "name": "lon",
-                        "in": "query",
-                        "description": "Longitude (en degrés)",
-                        "schema": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    {
-                        "name": "nom",
-                        "in": "query",
-                        "description": "Nom de la commune",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "boost",
-                        "in": "query",
-                        "description": "Mode de boost de la recherche par nom",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "code",
-                        "in": "query",
-                        "description": "Code de la commune",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "siren",
-                        "in": "query",
-                        "description": "Code SIREN de la commune",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeEpci",
-                        "in": "query",
-                        "description": "Code de l'EPCI associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeDepartement",
-                        "in": "query",
-                        "description": "Code du département associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeRegion",
-                        "in": "query",
-                        "description": "Code de la région associée",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeParent",
-                        "in": "query",
-                        "description": "Code de la commune si on a un arrondissement",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "ancienCode",
-                        "in": "query",
-                        "description": "Code INSEE ancien de la commune",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/zoneParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/typeCommune"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Liste de communes",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Commune"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/communes/{code}": {
-            "get": {
-                "summary": "Récupérer les informations concernant une commune",
-                "tags": [
-                    "Communes"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code INSEE de la commune",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Informations concernant une commune",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Commune"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Commune introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/communes_associees_deleguees": {
-            "get": {
-                "summary": "Recherche des communes associées et/ou déléguées",
-                "tags": [
-                    "Communes associées et déléguées"
-                ],
-                "parameters": [
-                    {
-                        "name": "lat",
-                        "in": "query",
-                        "description": "Latitude (en degrés)",
-                        "schema": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    {
-                        "name": "lon",
-                        "in": "query",
-                        "description": "Longitude (en degrés)",
-                        "schema": {
-                            "type": "number",
-                            "format": "float"
-                        }
-                    },
-                    {
-                        "name": "nom",
-                        "in": "query",
-                        "description": "Nom de la commune",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "code",
-                        "in": "query",
-                        "description": "Code de la commune",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeEpci",
-                        "in": "query",
-                        "description": "Code de l'EPCI associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeDepartement",
-                        "in": "query",
-                        "description": "Code du département associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeRegion",
-                        "in": "query",
-                        "description": "Code de la région associée",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/typeCommuneAssocieeDeleguee"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeAssocieeDelegueeFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeAssocieeDelegueeGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Liste de communes associées et/ou déléguées",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Commune"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/communes_associees_deleguees/{code}": {
-            "get": {
-                "summary": "Récupérer les informations concernant une commune associée ou déléguée",
-                "tags": [
-                    "Communes associées et déléguées"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code INSEE de la commune associée ou déléguée",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeAssocieeDelegueeFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeAssocieeDelegueeGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Informations concernant une commune associée ou déléguée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Commune"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Commune associée ou déléguée introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/epcis": {
-            "get": {
-                "summary": "Recherche des EPCI",
-                "tags": [
-                    "EPCI"
-                ],
-                "parameters": [
-                    {
-                        "name": "nom",
-                        "in": "query",
-                        "description": "Nom de l'EPCI",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "boost",
-                        "in": "query",
-                        "description": "Mode de boost de la recherche par nom",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeEpci",
-                        "in": "query",
-                        "description": "Code de l'EPCI associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeDepartement",
-                        "in": "query",
-                        "description": "Code du département associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeRegion",
-                        "in": "query",
-                        "description": "Code de la région associée",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/zoneParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/epciFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/epciGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Liste des EPCI",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Epci"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/epcis/{code}": {
-            "get": {
-                "summary": "Récupérer les informations concernant un EPCI",
-                "tags": [
-                    "EPCI"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code INSEE de l'EPCI",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/epciFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/epciGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Informations concernant une commune",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Epci"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "EPCI introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/epcis/{code}/communes": {
-            "get": {
-                "summary": "Renvoi les communes d'un EPCI",
-                "tags": [
-                    "EPCI",
-                    "Communes"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code de l'EPCI",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Liste des communes de l'EPCI",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Commune"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "EPCI introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/departements": {
-            "get": {
-                "summary": "Recherche des départements",
-                "tags": [
-                    "Départements"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "query",
-                        "description": "Code du département",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "codeRegion",
-                        "in": "query",
-                        "description": "Code région associé",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "nom",
-                        "in": "query",
-                        "description": "Nom du département",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/zoneParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/departementFieldsParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Le ou les départements",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Departement"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/departements/{code}": {
-            "get": {
-                "summary": "Récupérer les informations concernant un département",
-                "tags": [
-                    "Départements"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code du département",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/departementFieldsParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Informations concernant un département",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Departement"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Département introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/departements/{code}/communes": {
-            "get": {
-                "summary": "Renvoi les communes d'un département",
-                "tags": [
-                    "Départements",
-                    "Communes"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code du département",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeFieldsParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/formatParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/communeGeometryParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Liste des communes du département",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Commune"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Département introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/regions": {
-            "get": {
-                "summary": "Recherche des régions",
-                "tags": [
-                    "Régions"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "query",
-                        "description": "Code de la région",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "name": "nom",
-                        "in": "query",
-                        "description": "Nom de la région",
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/zoneParam"
-                    },
-                    {
-                        "$ref": "#/components/parameters/regionFieldsParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "La ou les régions",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Region"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/regions/{code}": {
-            "get": {
-                "summary": "Récupérer les informations concernant une région",
-                "tags": [
-                    "Régions"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code de la région",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/regionFieldsParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Informations concernant la région",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Region"
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Région introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        },
-        "/regions/{code}/departements": {
-            "get": {
-                "summary": "Renvoi les départements d'une région",
-                "tags": [
-                    "Départements",
-                    "Régions"
-                ],
-                "parameters": [
-                    {
-                        "name": "code",
-                        "in": "path",
-                        "description": "Code de la région",
-                        "required": true,
-                        "schema": {
-                            "type": "string"
-                        }
-                    },
-                    {
-                        "$ref": "#/components/parameters/regionFieldsParam"
-                    }
-                ],
-                "responses": {
-                    "200": {
-                        "description": "Liste des départements de la région",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "type": "array",
-                                    "items": {
-                                        "$ref": "#/components/schemas/Departement"
-                                    }
-                                }
-                            }
-                        }
-                    },
-                    "400": {
-                        "description": "Erreur. Requête mal formée",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    },
-                    "404": {
-                        "description": "Département introuvable",
-                        "content": {
-                            "application/json": {
-                                "schema": {
-                                    "$ref": "#/components/schemas/Error"
-                                }
-                            }
-                        }
-                    }
-                }
-            }
-        }
-    },
-    "servers": [
+  "info": { "title": "API Géo", "version": "1.1" },
+  "paths":
+    {
+      "/communes":
         {
-            "url": "https://geo.api.gouv.fr"
-        }
-    ],
-    "components": {
-        "parameters": {
-            "communeFieldsParam": {
-                "name": "fields",
-                "in": "query",
-                "description": "Liste des champs souhaités dans la réponse",
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "nom",
-                            "code",
-                            "codeParent",
-                            "codesPostaux",
-                            "siren",
-                            "centre",
-                            "surface",
-                            "contour",
-                            "mairie",
-                            "bbox",
-                            "codeEpci",
-                            "epci",
-                            "codeDepartement",
-                            "departement",
-                            "codeRegion",
-                            "region",
-                            "population",
-                            "anciensCodes",
-                            "deleguees",
-                            "associees",
-                            "zone"
-                        ]
+          "get":
+            {
+              "summary": "Recherche des communes",
+              "tags": ["Communes"],
+              "parameters":
+                [
+                  {
+                    "name": "codePostal",
+                    "in": "query",
+                    "description": "Code postal associé",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "lat",
+                    "in": "query",
+                    "description": "Latitude (en degrés)",
+                    "schema": { "type": "number", "format": "float" },
+                  },
+                  {
+                    "name": "lon",
+                    "in": "query",
+                    "description": "Longitude (en degrés)",
+                    "schema": { "type": "number", "format": "float" },
+                  },
+                  { "name": "nom", "in": "query", "description": "Nom de la commune", "schema": { "type": "string" } },
+                  {
+                    "name": "boost",
+                    "in": "query",
+                    "description": "Mode de boost de la recherche par nom",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "code",
+                    "in": "query",
+                    "description": "Code de la commune",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "siren",
+                    "in": "query",
+                    "description": "Code SIREN de la commune",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeEpci",
+                    "in": "query",
+                    "description": "Code de l'EPCI associé",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeDepartement",
+                    "in": "query",
+                    "description": "Code du département associé",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeRegion",
+                    "in": "query",
+                    "description": "Code de la région associée",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeParent",
+                    "in": "query",
+                    "description": "Code de la commune si on a un arrondissement",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "ancienCode",
+                    "in": "query",
+                    "description": "Code INSEE ancien de la commune",
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/zoneParam" },
+                  { "$ref": "#/components/parameters/typeCommune" },
+                  { "$ref": "#/components/parameters/communeFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/communeGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Liste de communes",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Commune" } } },
+                        },
                     },
-                    "default": [
-                        "nom",
-                        "code",
-                        "codesPostaux",
-                        "siren",
-                        "codeEpci",
-                        "codeDepartement",
-                        "codeRegion",
-                        "population"
-                    ]
-                }
-            },
-            "communeAssocieeDelegueeFieldsParam": {
-                "name": "fields",
-                "in": "query",
-                "description": "Liste des champs souhaités dans la réponse",
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "nom",
-                            "code",
-                            "type",
-                            "chefLieu",
-                            "centre",
-                            "surface",
-                            "contour",
-                            "bbox",
-                            "codeEpci",
-                            "epci",
-                            "codeDepartement",
-                            "departement",
-                            "codeRegion",
-                            "region"
-                        ]
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "default": [
-                        "nom",
-                        "code",
-                        "type",
-                        "chefLieu",
-                        "codeEpci",
-                        "codeDepartement",
-                        "codeRegion"
-                    ]
-                }
+                },
             },
-            "epciFieldsParam": {
-                "name": "fields",
-                "in": "query",
-                "description": "Liste des champs souhaités dans la réponse",
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "nom",
-                            "code",
-                            "population",
-                            "financement",
-                            "type",
-                            "codesRegions",
-                            "codesDepartements",
-                            "centre",
-                            "surface",
-                            "contour",
-                            "bbox",
-                            "zone"
-                        ]
-                    },
-                    "default": [
-                        "nom",
-                        "code",
-                        "codesRegions",
-                        "codesDepartements"
-                    ]
-                }
-            },
-            "departementFieldsParam": {
-                "name": "fields",
-                "in": "query",
-                "description": "Liste des champs souhaités dans la réponse",
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "nom",
-                            "code",
-                            "codeRegion",
-                            "region",
-                            "zone",
-                            "chefLieu"
-                        ]
-                    },
-                    "default": [
-                        "nom",
-                        "code",
-                        "codeRegion"
-                    ]
-                }
-            },
-            "regionFieldsParam": {
-                "name": "fields",
-                "in": "query",
-                "description": "Liste des champs souhaités dans la réponse",
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "nom",
-                            "code",
-                            "zone",
-                            "chefLieu"
-                        ]
-                    },
-                    "default": [
-                        "nom",
-                        "code"
-                    ]
-                }
-            },
-            "formatParam": {
-                "name": "format",
-                "in": "query",
-                "description": "Format de réponse attendu",
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "json",
-                        "geojson"
-                    ],
-                    "default": "json"
-                }
-            },
-            "communeGeometryParam": {
-                "name": "geometry",
-                "in": "query",
-                "description": "Géométrie à utiliser pour la sortie géographique",
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "centre",
-                        "contour",
-                        "mairie",
-                        "bbox"
-                    ],
-                    "default": "centre"
-                }
-            },
-            "communeAssocieeDelegueeGeometryParam": {
-                "name": "geometry",
-                "in": "query",
-                "description": "Géométrie à utiliser pour la sortie géographique",
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "centre",
-                        "contour",
-                        "bbox"
-                    ],
-                    "default": "centre"
-                }
-            },
-            "typeCommune": {
-                "name": "type",
-                "in": "query",
-                "description": "Type permettant de filtrer si on retourne les communes, les arrondissements ou les 2. Par défaut à commune-actuelle.",
-                "required": false,
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "commune-actuelle",
-                            "arrondissement-municipal"
-                        ]
-                    }
-                }
-            },
-            "typeCommuneAssocieeDeleguee": {
-                "name": "type",
-                "in": "query",
-                "description": "Type permettant de filtrer si on retourne les communes, les arrondissements ou les 2. Par défaut à commune-actuelle.",
-                "required": false,
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "commune-associee",
-                            "commune-deleguee"
-                        ]
-                    }
-                }
-            },
-            "zoneParam": {
-                "name": "zone",
-                "in": "query",
-                "description": "Zone permettant de filtrer à la métropole, aux DROM et aux COM. Défaut à metro,drom sauf pour les communes à metro,drom,com pour conserver le comportement historique.",
-                "required": false,
-                "style": "form",
-                "explode": false,
-                "schema": {
-                    "type": "array",
-                    "items": {
-                        "type": "string",
-                        "enum": [
-                            "metro",
-                            "drom",
-                            "com"
-                        ]
-                    }
-                }
-            },
-            "epciGeometryParam": {
-                "name": "geometry",
-                "in": "query",
-                "description": "Géométrie à utiliser pour la sortie géographique",
-                "schema": {
-                    "type": "string",
-                    "enum": [
-                        "centre",
-                        "contour",
-                        "bbox"
-                    ],
-                    "default": "centre"
-                }
-            },
-            "limitParam": {
-                "name": "limit",
-                "in": "query",
-                "description": "Nombre d'éléments à retourner",
-                "schema": {
-                    "type": "integer",
-                    "format": "int32",
-                    "default": 0
-                }
-            }
         },
-        "schemas": {
-            "Error": {
-                "type": "object",
-                "properties": {
-                    "code": {
-                        "type": "integer",
-                        "description": "Code HTTP de l'erreur"
+      "/communes/{code}":
+        {
+          "get":
+            {
+              "summary": "Récupérer les informations concernant une commune",
+              "tags": ["Communes"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code INSEE de la commune",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/communeFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/communeGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Informations concernant une commune",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Commune" } } },
                     },
-                    "message": {
-                        "type": "string",
-                        "description": "Libellé de l'erreur"
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "description": {
-                        "type": "string",
-                        "description": "Explication"
-                    }
-                }
+                  "404":
+                    {
+                      "description": "Commune introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
             },
-            "Commune": {
-                "type": "object",
-                "properties": {
-                    "code": {
-                        "type": "string",
-                        "description": "Code INSEE de la commune"
+        },
+      "/communes_associees_deleguees":
+        {
+          "get":
+            {
+              "summary": "Recherche des communes associées et/ou déléguées",
+              "tags": ["Communes associées et déléguées"],
+              "parameters":
+                [
+                  {
+                    "name": "lat",
+                    "in": "query",
+                    "description": "Latitude (en degrés)",
+                    "schema": { "type": "number", "format": "float" },
+                  },
+                  {
+                    "name": "lon",
+                    "in": "query",
+                    "description": "Longitude (en degrés)",
+                    "schema": { "type": "number", "format": "float" },
+                  },
+                  { "name": "nom", "in": "query", "description": "Nom de la commune", "schema": { "type": "string" } },
+                  {
+                    "name": "code",
+                    "in": "query",
+                    "description": "Code de la commune",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeEpci",
+                    "in": "query",
+                    "description": "Code de l'EPCI associé",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeDepartement",
+                    "in": "query",
+                    "description": "Code du département associé",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeRegion",
+                    "in": "query",
+                    "description": "Code de la région associée",
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/typeCommuneAssocieeDeleguee" },
+                  { "$ref": "#/components/parameters/communeAssocieeDelegueeFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/communeAssocieeDelegueeGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Liste de communes associées et/ou déléguées",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Commune" } } },
+                        },
                     },
-                    "nom": {
-                        "type": "string",
-                        "description": "Nom de la commune"
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "codesPostaux": {
-                        "type": "array",
-                        "description": "Liste des codes postaux associés à la commune",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "siren": {
-                        "type": "string",
-                        "description": "Code SIREN de la commune"
-                    },
-                    "codeEpci": {
-                        "type": "string",
-                        "description": "Code de l'EPCI associé à la commune"
-                    },
-                    "codeDepartement": {
-                        "type": "string",
-                        "description": "Code du département associé à la commune"
-                    },
-                    "codeRegion": {
-                        "type": "string",
-                        "description": "Code de la région associée à la commune"
-                    },
-                    "epci": {
-                        "$ref": "#/components/schemas/Epci"
-                    },
-                    "departement": {
-                        "$ref": "#/components/schemas/Departement"
-                    },
-                    "region": {
-                        "$ref": "#/components/schemas/Region"
-                    },
-                    "associees": {
-                        "type": "array",
-                        "description": "Liste des codes postaux associés à la commune",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "nom": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "deleguees": {
-                        "type": "array",
-                        "description": "Liste des codes postaux associés à la commune",
-                        "items": {
-                            "type": "object",
-                            "properties": {
-                                "code": {
-                                    "type": "string"
-                                },
-                                "nom": {
-                                    "type": "string"
-                                }
-                            }
-                        }
-                    },
-                    "population": {
-                        "type": "integer",
-                        "description": "Population municipale"
-                    },
-                    "anciensCodes": {
-                        "type": "array",
-                        "description": "Liste des anciens codes INSEE associés à la commune",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "surface": {
-                        "type": "number",
-                        "format": "float",
-                        "description": "Surface de la commune, en hectares"
-                    },
-                    "centre": {
-                        "type": "object",
-                        "description": "Centre de la commune (Point GeoJSON)"
-                    },
-                    "contour": {
-                        "type": "object",
-                        "description": "Contour de la commune (Polygon GeoJSON)"
-                    },
-                    "mairie": {
-                        "type": "object",
-                        "description": "Mairie principale de la commune (Point GeoJSON). Pour les COM et les communes mortes pour la France, on retourne le centre."
-                    },
-                    "bbox": {
-                        "type": "object",
-                        "description": "Rectangle englobant la commune (Polygon GeoJSON)"
-                    }
-                }
+                },
             },
-            "CommuneAssocieeDeleguee": {
-                "type": "object",
-                "properties": {
-                    "code": {
-                        "type": "string",
-                        "description": "Code INSEE de la commune associée ou déléguée"
+        },
+      "/communes_associees_deleguees/{code}":
+        {
+          "get":
+            {
+              "summary": "Récupérer les informations concernant une commune associée ou déléguée",
+              "tags": ["Communes associées et déléguées"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code INSEE de la commune associée ou déléguée",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/communeAssocieeDelegueeFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/communeAssocieeDelegueeGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Informations concernant une commune associée ou déléguée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Commune" } } },
                     },
-                    "nom": {
-                        "type": "string",
-                        "description": "Nom de la commune associée ou déléguée"
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "codeEpci": {
-                        "type": "string",
-                        "description": "Code de l'EPCI associé à la commune associée ou déléguée"
+                  "404":
+                    {
+                      "description": "Commune associée ou déléguée introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "codeDepartement": {
-                        "type": "string",
-                        "description": "Code du département associé à la commune associée ou déléguée"
-                    },
-                    "codeRegion": {
-                        "type": "string",
-                        "description": "Code de la région associée à la commune associée ou déléguée"
-                    },
-                    "epci": {
-                        "$ref": "#/components/schemas/Epci"
-                    },
-                    "departement": {
-                        "$ref": "#/components/schemas/Departement"
-                    },
-                    "region": {
-                        "$ref": "#/components/schemas/Region"
-                    },
-                    "surface": {
-                        "type": "number",
-                        "format": "float",
-                        "description": "Surface de la commune associée ou déléguée, en hectares"
-                    },
-                    "centre": {
-                        "type": "object",
-                        "description": "Centre de la commune associée ou déléguée (Point GeoJSON)"
-                    },
-                    "contour": {
-                        "type": "object",
-                        "description": "Contour de la commune associée ou déléguée (Polygon GeoJSON)"
-                    },
-                    "bbox": {
-                        "type": "object",
-                        "description": "Rectangle englobant la commune associée ou déléguée (Polygon GeoJSON)"
-                    }
-                }
+                },
             },
-            "Epci": {
-                "type": "object",
-                "properties": {
-                    "code": {
-                        "type": "string",
-                        "description": "Code SIREN de l'EPCI"
+        },
+      "/epcis":
+        {
+          "get":
+            {
+              "summary": "Recherche des EPCI",
+              "tags": ["EPCI"],
+              "parameters":
+                [
+                  { "name": "nom", "in": "query", "description": "Nom de l'EPCI", "schema": { "type": "string" } },
+                  {
+                    "name": "boost",
+                    "in": "query",
+                    "description": "Mode de boost de la recherche par nom",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeEpci",
+                    "in": "query",
+                    "description": "Code de l'EPCI associé",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeDepartement",
+                    "in": "query",
+                    "description": "Code du département associé",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeRegion",
+                    "in": "query",
+                    "description": "Code de la région associée",
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/zoneParam" },
+                  { "$ref": "#/components/parameters/epciFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/epciGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Liste des EPCI",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Epci" } } },
+                        },
                     },
-                    "nom": {
-                        "type": "string",
-                        "description": "Nom de l'EPCI"
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "type": {
-                        "type": "string",
-                        "description": "Type de l'EPCI, soit communauté d'agglomération (CA), soit communauté de communes (CC), soit communauté urbaine (CU), soit métropole de Lyon (MET69), soit métropole (METRO)"
-                    },
-                    "financement": {
-                        "type": "string",
-                        "description": "Financement de l'EPCI, soit fiscalité additionnelle (FA), soit en fiscalité professionnelle unique (FPU)"
-                    },
-                    "codesDepartements": {
-                        "type": "array",
-                        "description": "Liste des départements de l'EPCI",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "codesRegions": {
-                        "type": "array",
-                        "description": "Liste des régions de l'EPCI",
-                        "items": {
-                            "type": "string"
-                        }
-                    },
-                    "population": {
-                        "type": "integer",
-                        "description": "Population municipale"
-                    },
-                    "surface": {
-                        "type": "number",
-                        "format": "float",
-                        "description": "Surface de l'EPCI, en hectares"
-                    },
-                    "centre": {
-                        "type": "object",
-                        "description": "Centre de l'EPCI (Point GeoJSON)"
-                    },
-                    "contour": {
-                        "type": "object",
-                        "description": "Contour de l'EPCI (Polygon GeoJSON)"
-                    },
-                    "bbox": {
-                        "type": "object",
-                        "description": "Rectangle englobant la commune (Polygon GeoJSON)"
-                    }
-                }
+                },
             },
-            "Departement": {
-                "type": "object",
-                "properties": {
-                    "code": {
-                        "type": "string",
-                        "description": "Code du département"
+        },
+      "/epcis/{code}":
+        {
+          "get":
+            {
+              "summary": "Récupérer les informations concernant un EPCI",
+              "tags": ["EPCI"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code INSEE de l'EPCI",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/epciFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/epciGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Informations concernant une commune",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Epci" } } },
                     },
-                    "nom": {
-                        "type": "string",
-                        "description": "Nom du département"
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "codeRegion": {
-                        "type": "string",
-                        "description": "Code de la région"
+                  "404":
+                    {
+                      "description": "EPCI introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
                     },
-                    "region": {
-                        "$ref": "#/components/schemas/Region"
-                    }
-                }
+                },
             },
-            "Region": {
-                "type": "object",
-                "properties": {
-                    "code": {
-                        "type": "string",
-                        "description": "Code de la région"
+        },
+      "/epcis/{code}/communes":
+        {
+          "get":
+            {
+              "summary": "Renvoi les communes d'un EPCI",
+              "tags": ["EPCI", "Communes"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code de l'EPCI",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/communeFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/communeGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Liste des communes de l'EPCI",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Commune" } } },
+                        },
                     },
-                    "nom": {
-                        "type": "string",
-                        "description": "Nom de la région"
-                    }
-                }
-            }
-        }
-    }
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                  "404":
+                    {
+                      "description": "EPCI introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
+            },
+        },
+      "/departements":
+        {
+          "get":
+            {
+              "summary": "Recherche des départements",
+              "tags": ["Départements"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "query",
+                    "description": "Code du département",
+                    "schema": { "type": "string" },
+                  },
+                  {
+                    "name": "codeRegion",
+                    "in": "query",
+                    "description": "Code région associé",
+                    "schema": { "type": "string" },
+                  },
+                  { "name": "nom", "in": "query", "description": "Nom du département", "schema": { "type": "string" } },
+                  { "$ref": "#/components/parameters/zoneParam" },
+                  { "$ref": "#/components/parameters/departementFieldsParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Le ou les départements",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Departement" } } },
+                        },
+                    },
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
+            },
+        },
+      "/departements/{code}":
+        {
+          "get":
+            {
+              "summary": "Récupérer les informations concernant un département",
+              "tags": ["Départements"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code du département",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/departementFieldsParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Informations concernant un département",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Departement" } } },
+                    },
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                  "404":
+                    {
+                      "description": "Département introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
+            },
+        },
+      "/departements/{code}/communes":
+        {
+          "get":
+            {
+              "summary": "Renvoi les communes d'un département",
+              "tags": ["Départements", "Communes"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code du département",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/communeFieldsParam" },
+                  { "$ref": "#/components/parameters/formatParam" },
+                  { "$ref": "#/components/parameters/communeGeometryParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Liste des communes du département",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Commune" } } },
+                        },
+                    },
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                  "404":
+                    {
+                      "description": "Département introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
+            },
+        },
+      "/regions":
+        {
+          "get":
+            {
+              "summary": "Recherche des régions",
+              "tags": ["Régions"],
+              "parameters":
+                [
+                  { "name": "code", "in": "query", "description": "Code de la région", "schema": { "type": "string" } },
+                  { "name": "nom", "in": "query", "description": "Nom de la région", "schema": { "type": "string" } },
+                  { "$ref": "#/components/parameters/zoneParam" },
+                  { "$ref": "#/components/parameters/regionFieldsParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "La ou les régions",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Region" } } },
+                        },
+                    },
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
+            },
+        },
+      "/regions/{code}":
+        {
+          "get":
+            {
+              "summary": "Récupérer les informations concernant une région",
+              "tags": ["Régions"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code de la région",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/regionFieldsParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Informations concernant la région",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Region" } } },
+                    },
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                  "404":
+                    {
+                      "description": "Région introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
+            },
+        },
+      "/regions/{code}/departements":
+        {
+          "get":
+            {
+              "summary": "Renvoi les départements d'une région",
+              "tags": ["Départements", "Régions"],
+              "parameters":
+                [
+                  {
+                    "name": "code",
+                    "in": "path",
+                    "description": "Code de la région",
+                    "required": true,
+                    "schema": { "type": "string" },
+                  },
+                  { "$ref": "#/components/parameters/regionFieldsParam" },
+                ],
+              "responses":
+                {
+                  "200":
+                    {
+                      "description": "Liste des départements de la région",
+                      "content":
+                        {
+                          "application/json":
+                            { "schema": { "type": "array", "items": { "$ref": "#/components/schemas/Departement" } } },
+                        },
+                    },
+                  "400":
+                    {
+                      "description": "Erreur. Requête mal formée",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                  "404":
+                    {
+                      "description": "Département introuvable",
+                      "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } },
+                    },
+                },
+            },
+        },
+    },
+  "servers": [{ "url": "https://geo.api.gouv.fr" }],
+  "components":
+    {
+      "parameters":
+        {
+          "communeFieldsParam":
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Liste des champs souhaités dans la réponse",
+              "style": "form",
+              "explode": false,
+              "schema":
+                {
+                  "type": "array",
+                  "items":
+                    {
+                      "type": "string",
+                      "enum":
+                        [
+                          "nom",
+                          "code",
+                          "codeParent",
+                          "codesPostaux",
+                          "siren",
+                          "centre",
+                          "surface",
+                          "contour",
+                          "mairie",
+                          "bbox",
+                          "codeEpci",
+                          "epci",
+                          "codeDepartement",
+                          "departement",
+                          "codeRegion",
+                          "region",
+                          "population",
+                          "anciensCodes",
+                          "deleguees",
+                          "associees",
+                          "zone",
+                        ],
+                    },
+                  "default":
+                    ["nom", "code", "codesPostaux", "siren", "codeEpci", "codeDepartement", "codeRegion", "population"],
+                },
+            },
+          "communeAssocieeDelegueeFieldsParam":
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Liste des champs souhaités dans la réponse",
+              "style": "form",
+              "explode": false,
+              "schema":
+                {
+                  "type": "array",
+                  "items":
+                    {
+                      "type": "string",
+                      "enum":
+                        [
+                          "nom",
+                          "code",
+                          "type",
+                          "chefLieu",
+                          "centre",
+                          "surface",
+                          "contour",
+                          "bbox",
+                          "codeEpci",
+                          "epci",
+                          "codeDepartement",
+                          "departement",
+                          "codeRegion",
+                          "region",
+                        ],
+                    },
+                  "default": ["nom", "code", "type", "chefLieu", "codeEpci", "codeDepartement", "codeRegion"],
+                },
+            },
+          "epciFieldsParam":
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Liste des champs souhaités dans la réponse",
+              "style": "form",
+              "explode": false,
+              "schema":
+                {
+                  "type": "array",
+                  "items":
+                    {
+                      "type": "string",
+                      "enum":
+                        [
+                          "nom",
+                          "code",
+                          "population",
+                          "financement",
+                          "type",
+                          "codesRegions",
+                          "codesDepartements",
+                          "centre",
+                          "surface",
+                          "contour",
+                          "bbox",
+                          "zone",
+                        ],
+                    },
+                  "default": ["nom", "code", "codesRegions", "codesDepartements"],
+                },
+            },
+          "departementFieldsParam":
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Liste des champs souhaités dans la réponse",
+              "style": "form",
+              "explode": false,
+              "schema":
+                {
+                  "type": "array",
+                  "items": { "type": "string", "enum": ["nom", "code", "codeRegion", "region", "zone", "chefLieu"] },
+                  "default": ["nom", "code", "codeRegion"],
+                },
+            },
+          "regionFieldsParam":
+            {
+              "name": "fields",
+              "in": "query",
+              "description": "Liste des champs souhaités dans la réponse",
+              "style": "form",
+              "explode": false,
+              "schema":
+                {
+                  "type": "array",
+                  "items": { "type": "string", "enum": ["nom", "code", "zone", "chefLieu"] },
+                  "default": ["nom", "code"],
+                },
+            },
+          "formatParam":
+            {
+              "name": "format",
+              "in": "query",
+              "description": "Format de réponse attendu",
+              "schema": { "type": "string", "enum": ["json", "geojson"], "default": "json" },
+            },
+          "communeGeometryParam":
+            {
+              "name": "geometry",
+              "in": "query",
+              "description": "Géométrie à utiliser pour la sortie géographique",
+              "schema": { "type": "string", "enum": ["centre", "contour", "mairie", "bbox"], "default": "centre" },
+            },
+          "communeAssocieeDelegueeGeometryParam":
+            {
+              "name": "geometry",
+              "in": "query",
+              "description": "Géométrie à utiliser pour la sortie géographique",
+              "schema": { "type": "string", "enum": ["centre", "contour", "bbox"], "default": "centre" },
+            },
+          "typeCommune":
+            {
+              "name": "type",
+              "in": "query",
+              "description": "Type permettant de filtrer si on retourne les communes, les arrondissements ou les 2. Par défaut à commune-actuelle.",
+              "required": false,
+              "style": "form",
+              "explode": false,
+              "schema":
+                {
+                  "type": "array",
+                  "items": { "type": "string", "enum": ["commune-actuelle", "arrondissement-municipal"] },
+                },
+            },
+          "typeCommuneAssocieeDeleguee":
+            {
+              "name": "type",
+              "in": "query",
+              "description": "Type permettant de filtrer si on retourne les communes, les arrondissements ou les 2. Par défaut à commune-actuelle.",
+              "required": false,
+              "style": "form",
+              "explode": false,
+              "schema":
+                { "type": "array", "items": { "type": "string", "enum": ["commune-associee", "commune-deleguee"] } },
+            },
+          "zoneParam":
+            {
+              "name": "zone",
+              "in": "query",
+              "description": "Zone permettant de filtrer à la métropole, aux DROM et aux COM. Défaut à metro,drom sauf pour les communes à metro,drom,com pour conserver le comportement historique.",
+              "required": false,
+              "style": "form",
+              "explode": false,
+              "schema": { "type": "array", "items": { "type": "string", "enum": ["metro", "drom", "com"] } },
+            },
+          "epciGeometryParam":
+            {
+              "name": "geometry",
+              "in": "query",
+              "description": "Géométrie à utiliser pour la sortie géographique",
+              "schema": { "type": "string", "enum": ["centre", "contour", "bbox"], "default": "centre" },
+            },
+          "limitParam":
+            {
+              "name": "limit",
+              "in": "query",
+              "description": "Nombre d'éléments à retourner",
+              "schema": { "type": "integer", "format": "int32", "default": 0 },
+            },
+        },
+      "schemas":
+        {
+          "Error":
+            {
+              "type": "object",
+              "properties":
+                {
+                  "code": { "type": "integer", "description": "Code HTTP de l'erreur" },
+                  "message": { "type": "string", "description": "Libellé de l'erreur" },
+                  "description": { "type": "string", "description": "Explication" },
+                },
+            },
+          "Commune":
+            {
+              "type": "object",
+              "properties":
+                {
+                  "code": { "type": "string", "description": "Code INSEE de la commune" },
+                  "nom": { "type": "string", "description": "Nom de la commune" },
+                  "codesPostaux":
+                    {
+                      "type": "array",
+                      "description": "Liste des codes postaux associés à la commune",
+                      "items": { "type": "string" },
+                    },
+                  "siren": { "type": "string", "description": "Code SIREN de la commune" },
+                  "codeEpci": { "type": "string", "description": "Code de l'EPCI associé à la commune" },
+                  "codeDepartement": { "type": "string", "description": "Code du département associé à la commune" },
+                  "codeRegion": { "type": "string", "description": "Code de la région associée à la commune" },
+                  "epci": { "$ref": "#/components/schemas/Epci" },
+                  "departement": { "$ref": "#/components/schemas/Departement" },
+                  "region": { "$ref": "#/components/schemas/Region" },
+                  "associees":
+                    {
+                      "type": "array",
+                      "description": "Liste des codes postaux associés à la commune",
+                      "items":
+                        {
+                          "type": "object",
+                          "properties": { "code": { "type": "string" }, "nom": { "type": "string" } },
+                        },
+                    },
+                  "deleguees":
+                    {
+                      "type": "array",
+                      "description": "Liste des codes postaux associés à la commune",
+                      "items":
+                        {
+                          "type": "object",
+                          "properties": { "code": { "type": "string" }, "nom": { "type": "string" } },
+                        },
+                    },
+                  "population": { "type": "integer", "description": "Population municipale" },
+                  "anciensCodes":
+                    {
+                      "type": "array",
+                      "description": "Liste des anciens codes INSEE associés à la commune",
+                      "items": { "type": "string" },
+                    },
+                  "surface":
+                    { "type": "number", "format": "float", "description": "Surface de la commune, en hectares" },
+                  "centre": { "type": "object", "description": "Centre de la commune (Point GeoJSON)" },
+                  "contour": { "type": "object", "description": "Contour de la commune (Polygon GeoJSON)" },
+                  "mairie":
+                    {
+                      "type": "object",
+                      "description": "Mairie principale de la commune (Point GeoJSON). Pour les COM et les communes mortes pour la France, on retourne le centre.",
+                    },
+                  "bbox": { "type": "object", "description": "Rectangle englobant la commune (Polygon GeoJSON)" },
+                },
+            },
+          "CommuneAssocieeDeleguee":
+            {
+              "type": "object",
+              "properties":
+                {
+                  "code": { "type": "string", "description": "Code INSEE de la commune associée ou déléguée" },
+                  "nom": { "type": "string", "description": "Nom de la commune associée ou déléguée" },
+                  "codeEpci":
+                    { "type": "string", "description": "Code de l'EPCI associé à la commune associée ou déléguée" },
+                  "codeDepartement":
+                    {
+                      "type": "string",
+                      "description": "Code du département associé à la commune associée ou déléguée",
+                    },
+                  "codeRegion":
+                    { "type": "string", "description": "Code de la région associée à la commune associée ou déléguée" },
+                  "epci": { "$ref": "#/components/schemas/Epci" },
+                  "departement": { "$ref": "#/components/schemas/Departement" },
+                  "region": { "$ref": "#/components/schemas/Region" },
+                  "surface":
+                    {
+                      "type": "number",
+                      "format": "float",
+                      "description": "Surface de la commune associée ou déléguée, en hectares",
+                    },
+                  "centre":
+                    { "type": "object", "description": "Centre de la commune associée ou déléguée (Point GeoJSON)" },
+                  "contour":
+                    { "type": "object", "description": "Contour de la commune associée ou déléguée (Polygon GeoJSON)" },
+                  "bbox":
+                    {
+                      "type": "object",
+                      "description": "Rectangle englobant la commune associée ou déléguée (Polygon GeoJSON)",
+                    },
+                },
+            },
+          "Epci":
+            {
+              "type": "object",
+              "properties":
+                {
+                  "code": { "type": "string", "description": "Code SIREN de l'EPCI" },
+                  "nom": { "type": "string", "description": "Nom de l'EPCI" },
+                  "type":
+                    {
+                      "type": "string",
+                      "description": "Type de l'EPCI, soit communauté d'agglomération (CA), soit communauté de communes (CC), soit communauté urbaine (CU), soit métropole de Lyon (MET69), soit métropole (METRO)",
+                    },
+                  "financement":
+                    {
+                      "type": "string",
+                      "description": "Financement de l'EPCI, soit fiscalité additionnelle (FA), soit en fiscalité professionnelle unique (FPU)",
+                    },
+                  "codesDepartements":
+                    {
+                      "type": "array",
+                      "description": "Liste des départements de l'EPCI",
+                      "items": { "type": "string" },
+                    },
+                  "codesRegions":
+                    { "type": "array", "description": "Liste des régions de l'EPCI", "items": { "type": "string" } },
+                  "population": { "type": "integer", "description": "Population municipale" },
+                  "surface": { "type": "number", "format": "float", "description": "Surface de l'EPCI, en hectares" },
+                  "centre": { "type": "object", "description": "Centre de l'EPCI (Point GeoJSON)" },
+                  "contour": { "type": "object", "description": "Contour de l'EPCI (Polygon GeoJSON)" },
+                  "bbox": { "type": "object", "description": "Rectangle englobant la commune (Polygon GeoJSON)" },
+                },
+            },
+          "Departement":
+            {
+              "type": "object",
+              "properties":
+                {
+                  "code": { "type": "string", "description": "Code du département" },
+                  "nom": { "type": "string", "description": "Nom du département" },
+                  "codeRegion": { "type": "string", "description": "Code de la région" },
+                  "region": { "$ref": "#/components/schemas/Region" },
+                },
+            },
+          "Region":
+            {
+              "type": "object",
+              "properties":
+                {
+                  "code": { "type": "string", "description": "Code de la région" },
+                  "nom": { "type": "string", "description": "Nom de la région" },
+                },
+            },
+        },
+    },
 }

--- a/api/src/questionnaires/content/classification.ts
+++ b/api/src/questionnaires/content/classification.ts
@@ -1,6 +1,4 @@
-import type { Intervention } from "@/projet-qualification/classification/const/interventions";
-import type { Site } from "@/projet-qualification/classification/const/sites";
-import type { Thematique } from "@/projet-qualification/classification/const/thematiques";
+import type { EtiquettesRequises } from "../questionnaire-contract";
 
 /**
  * Étiquettes qui DÉFINISSENT chaque questionnaire, sur les trois axes du schéma commun.
@@ -26,22 +24,10 @@ import type { Thematique } from "@/projet-qualification/classification/const/the
  * « école » seule attraperait n'importe quel projet d'école, et « solaire » seul n'importe quelle
  * installation photovoltaïque. C'est la conjonction qui définit le questionnaire.
  *
- * Le typage sur Thematique/Site/Intervention est volontaire : une étiquette hors taxonomie ne
- * compile pas.
+ * Ces valeurs ne servent qu'à l'AMORÇAGE (`pnpm seed:questionnaires`). La source de vérité est la
+ * base, éditable depuis le back-office. Elles sont validées comme n'importe quelle édition :
+ * `validerDefinition` vérifie leur appartenance aux taxonomies fermées, sans privilège.
  */
-export interface EtiquettesRequises {
-  thematiques: readonly Thematique[];
-  sites: readonly Site[];
-  interventions: readonly Intervention[];
-}
-
-/**
- * Confiance minimale de l'étiquette DANS LA CLASSIFICATION DU PROJET pour qu'elle compte.
- *
- * Même valeur que le seuil du moteur de matching des aides (AidesMatchingService.DEFAULT_THRESHOLD) :
- * en dessous, le job LLM n'est pas assez sûr de lui pour qu'on agisse dessus.
- */
-export const SEUIL_CONFIANCE = 0.8;
 
 export const ETIQUETTES_REQUISES: Record<string, EtiquettesRequises> = {
   // Le lieu SEUL définit ce questionnaire.

--- a/api/src/questionnaires/content/content.spec.ts
+++ b/api/src/questionnaires/content/content.spec.ts
@@ -2,7 +2,7 @@ import { interventions } from "@/projet-qualification/classification/const/inter
 import { sites } from "@/projet-qualification/classification/const/sites";
 import { thematiques } from "@/projet-qualification/classification/const/thematiques";
 import type { QuestionnaireFichier } from "../questionnaire-contract";
-import { assembler, QUESTIONNAIRES, questionnaireParSlug } from "./index";
+import { assembler, QUESTIONNAIRES } from "./index";
 import { ETIQUETTES_REQUISES } from "./classification";
 
 // Ces tests portent sur le CONTENU (JSON partenaire + classification Communs). Ils sont le
@@ -119,11 +119,6 @@ describe("Contenu des questionnaires", () => {
     }
   });
 
-  it("questionnaireParSlug retrouve un questionnaire connu et rien d'autre", () => {
-    expect(questionnaireParSlug("atoutbiodiv-salle")?.slug).toBe("atoutbiodiv-salle");
-    expect(questionnaireParSlug("inexistant")).toBeUndefined();
-  });
-
   it("aucun fichier partenaire ne porte plus de champ `eligibilite`", () => {
     // Le vocabulaire thématique de MEC (« Équipements et services publics »…) n'existe pas
     // dans les taxonomies de l'API : le champ n'a jamais pu servir. Cf. README.md.
@@ -133,11 +128,18 @@ describe("Contenu des questionnaires", () => {
   });
 });
 
-describe("Garde-fous du chargeur de contenu", () => {
+/**
+ * Le chargeur ne valide plus que l'ASSEMBLAGE : champ hérité, entrée d'étiquettes absente, fichier
+ * de recommandations manquant. Les règles de FOND (étiquettes dans la taxonomie, conditions
+ * résolubles, ids uniques) sont l'affaire de `validerDefinition` — seule autorité, testée dans
+ * questionnaire-validation.spec.ts. Elles étaient vérifiées ici EN DOUBLE, et les deux jeux avaient
+ * déjà divergé : le chargeur ignorait les taxonomies et l'unicité des ids.
+ */
+describe("Garde-fous du chargeur d'amorçage", () => {
   // Ancré sur le VRAI contenu : les conditions du catalogue de recommandations d'AtoutBiodiv
   // pointent des questions réelles, un fichier bidon ne les satisferait pas.
   const fichierValide = (): QuestionnaireFichier => {
-    const { slug, version, source, banniere, questions } = questionnaireParSlug("atoutbiodiv-salle")!;
+    const { slug, version, source, banniere, questions } = QUESTIONNAIRES.find((q) => q.slug === "atoutbiodiv-salle")!;
     return { slug, version, source, banniere, questions };
   };
 
@@ -159,24 +161,5 @@ describe("Garde-fous du chargeur de contenu", () => {
     const inconnu = { ...fichierValide(), slug: "questionnaire-sans-etiquette" };
 
     expect(() => assembler(inconnu)).toThrow(/aucune étiquette d'éligibilité/);
-  });
-
-  it("refuse un questionnaire qui n'exige AUCUNE étiquette", () => {
-    // Le pire cas, et il est contre-intuitif : une conjonction VIDE est VRAIE. Un questionnaire
-    // qui n'exige rien serait proposé à TOUS les projets, sans exception. Mieux vaut refuser de
-    // démarrer que d'inonder toutes les collectivités de France.
-    ETIQUETTES_REQUISES["questionnaire-vide"] = { thematiques: [], sites: [], interventions: [] };
-
-    try {
-      expect(() => assembler({ ...fichierValide(), slug: "questionnaire-vide" })).toThrow(/proposé à TOUS les projets/);
-    } finally {
-      delete ETIQUETTES_REQUISES["questionnaire-vide"];
-    }
-  });
-
-  it("refuse une condition qui pointe une question inexistante", () => {
-    expect(() => assembler({ ...fichierValide(), slug: "atoutbiodiv-salle", questions: [] })).toThrow(
-      /question inconnue/,
-    );
   });
 });

--- a/api/src/questionnaires/content/index.ts
+++ b/api/src/questionnaires/content/index.ts
@@ -24,12 +24,13 @@ const FICHIERS_RECOMMANDATIONS = [
 ] as unknown as RecommandationsFichier[];
 
 /**
- * Assemble un questionnaire : contenu partenaire + recommandations + classification
- * d'éligibilité (détenue par Communs). Toute incohérence est une ERREUR AU DÉMARRAGE, pas
- * une recommandation qui disparaît silencieusement en production : une `condition` qui
- * pointe une question ou une option inexistante est presque toujours une coquille dans la
- * PR de contenu, et elle serait autrement indétectable (la recommandation ne s'afficherait
- * simplement jamais).
+ * ASSEMBLE une définition d'amorçage : JSON partenaire + recommandations + étiquettes.
+ *
+ * PUR CHARGEUR. Il ne valide QUE ce qui relève de l'assemblage : un champ hérité qui traîne, un
+ * fichier de recommandations manquant, une entrée absente d'ETIQUETTES_REQUISES. Tout le reste —
+ * étiquettes dans la taxonomie, conditions résolubles, ids uniques — est jugé par
+ * `validerDefinition`, SEULE autorité, que le script d'amorçage appelle comme le fait toute
+ * écriture. Deux jeux de règles sur le même invariant divergent : les nôtres l'avaient déjà fait.
  */
 export function assembler(fichier: QuestionnaireFichier): QuestionnaireDef {
   const { slug } = fichier;
@@ -42,8 +43,7 @@ export function assembler(fichier: QuestionnaireFichier): QuestionnaireDef {
   if ("eligibilite" in fichier) {
     throw new Error(
       `Questionnaire "${slug}" : le champ "eligibilite" n'est plus supporté. L'éligibilité est décidée ` +
-        `par Communs : le projet doit porter les étiquettes définissantes du questionnaire — déclarez-les ` +
-        `dans content/classification.ts (taxonomies fermées : thematiques, sites, interventions).`,
+        `par Communs : le projet doit porter les étiquettes définissantes du questionnaire.`,
     );
   }
 
@@ -55,54 +55,17 @@ export function assembler(fichier: QuestionnaireFichier): QuestionnaireDef {
     );
   }
 
-  // Une liste vide sur les trois axes serait pire qu'une absence : le questionnaire n'exigerait
-  // RIEN, donc il serait proposé à TOUS les projets. Une conjonction vide est vraie.
-  const nbEtiquettes =
-    etiquettesRequises.thematiques.length + etiquettesRequises.sites.length + etiquettesRequises.interventions.length;
-  if (nbEtiquettes === 0) {
-    throw new Error(
-      `Questionnaire "${slug}" : aucune étiquette requise. Il serait proposé à TOUS les projets ` +
-        `(une conjonction vide est vraie). Déclarez au moins une étiquette dans content/classification.ts.`,
-    );
-  }
-
   const fichierRecos = FICHIERS_RECOMMANDATIONS.find((r) => r.questionnaireSlug === slug);
   if (!fichierRecos) {
     throw new Error(`Questionnaire "${slug}" : aucun fichier de recommandations correspondant.`);
-  }
-
-  const questionsParId = new Map(fichier.questions.map((q) => [q.id, q]));
-
-  for (const reco of fichierRecos.recommandations) {
-    if (reco.condition === true) continue;
-
-    const question = questionsParId.get(reco.condition.question);
-    if (!question) {
-      throw new Error(
-        `Recommandation "${slug}:${reco.id}" : condition sur la question inconnue ` +
-          `"${reco.condition.question}" (connues : ${[...questionsParId.keys()].join(", ")}).`,
-      );
-    }
-    const optionsInconnues = reco.condition.parmi.filter((o) => !question.options.some((opt) => opt.id === o));
-    if (optionsInconnues.length > 0) {
-      throw new Error(
-        `Recommandation "${slug}:${reco.id}" : condition sur des options inconnues de la question ` +
-          `"${question.id}" : ${optionsInconnues.join(", ")} ` +
-          `(connues : ${question.options.map((o) => o.id).join(", ")}).`,
-      );
-    }
   }
 
   return { ...fichier, etiquettesRequises, recommandations: fichierRecos.recommandations };
 }
 
 /**
- * Registre des questionnaires. Source de vérité du CONTENU : les JSON de content/,
- * versionnés en Git. Les basculer plus tard vers une table ou un dépôt de schémas chargé au
- * démarrage ne demandera de réécrire ni le moteur, ni les services — seul ce fichier change.
+ * Définitions d'AMORÇAGE. Ce ne sont plus la source de vérité : la base l'est, éditable depuis le
+ * back-office. Ces JSON ne servent qu'à `pnpm seed:questionnaires`, comme le CSV DINUM sert à
+ * amorcer le catalogue de services.
  */
 export const QUESTIONNAIRES: readonly QuestionnaireDef[] = FICHIERS_QUESTIONNAIRES.map(assembler);
-
-export function questionnaireParSlug(slug: string): QuestionnaireDef | undefined {
-  return QUESTIONNAIRES.find((q) => q.slug === slug);
-}

--- a/api/src/questionnaires/content/recommandations/atoutbiodiv-place.json
+++ b/api/src/questionnaires/content/recommandations/atoutbiodiv-place.json
@@ -15,7 +15,8 @@
           "icone": "🌿",
           "libelle": "Fonds vert — Renaturation des espaces publics",
           "description": "Financement direct de la désimperméabilisation des places et voiries communales.",
-          "url": "https://aides-territoires.beta.gouv.fr/aides/a086-financer-des-solutions-dadaptation-au-changem/"
+          "url": "https://aides-territoires.beta.gouv.fr/aides/financer-des-solutions-d-adaptation-au-changement-cl/",
+          "aideId": 165809
         },
         {
           "icone": "💧",

--- a/api/src/questionnaires/dto/questionnaire-edition.dto.ts
+++ b/api/src/questionnaires/dto/questionnaire-edition.dto.ts
@@ -1,0 +1,52 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
+import { IsArray, IsNotEmpty, IsObject, IsOptional, IsString } from "class-validator";
+import type { BanniereDef, EtiquettesRequises, QuestionDef, RecommandationDef } from "../questionnaire-contract";
+
+/**
+ * Le questionnaire ENTIER, tel qu'il sera enregistré. PUT, pas PATCH : un éditeur envoie le
+ * document qu'il a sous les yeux. Un PATCH champ par champ ouvrirait la porte à des états
+ * incohérents entre deux appels — une condition sauvegardée avant la question qu'elle vise.
+ *
+ * La validation de FOND (étiquettes dans la taxonomie, conditions résolubles, ids uniques) n'est
+ * PAS ici : elle vit dans `validerDefinition`, seule autorité, appelée par le dépôt à l'écriture.
+ * La rejouer ici donnerait deux règles à tenir en phase.
+ */
+export class QuestionnaireEditionRequest {
+  @ApiProperty({ description: "Nom du partenaire qui fournit le contenu (« AtoutBiodiv »)." })
+  @IsString()
+  @IsNotEmpty()
+  sourceNom!: string;
+
+  @ApiProperty({ type: Object, description: "Bandeau : { icone, titre, sousTitre }." })
+  @IsObject()
+  banniere!: BanniereDef;
+
+  @ApiProperty({ type: [Object], description: "Questions et leurs options." })
+  @IsArray()
+  questions!: QuestionDef[];
+
+  @ApiProperty({ type: [Object], description: "Recommandations AVEC leurs conditions." })
+  @IsArray()
+  recommandations!: RecommandationDef[];
+
+  @ApiProperty({ type: Object, description: "Étiquettes que le projet doit TOUTES porter." })
+  @IsObject()
+  etiquettesRequises!: EtiquettesRequises;
+
+  @ApiPropertyOptional({ description: "Qui édite — pour la traçabilité." })
+  @IsOptional()
+  @IsString()
+  editePar?: string;
+}
+
+/** Les taxonomies fermées, servies à l'éditeur pour qu'il ne propose QUE des étiquettes valides. */
+export class TaxonomiesResponse {
+  @ApiProperty({ type: [String] })
+  thematiques!: string[];
+
+  @ApiProperty({ type: [String] })
+  sites!: string[];
+
+  @ApiProperty({ type: [String] })
+  interventions!: string[];
+}

--- a/api/src/questionnaires/eligibilite.spec.ts
+++ b/api/src/questionnaires/eligibilite.spec.ts
@@ -1,6 +1,6 @@
 import { AideClassification } from "@/aides/dto/aides.dto";
 import { QUESTIONNAIRES } from "./content";
-import { SEUIL_CONFIANCE } from "./content/classification";
+import { SEUIL_CONFIANCE } from "./questionnaire-contract";
 import { etiquettesManquantes } from "./questionnaires.service";
 
 /**

--- a/api/src/questionnaires/questionnaire-contract.ts
+++ b/api/src/questionnaires/questionnaire-contract.ts
@@ -1,5 +1,3 @@
-import type { EtiquettesRequises } from "./content/classification";
-
 // ============================================================
 // Contrat des questionnaires spécialisés
 // ============================================================
@@ -11,6 +9,31 @@ import type { EtiquettesRequises } from "./content/classification";
 // Frontière stricte : `condition` (et la classification d'éligibilité) ne sortent JAMAIS de
 // l'API. Elles sont évaluées côté serveur, et les DTO de réponse ne les portent pas. Exposer
 // une condition serait une fuite de logique métier vers le client — la spec l'interdit.
+
+/**
+ * Étiquettes qui DÉFINISSENT un questionnaire. Le projet doit TOUTES les porter (confiance ≥
+ * SEUIL_CONFIANCE) pour qu'il lui soit proposé.
+ *
+ * `string[]` et non `Thematique[]` : les valeurs viennent d'un jsonb, éditable depuis le
+ * back-office. Un typage littéral ne protégerait plus rien — c'est `validerDefinition` qui vérifie
+ * l'appartenance aux taxonomies fermées, et lui seul peut le faire à l'écriture.
+ */
+export interface EtiquettesRequises {
+  thematiques: readonly string[];
+  sites: readonly string[];
+  interventions: readonly string[];
+}
+
+/** Les trois axes du schéma commun. */
+export const AXES = ["thematiques", "sites", "interventions"] as const;
+export type Axe = (typeof AXES)[number];
+
+/**
+ * Confiance minimale de l'étiquette DANS LA CLASSIFICATION DU PROJET pour qu'elle compte.
+ * Même valeur que le seuil du moteur de matching des aides : en dessous, le job LLM n'est pas assez
+ * sûr de lui pour qu'on agisse dessus.
+ */
+export const SEUIL_CONFIANCE = 0.8;
 
 export const SIGNAUX = ["favorable", "vigilance", "neutre"] as const;
 export type Signal = (typeof SIGNAUX)[number];

--- a/api/src/questionnaires/questionnaire-contract.ts
+++ b/api/src/questionnaires/questionnaire-contract.ts
@@ -92,11 +92,30 @@ export interface QuestionnaireFichier {
 // Contenu partenaire : recommandations
 // ------------------------------------------------------------
 
+/**
+ * Un financement cité par une recommandation.
+ *
+ * `aideId` — l'identifiant Aides-territoires, QUAND le financement désigne une aide précise. Il
+ * permet à MEC de proposer « ajouter cette aide au projet » (POST /projets/:id/aides/ajouts) sans
+ * que l'agent ait à la retrouver à la main.
+ *
+ * FACULTATIF, et ça n'est pas une négligence : beaucoup de financements désignent une FAMILLE
+ * d'aides, pas une aide (« Fonds vert — Biodiversité », « DETR »), et leur `url` est une recherche,
+ * pas une fiche. Les forcer à porter un id obligerait à en inventer un — donc à envoyer une
+ * collectivité vers la mauvaise aide.
+ *
+ * ON NE PEUT PAS VÉRIFIER À L'ÉCRITURE QU'UN ID EXISTE : Aides-territoires ne sait pas récupérer
+ * une aide par son identifiant (`/aids/<id>/` répond 404, et `?id=<n>` est silencieusement ignoré).
+ * On ne le saura qu'au moment de l'ajout, contre le périmètre d'un projet. Un id valide peut
+ * d'ailleurs légitimement échouer là : une aide d'Agence de l'Eau Adour-Garonne n'est pas
+ * disponible pour une commune bretonne. Ce n'est pas un bug, c'est le territoire.
+ */
 export interface FinancementDef {
   icone?: string;
   libelle: string;
   description?: string;
   url: string;
+  aideId?: number;
 }
 
 export interface RessourceDef {

--- a/api/src/questionnaires/questionnaire-validation.spec.ts
+++ b/api/src/questionnaires/questionnaire-validation.spec.ts
@@ -1,0 +1,147 @@
+import { BadRequestException } from "@nestjs/common";
+import type { QuestionnaireDef } from "./questionnaire-contract";
+import { validerDefinition } from "./questionnaire-validation";
+
+/**
+ * LE FILET DE SÉCURITÉ, DÉPLACÉ.
+ *
+ * Tant que les questionnaires vivaient dans le dépôt, une incohérence empêchait l'API de DÉMARRER.
+ * Brutal, mais parfait : le bug ne pouvait pas atteindre la production. En base, éditables depuis
+ * le back-office, ce filet disparaît — sauf s'il est intégralement reconstruit à l'écriture.
+ *
+ * C'est ce que ces tests verrouillent. Chacun correspond à un refus que le chargeur opposait au
+ * démarrage. Si l'un d'eux tombe, une personne pourra enregistrer depuis le back-office un
+ * questionnaire cassé, et le casse n'apparaîtra NULLE PART : la recommandation ne s'affichera
+ * simplement jamais, ou le questionnaire ne sera jamais proposé.
+ */
+
+const option = (id: string, libelle: string) => ({ id, libelle, signal: "neutre" as const });
+
+const reco = (id: string, titre: string, condition: QuestionnaireDef["recommandations"][number]["condition"]) => ({
+  id,
+  titre,
+  description: `Description de ${titre}`,
+  condition,
+  financements: [],
+  ressources: [],
+  engagement: "faible",
+});
+
+const valide = (): QuestionnaireDef => ({
+  slug: "test",
+  version: 1,
+  source: { nom: "AtoutBiodiv" },
+  banniere: { icone: "🌿", titre: "Titre", sousTitre: "Sous-titre" },
+  questions: [
+    {
+      id: "surface",
+      type: "choix-unique",
+      intitule: "Quelle surface ?",
+      options: [option("petite", "Petite"), option("grande", "Grande")],
+    },
+  ],
+  recommandations: [
+    reco("haies", "Planter des haies", { question: "surface", parmi: ["grande"] }),
+    reco("toujours", "Recommandation inconditionnelle", true),
+  ],
+  etiquettesRequises: { thematiques: [], sites: ["Place ou centre-bourg"], interventions: [] },
+});
+
+describe("Validation d'un questionnaire à l'écriture", () => {
+  it("accepte une définition cohérente", () => {
+    expect(() => validerDefinition(valide())).not.toThrow();
+  });
+
+  describe("Étiquettes d'éligibilité", () => {
+    it("REFUSE un questionnaire qui n'exige AUCUNE étiquette", () => {
+      // Le plus dangereux, et le plus contre-intuitif : une conjonction VIDE est VRAIE. Ce
+      // questionnaire serait proposé à TOUS les projets de France, sans exception.
+      const def = { ...valide(), etiquettesRequises: { thematiques: [], sites: [], interventions: [] } };
+
+      expect(() => validerDefinition(def)).toThrow(/proposé à TOUS les projets/);
+    });
+
+    it("REFUSE une étiquette hors de la taxonomie fermée", () => {
+      // Une coquille ici, et le questionnaire n'est JAMAIS proposé — sans le moindre message. C'est
+      // exactement le bug que le typage TypeScript empêchait, et qu'il faut donc rattraper ici.
+      const def = {
+        ...valide(),
+        etiquettesRequises: { thematiques: [], sites: ["Place ou centre bourg"], interventions: [] },
+      } as unknown as QuestionnaireDef;
+
+      expect(() => validerDefinition(def)).toThrow(/hors de la taxonomie/);
+    });
+
+    it("nomme l'étiquette fautive — la personne qui édite n'a pas accès au code", () => {
+      const def = {
+        ...valide(),
+        etiquettesRequises: { thematiques: ["Vélo"], sites: [], interventions: [] },
+      } as unknown as QuestionnaireDef;
+
+      expect(() => validerDefinition(def)).toThrow(/« Vélo »/);
+    });
+  });
+
+  describe("Conditions des recommandations", () => {
+    it("REFUSE une condition qui pointe une question inexistante", () => {
+      // Autrement INDÉTECTABLE : la recommandation ne s'afficherait simplement jamais. C'est le
+      // garde-fou le plus important.
+      const def = valide();
+      def.recommandations = [reco("haies", "Haies", { question: "inconnue", parmi: ["grande"] })];
+
+      expect(() => validerDefinition(def)).toThrow(/n'existe pas/);
+    });
+
+    it("REFUSE une condition qui cite une option inexistante", () => {
+      const def = valide();
+      def.recommandations = [reco("haies", "Haies", { question: "surface", parmi: ["enorme"] })];
+
+      expect(() => validerDefinition(def)).toThrow(/options inconnues/);
+    });
+
+    it("accepte une condition inconditionnelle (`true`)", () => {
+      const def = valide();
+      def.recommandations = [reco("toujours", "Toujours", true)];
+
+      expect(() => validerDefinition(def)).not.toThrow();
+    });
+  });
+
+  describe("Identifiants", () => {
+    it("REFUSE deux questions de même id", () => {
+      const def = valide();
+      def.questions = [def.questions[0], { ...def.questions[0] }];
+
+      expect(() => validerDefinition(def)).toThrow(/deux questions portent l'id/);
+    });
+
+    it("REFUSE deux options de même id dans une question", () => {
+      // La réponse de la collectivité serait ambiguë : impossible de savoir laquelle elle a choisie.
+      const def = valide();
+      def.questions[0].options = [option("petite", "Petite"), option("petite", "Petite (bis)")];
+
+      expect(() => validerDefinition(def)).toThrow(/deux options portent l'id/);
+    });
+
+    it("REFUSE une question sans option", () => {
+      const def = valide();
+      def.questions[0].options = [];
+
+      expect(() => validerDefinition(def)).toThrow(/aucune option/);
+    });
+
+    it("REFUSE un questionnaire sans question", () => {
+      const def = { ...valide(), questions: [], recommandations: [] };
+
+      expect(() => validerDefinition(def)).toThrow(/aucune question/);
+    });
+  });
+
+  it("lève une BadRequestException, pas une Error — c'est un 400, pas un 500", () => {
+    // Une définition invalide vient de l'éditeur, pas d'un bug de l'API. Le lui dire en 400 avec un
+    // message précis, c'est la différence entre « corrigez le lieu X » et « erreur serveur ».
+    const def = { ...valide(), etiquettesRequises: { thematiques: [], sites: [], interventions: [] } };
+
+    expect(() => validerDefinition(def)).toThrow(BadRequestException);
+  });
+});

--- a/api/src/questionnaires/questionnaire-validation.ts
+++ b/api/src/questionnaires/questionnaire-validation.ts
@@ -1,0 +1,140 @@
+import { BadRequestException } from "@nestjs/common";
+import { interventions } from "@/projet-qualification/classification/const/interventions";
+import { sites } from "@/projet-qualification/classification/const/sites";
+import { thematiques } from "@/projet-qualification/classification/const/thematiques";
+import type { QuestionnaireDef } from "./questionnaire-contract";
+
+/**
+ * LES GARDE-FOUS DU CHARGEUR, DÉPLACÉS À L'ÉCRITURE.
+ *
+ * Tant que les questionnaires vivaient dans le dépôt, le chargeur refusait de DÉMARRER si une
+ * condition pointait une question inexistante, si une étiquette sortait de la taxonomie fermée, ou
+ * si un questionnaire n'exigeait aucune étiquette. C'était brutal, et c'était un filet parfait : le
+ * bug ne pouvait pas atteindre la production.
+ *
+ * En base, ce filet disparaît. On le reconstruit ici, INTÉGRALEMENT : les mêmes vérifications, au
+ * même niveau d'exigence, rendues en 400 explicite. Aucune n'a été assouplie — c'était la condition
+ * pour accepter de rendre les questionnaires éditables.
+ *
+ * Chaque message nomme le champ fautif ET ce qui était attendu. Une personne qui édite depuis le
+ * back-office n'a pas accès au code : le message d'erreur est tout ce qu'elle a.
+ */
+
+const REFERENTIELS = {
+  thematiques: new Set<string>(thematiques),
+  sites: new Set<string>(sites),
+  interventions: new Set<string>(interventions),
+};
+
+const AXES = ["thematiques", "sites", "interventions"] as const;
+
+const LIBELLE_AXE: Record<(typeof AXES)[number], string> = {
+  thematiques: "thématique",
+  sites: "lieu",
+  interventions: "modalité",
+};
+
+export function validerDefinition(def: QuestionnaireDef): void {
+  validerEtiquettes(def);
+  validerQuestions(def);
+  validerRecommandations(def);
+}
+
+/**
+ * Les étiquettes appartiennent aux taxonomies fermées, et il y en a AU MOINS UNE.
+ *
+ * Le second point est contre-intuitif, et c'est le plus dangereux : une conjonction VIDE est VRAIE.
+ * Un questionnaire qui n'exigerait rien serait proposé à TOUS les projets de France, sans
+ * exception. Mieux vaut refuser l'enregistrement.
+ */
+function validerEtiquettes(def: QuestionnaireDef): void {
+  const requises = def.etiquettesRequises;
+
+  const total = AXES.reduce((n, axe) => n + (requises[axe]?.length ?? 0), 0);
+  if (total === 0) {
+    throw new BadRequestException(
+      `Questionnaire "${def.slug}" : aucune étiquette requise. Il serait proposé à TOUS les projets ` +
+        `(une conjonction vide est vraie). Déclarez au moins une thématique, un lieu ou une modalité.`,
+    );
+  }
+
+  for (const axe of AXES) {
+    for (const label of requises[axe] ?? []) {
+      if (!REFERENTIELS[axe].has(label)) {
+        throw new BadRequestException(
+          `Questionnaire "${def.slug}" : ${LIBELLE_AXE[axe]} « ${label} » hors de la taxonomie du schéma ` +
+            `commun. Une étiquette mal orthographiée ferait que le questionnaire n'est JAMAIS proposé, ` +
+            `sans le moindre message.`,
+        );
+      }
+    }
+  }
+}
+
+/** Ids uniques : deux questions homonymes rendraient la réponse de l'une indiscernable de l'autre. */
+function validerQuestions(def: QuestionnaireDef): void {
+  if (def.questions.length === 0) {
+    throw new BadRequestException(`Questionnaire "${def.slug}" : aucune question.`);
+  }
+
+  const vues = new Set<string>();
+  for (const question of def.questions) {
+    if (vues.has(question.id)) {
+      throw new BadRequestException(`Questionnaire "${def.slug}" : deux questions portent l'id "${question.id}".`);
+    }
+    vues.add(question.id);
+
+    if (question.options.length === 0) {
+      throw new BadRequestException(`Question "${question.id}" : aucune option — elle serait sans réponse possible.`);
+    }
+
+    const options = new Set<string>();
+    for (const option of question.options) {
+      if (options.has(option.id)) {
+        throw new BadRequestException(
+          `Question "${question.id}" : deux options portent l'id "${option.id}". La réponse de la ` +
+            `collectivité serait ambiguë.`,
+        );
+      }
+      options.add(option.id);
+    }
+  }
+}
+
+/**
+ * Une condition qui pointe une question ou une option inexistante est presque toujours une coquille
+ * — et elle serait AUTREMENT INDÉTECTABLE : la recommandation ne s'afficherait simplement jamais.
+ * C'est le garde-fou le plus important de ce fichier.
+ */
+function validerRecommandations(def: QuestionnaireDef): void {
+  const questionsParId = new Map(def.questions.map((q) => [q.id, q]));
+  const vues = new Set<string>();
+
+  for (const reco of def.recommandations) {
+    if (vues.has(reco.id)) {
+      throw new BadRequestException(`Questionnaire "${def.slug}" : deux recommandations portent l'id "${reco.id}".`);
+    }
+    vues.add(reco.id);
+
+    // `true` = inconditionnelle : elle sort dès que le questionnaire est entamé.
+    if (reco.condition === true) continue;
+
+    const question = questionsParId.get(reco.condition.question);
+    if (!question) {
+      throw new BadRequestException(
+        `Recommandation "${reco.id}" : sa condition porte sur la question "${reco.condition.question}", ` +
+          `qui n'existe pas (questions connues : ${[...questionsParId.keys()].join(", ")}). La ` +
+          `recommandation ne s'afficherait jamais.`,
+      );
+    }
+
+    const inconnues = reco.condition.parmi.filter((o) => !question.options.some((opt) => opt.id === o));
+    if (inconnues.length > 0) {
+      throw new BadRequestException(
+        `Recommandation "${reco.id}" : sa condition cite des options inconnues de la question ` +
+          `"${question.id}" : ${inconnues.join(", ")} (options connues : ` +
+          `${question.options.map((o) => o.id).join(", ")}). La recommandation ne s'afficherait jamais.`,
+      );
+    }
+  }
+}

--- a/api/src/questionnaires/questionnaire-validation.ts
+++ b/api/src/questionnaires/questionnaire-validation.ts
@@ -117,6 +117,20 @@ function validerRecommandations(def: Definition): void {
     }
     vues.add(reco.id);
 
+    for (const financement of reco.financements) {
+      // On ne peut vérifier que la FORME. PAS l'existence : Aides-territoires ne sait pas récupérer
+      // une aide par son identifiant (`/aids/<id>/` → 404, `?id=<n>` silencieusement ignoré). On ne
+      // saura donc qu'un id est bon qu'au moment où MEC tentera l'ajout, sur le périmètre d'un
+      // projet — et un id parfaitement valide peut y échouer légitimement : une aide régionale n'est
+      // pas disponible partout.
+      if (financement.aideId !== undefined && (!Number.isInteger(financement.aideId) || financement.aideId <= 0)) {
+        throw new BadRequestException(
+          `Recommandation "${reco.id}" : le financement « ${financement.libelle} » porte un aideId ` +
+            `invalide (${financement.aideId}). Attendu : l'identifiant Aides-territoires, un entier positif.`,
+        );
+      }
+    }
+
     // `true` = inconditionnelle : elle sort dès que le questionnaire est entamé.
     if (reco.condition === true) continue;
 

--- a/api/src/questionnaires/questionnaire-validation.ts
+++ b/api/src/questionnaires/questionnaire-validation.ts
@@ -2,7 +2,10 @@ import { BadRequestException } from "@nestjs/common";
 import { interventions } from "@/projet-qualification/classification/const/interventions";
 import { sites } from "@/projet-qualification/classification/const/sites";
 import { thematiques } from "@/projet-qualification/classification/const/thematiques";
-import type { QuestionnaireDef } from "./questionnaire-contract";
+import { AXES, type QuestionnaireDef } from "./questionnaire-contract";
+
+/** La version n'est pas du contenu : elle est posée par la base, jamais validée. */
+type Definition = Omit<QuestionnaireDef, "version">;
 
 /**
  * LES GARDE-FOUS DU CHARGEUR, DÉPLACÉS À L'ÉCRITURE.
@@ -26,15 +29,13 @@ const REFERENTIELS = {
   interventions: new Set<string>(interventions),
 };
 
-const AXES = ["thematiques", "sites", "interventions"] as const;
-
 const LIBELLE_AXE: Record<(typeof AXES)[number], string> = {
   thematiques: "thématique",
   sites: "lieu",
   interventions: "modalité",
 };
 
-export function validerDefinition(def: QuestionnaireDef): void {
+export function validerDefinition(def: Omit<QuestionnaireDef, "version">): void {
   validerEtiquettes(def);
   validerQuestions(def);
   validerRecommandations(def);
@@ -47,7 +48,7 @@ export function validerDefinition(def: QuestionnaireDef): void {
  * Un questionnaire qui n'exigerait rien serait proposé à TOUS les projets de France, sans
  * exception. Mieux vaut refuser l'enregistrement.
  */
-function validerEtiquettes(def: QuestionnaireDef): void {
+function validerEtiquettes(def: Definition): void {
   const requises = def.etiquettesRequises;
 
   const total = AXES.reduce((n, axe) => n + (requises[axe]?.length ?? 0), 0);
@@ -72,7 +73,7 @@ function validerEtiquettes(def: QuestionnaireDef): void {
 }
 
 /** Ids uniques : deux questions homonymes rendraient la réponse de l'une indiscernable de l'autre. */
-function validerQuestions(def: QuestionnaireDef): void {
+function validerQuestions(def: Definition): void {
   if (def.questions.length === 0) {
     throw new BadRequestException(`Questionnaire "${def.slug}" : aucune question.`);
   }
@@ -106,7 +107,7 @@ function validerQuestions(def: QuestionnaireDef): void {
  * — et elle serait AUTREMENT INDÉTECTABLE : la recommandation ne s'afficherait simplement jamais.
  * C'est le garde-fou le plus important de ce fichier.
  */
-function validerRecommandations(def: QuestionnaireDef): void {
+function validerRecommandations(def: Definition): void {
   const questionsParId = new Map(def.questions.map((q) => [q.id, q]));
   const vues = new Set<string>();
 

--- a/api/src/questionnaires/questionnaires-admin.controller.ts
+++ b/api/src/questionnaires/questionnaires-admin.controller.ts
@@ -1,0 +1,83 @@
+import { Body, Controller, Delete, Get, HttpCode, Param, Put, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { interventions } from "@/projet-qualification/classification/const/interventions";
+import { sites } from "@/projet-qualification/classification/const/sites";
+import { thematiques } from "@/projet-qualification/classification/const/thematiques";
+import { QuestionnairesRepository } from "./questionnaires.repository";
+import { QuestionnaireEditionRequest, TaxonomiesResponse } from "./dto/questionnaire-edition.dto";
+
+/**
+ * ÉCRITURE des questionnaires. Vit ici, dans le module des questionnaires, et non dans `src/admin`.
+ *
+ * POURQUOI. Le back-office doit rester supprimable sans amputer l'API — c'était la contrainte. Or
+ * ceci est l'UNIQUE chemin d'écriture, et c'est lui qui porte la validation qui remplace le refus
+ * de démarrage qu'on avait quand les questionnaires vivaient dans le dépôt. L'héberger dans un
+ * module jetable, c'était rendre le contenu non éditable le jour où on jette l'écran.
+ *
+ * La bonne frontière n'est pas « back-office vs reste » : c'est « écrire un contenu métier » vs
+ * « afficher un écran ». L'écriture appartient au domaine, à côté de la lecture. `src/admin` ne
+ * garde que la SIMULATION — son vrai propos — et redevient réellement jetable.
+ *
+ * Derrière `ServiceApiKeyGuard` : c'est le garde d'administration, jamais une clé de plateforme
+ * partenaire. Éditer un questionnaire n'est pas un droit de MEC.
+ */
+@ApiBearerAuth()
+@ApiTags("Administration")
+@Controller("admin")
+@UseGuards(ServiceApiKeyGuard)
+export class QuestionnairesAdminController {
+  constructor(private readonly repository: QuestionnairesRepository) {}
+
+  @Get("taxonomies")
+  @ApiOperation({
+    summary: "Les taxonomies fermées du schéma commun",
+    description:
+      "137 thématiques, 58 lieux, 15 modalités. Servies à l'éditeur pour qu'il ne propose QUE des " +
+      "étiquettes valides : le sélecteur rend la coquille impossible, là où la validation ne fait " +
+      "que la rattraper. Sans cet endpoint, le back-office devrait recopier les listes — et une " +
+      "copie dérive.",
+  })
+  @ApiEndpointResponses({ successStatus: 200, response: TaxonomiesResponse, description: "Taxonomies" })
+  taxonomies(): TaxonomiesResponse {
+    return { thematiques: [...thematiques], sites: [...sites], interventions: [...interventions] };
+  }
+
+  @Put("questionnaires/:slug")
+  @ApiOperation({
+    summary: "Créer ou remplacer un questionnaire",
+    description:
+      "PUT, pas PATCH : un éditeur envoie le document qu'il a sous les yeux. Un PATCH champ par " +
+      "champ autoriserait des états incohérents entre deux appels — une condition enregistrée avant " +
+      "la question qu'elle vise.\n\n" +
+      "Tout est revalidé avant écriture, et un écart est un 400 explicite (cf. validerDefinition).\n\n" +
+      "La `version` s'incrémente automatiquement. Elle n'invalide rien : les réponses des " +
+      "collectivités devenues sans objet sont ignorées à la lecture, jamais effacées.",
+  })
+  editer(@Param("slug") slug: string, @Body() dto: QuestionnaireEditionRequest) {
+    return this.repository.enregistrer(
+      {
+        slug,
+        source: { nom: dto.sourceNom },
+        banniere: dto.banniere,
+        questions: dto.questions,
+        recommandations: dto.recommandations,
+        etiquettesRequises: dto.etiquettesRequises,
+      },
+      dto.editePar,
+    );
+  }
+
+  @Delete("questionnaires/:slug")
+  @HttpCode(204)
+  @ApiOperation({
+    summary: "Supprimer un questionnaire",
+    description:
+      "Les réponses déjà données par les collectivités ne sont PAS supprimées : elles cessent " +
+      "simplement d'être lues. Si le questionnaire est recréé sous le même slug, elles reviennent.",
+  })
+  supprimer(@Param("slug") slug: string): Promise<void> {
+    return this.repository.supprimer(slug);
+  }
+}

--- a/api/src/questionnaires/questionnaires.module.ts
+++ b/api/src/questionnaires/questionnaires.module.ts
@@ -3,18 +3,19 @@ import { DatabaseModule } from "@database/database.module";
 import { ProjetsModule } from "@projets/projets.module";
 import { QuestionnairesController } from "./questionnaires.controller";
 import { QuestionnairesService } from "./questionnaires.service";
+import { QuestionnairesRepository } from "./questionnaires.repository";
 
 @Module({
   imports: [DatabaseModule, ProjetsModule],
   controllers: [QuestionnairesController],
-  providers: [
-    QuestionnairesService,
-    // Le moteur de matching est fourni ici plutôt qu'importé depuis AidesModule : il est
-    // sans état (seule dépendance : le logger), et importer AidesModule entraînerait ses
-    // files BullMQ et son cron de synchronisation quotidienne, dont on n'a aucun besoin.
-  ],
-  // Exporté : la source de recommandations « questionnaire » consomme le même état
-  // (éligibilité + réponses réconciliées), pour éviter d'en avoir deux définitions.
-  exports: [QuestionnairesService],
+  providers: [QuestionnairesService, QuestionnairesRepository],
+  // `QuestionnairesService` est exporté parce que la source de recommandations « questionnaire »
+  // consomme le même état (éligibilité + réponses réconciliées) : une seule définition.
+  //
+  // `QuestionnairesRepository` l'est parce que le back-office ÉDITE les questionnaires, et doit
+  // passer par la MÊME porte que la lecture. Un second chemin d'écriture contournerait la
+  // validation — or c'est elle qui remplace le refus de démarrage qu'on avait quand les
+  // questionnaires vivaient dans le dépôt.
+  exports: [QuestionnairesService, QuestionnairesRepository],
 })
 export class QuestionnairesModule {}

--- a/api/src/questionnaires/questionnaires.module.ts
+++ b/api/src/questionnaires/questionnaires.module.ts
@@ -2,20 +2,22 @@ import { Module } from "@nestjs/common";
 import { DatabaseModule } from "@database/database.module";
 import { ProjetsModule } from "@projets/projets.module";
 import { QuestionnairesController } from "./questionnaires.controller";
+import { QuestionnairesAdminController } from "./questionnaires-admin.controller";
 import { QuestionnairesService } from "./questionnaires.service";
 import { QuestionnairesRepository } from "./questionnaires.repository";
 
 @Module({
   imports: [DatabaseModule, ProjetsModule],
-  controllers: [QuestionnairesController],
+  // Deux contrôleurs, deux publics : la LECTURE pour les plateformes partenaires (ApiKeyGuard),
+  // l'ÉCRITURE pour l'administration (ServiceApiKeyGuard). L'écriture reste dans le domaine, et non
+  // dans le module du back-office — qui doit rester jetable.
+  controllers: [QuestionnairesController, QuestionnairesAdminController],
   providers: [QuestionnairesService, QuestionnairesRepository],
   // `QuestionnairesService` est exporté parce que la source de recommandations « questionnaire »
   // consomme le même état (éligibilité + réponses réconciliées) : une seule définition.
   //
-  // `QuestionnairesRepository` l'est parce que le back-office ÉDITE les questionnaires, et doit
-  // passer par la MÊME porte que la lecture. Un second chemin d'écriture contournerait la
-  // validation — or c'est elle qui remplace le refus de démarrage qu'on avait quand les
-  // questionnaires vivaient dans le dépôt.
+  // `QuestionnairesRepository` l'est pour que le back-office puisse LIRE le contenu (simulation).
+  // L'écriture, elle, ne sort pas de ce module : elle passe par QuestionnairesAdminController.
   exports: [QuestionnairesService, QuestionnairesRepository],
 })
 export class QuestionnairesModule {}

--- a/api/src/questionnaires/questionnaires.repository.ts
+++ b/api/src/questionnaires/questionnaires.repository.ts
@@ -1,0 +1,101 @@
+import { Injectable, NotFoundException } from "@nestjs/common";
+import { eq, sql } from "drizzle-orm";
+import { DatabaseService } from "@database/database.service";
+import { questionnaires } from "@database/schema";
+import type { EtiquettesRequises } from "./content/classification";
+import type { BanniereDef, QuestionDef, QuestionnaireDef, RecommandationDef } from "./questionnaire-contract";
+import { validerDefinition } from "./questionnaire-validation";
+
+type Ligne = typeof questionnaires.$inferSelect;
+
+/**
+ * Les questionnaires vivent en BASE, et sont éditables depuis le back-office.
+ *
+ * Ils vivaient dans le dépôt (JSON partenaire + classification.ts), relus en PR, et le chargeur
+ * refusait de démarrer sur la moindre incohérence. On a échangé ce filet contre l'édition sans
+ * déploiement — mais on ne l'a pas perdu : `validerDefinition` le rejoue à l'écriture, et refuse
+ * (400) exactement ce que le chargeur refusait.
+ */
+@Injectable()
+export class QuestionnairesRepository {
+  constructor(private readonly dbService: DatabaseService) {}
+
+  /** Tous les questionnaires, dans l'ordre alphabétique de leur slug (stable entre deux appels). */
+  async tous(): Promise<QuestionnaireDef[]> {
+    const lignes = await this.dbService.database.select().from(questionnaires).orderBy(questionnaires.slug);
+    return lignes.map(versDefinition);
+  }
+
+  async parSlug(slug: string): Promise<QuestionnaireDef> {
+    const [ligne] = await this.dbService.database
+      .select()
+      .from(questionnaires)
+      .where(eq(questionnaires.slug, slug))
+      .limit(1);
+
+    if (!ligne) throw new NotFoundException(`Questionnaire "${slug}" inconnu.`);
+    return versDefinition(ligne);
+  }
+
+  /**
+   * Crée ou remplace un questionnaire, APRÈS validation complète.
+   *
+   * La version s'incrémente à chaque édition. Elle n'invalide rien : `reconcilierReponses` ignore à
+   * la lecture les réponses devenues sans objet, sans réécrire la ligne stockée. Une collectivité
+   * qui avait répondu à une question supprimée ne perd pas ses autres réponses.
+   */
+  async enregistrer(def: QuestionnaireDef, editePar?: string): Promise<QuestionnaireDef> {
+    validerDefinition(def);
+
+    const valeurs = {
+      slug: def.slug,
+      sourceNom: def.source.nom,
+      banniere: def.banniere as unknown as Record<string, unknown>,
+      questions: def.questions as unknown as unknown[],
+      recommandations: def.recommandations as unknown as unknown[],
+      etiquettesRequises: {
+        thematiques: [...def.etiquettesRequises.thematiques],
+        sites: [...def.etiquettesRequises.sites],
+        interventions: [...def.etiquettesRequises.interventions],
+      },
+      editePar: editePar ?? null,
+    };
+
+    const [ligne] = await this.dbService.database
+      .insert(questionnaires)
+      .values(valeurs)
+      .onConflictDoUpdate({
+        target: questionnaires.slug,
+        set: { ...valeurs, version: sqlIncrement() },
+      })
+      .returning();
+
+    return versDefinition(ligne);
+  }
+
+  async supprimer(slug: string): Promise<void> {
+    const supprimees = await this.dbService.database
+      .delete(questionnaires)
+      .where(eq(questionnaires.slug, slug))
+      .returning({ slug: questionnaires.slug });
+
+    if (supprimees.length === 0) throw new NotFoundException(`Questionnaire "${slug}" inconnu.`);
+  }
+}
+
+/** `version + 1` — l'édition incrémente, elle ne réinitialise pas. */
+function sqlIncrement() {
+  return sql`${questionnaires.version} + 1`;
+}
+
+function versDefinition(l: Ligne): QuestionnaireDef {
+  return {
+    slug: l.slug,
+    version: l.version,
+    source: { nom: l.sourceNom },
+    banniere: l.banniere as unknown as BanniereDef,
+    questions: l.questions as unknown as QuestionDef[],
+    recommandations: l.recommandations as unknown as RecommandationDef[],
+    etiquettesRequises: l.etiquettesRequises as unknown as EtiquettesRequises,
+  };
+}

--- a/api/src/questionnaires/questionnaires.repository.ts
+++ b/api/src/questionnaires/questionnaires.repository.ts
@@ -2,8 +2,13 @@ import { Injectable, NotFoundException } from "@nestjs/common";
 import { eq, sql } from "drizzle-orm";
 import { DatabaseService } from "@database/database.service";
 import { questionnaires } from "@database/schema";
-import type { EtiquettesRequises } from "./content/classification";
-import type { BanniereDef, QuestionDef, QuestionnaireDef, RecommandationDef } from "./questionnaire-contract";
+import type {
+  BanniereDef,
+  EtiquettesRequises,
+  QuestionDef,
+  QuestionnaireDef,
+  RecommandationDef,
+} from "./questionnaire-contract";
 import { validerDefinition } from "./questionnaire-validation";
 
 type Ligne = typeof questionnaires.$inferSelect;
@@ -16,25 +21,34 @@ type Ligne = typeof questionnaires.$inferSelect;
  * déploiement — mais on ne l'a pas perdu : `validerDefinition` le rejoue à l'écriture, et refuse
  * (400) exactement ce que le chargeur refusait.
  */
+/**
+ * Durée de vie du cache mémoire.
+ *
+ * Les questionnaires sont 4 lignes quasi immuables, éditées à la main quelques fois par an — et
+ * relues DEUX fois à chaque affichage de fiche projet (une fois pour les questionnaires, une fois
+ * pour les recommandations qui s'appuient dessus). Les garder en mémoire supprime ces lectures.
+ *
+ * Le TTL couvre le cas multi-instance : celle qui écrit vide son propre cache, les autres
+ * rattrapent en moins d'une minute. Personne n'attend qu'une édition de back-office soit visible à
+ * la milliseconde — et le dire ici évite qu'on cherche un bug le jour où ça prend 30 secondes.
+ */
+const CACHE_MS = 60_000;
+
 @Injectable()
 export class QuestionnairesRepository {
+  private cache: { defs: QuestionnaireDef[]; expire: number } | null = null;
+
   constructor(private readonly dbService: DatabaseService) {}
 
   /** Tous les questionnaires, dans l'ordre alphabétique de leur slug (stable entre deux appels). */
   async tous(): Promise<QuestionnaireDef[]> {
+    if (this.cache && this.cache.expire > Date.now()) return this.cache.defs;
+
     const lignes = await this.dbService.database.select().from(questionnaires).orderBy(questionnaires.slug);
-    return lignes.map(versDefinition);
-  }
+    const defs = lignes.map(versDefinition);
 
-  async parSlug(slug: string): Promise<QuestionnaireDef> {
-    const [ligne] = await this.dbService.database
-      .select()
-      .from(questionnaires)
-      .where(eq(questionnaires.slug, slug))
-      .limit(1);
-
-    if (!ligne) throw new NotFoundException(`Questionnaire "${slug}" inconnu.`);
-    return versDefinition(ligne);
+    this.cache = { defs, expire: Date.now() + CACHE_MS };
+    return defs;
   }
 
   /**
@@ -44,32 +58,23 @@ export class QuestionnairesRepository {
    * la lecture les réponses devenues sans objet, sans réécrire la ligne stockée. Une collectivité
    * qui avait répondu à une question supprimée ne perd pas ses autres réponses.
    */
-  async enregistrer(def: QuestionnaireDef, editePar?: string): Promise<QuestionnaireDef> {
+  async enregistrer(def: Omit<QuestionnaireDef, "version">, editePar?: string): Promise<QuestionnaireDef> {
     validerDefinition(def);
 
-    const valeurs = {
-      slug: def.slug,
-      sourceNom: def.source.nom,
-      banniere: def.banniere as unknown as Record<string, unknown>,
-      questions: def.questions as unknown as unknown[],
-      recommandations: def.recommandations as unknown as unknown[],
-      etiquettesRequises: {
-        thematiques: [...def.etiquettesRequises.thematiques],
-        sites: [...def.etiquettesRequises.sites],
-        interventions: [...def.etiquettesRequises.interventions],
-      },
-      editePar: editePar ?? null,
-    };
+    const valeurs = versLigne(def, editePar);
 
     const [ligne] = await this.dbService.database
       .insert(questionnaires)
       .values(valeurs)
       .onConflictDoUpdate({
         target: questionnaires.slug,
-        set: { ...valeurs, version: sqlIncrement() },
+        // La version s'incrémente ici, jamais depuis le client : un éditeur qui la fournirait
+        // pourrait faire reculer un questionnaire déjà édité par quelqu'un d'autre.
+        set: { ...valeurs, version: sql`${questionnaires.version} + 1` },
       })
       .returning();
 
+    this.cache = null;
     return versDefinition(ligne);
   }
 
@@ -79,13 +84,29 @@ export class QuestionnairesRepository {
       .where(eq(questionnaires.slug, slug))
       .returning({ slug: questionnaires.slug });
 
+    this.cache = null;
     if (supprimees.length === 0) throw new NotFoundException(`Questionnaire "${slug}" inconnu.`);
   }
 }
 
-/** `version + 1` — l'édition incrémente, elle ne réinitialise pas. */
-function sqlIncrement() {
-  return sql`${questionnaires.version} + 1`;
+/**
+ * Définition → ligne. Exporté pour que le script d'amorçage n'en écrive pas une seconde version :
+ * il ajoutait déjà une colonne de moins que celle-ci (il n'incrémentait pas `version`).
+ */
+export function versLigne(def: Omit<QuestionnaireDef, "version">, editePar?: string) {
+  return {
+    slug: def.slug,
+    sourceNom: def.source.nom,
+    banniere: def.banniere as unknown as Record<string, unknown>,
+    questions: def.questions as unknown as unknown[],
+    recommandations: def.recommandations as unknown as unknown[],
+    etiquettesRequises: {
+      thematiques: [...def.etiquettesRequises.thematiques],
+      sites: [...def.etiquettesRequises.sites],
+      interventions: [...def.etiquettesRequises.interventions],
+    },
+    editePar: editePar ?? null,
+  };
 }
 
 function versDefinition(l: Ligne): QuestionnaireDef {

--- a/api/src/questionnaires/questionnaires.service.ts
+++ b/api/src/questionnaires/questionnaires.service.ts
@@ -6,8 +6,14 @@ import { ProjetResponse } from "@projets/dto/projet.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { AideClassification } from "@/aides/dto/aides.dto";
 import { QuestionnairesRepository } from "./questionnaires.repository";
-import { SEUIL_CONFIANCE, type EtiquettesRequises } from "./content/classification";
-import { calculerStatut, reconcilierReponses, type QuestionnaireDef } from "./questionnaire-contract";
+import {
+  AXES,
+  calculerStatut,
+  reconcilierReponses,
+  SEUIL_CONFIANCE,
+  type EtiquettesRequises,
+  type QuestionnaireDef,
+} from "./questionnaire-contract";
 import { ProjetQuestionnairesResponse, QuestionnaireResponse } from "./dto/questionnaire.dto";
 
 /** Questionnaire éligible + réponses réconciliées : la vue interne, partagée avec les sources de recommandations. */
@@ -39,9 +45,7 @@ export function etiquettesManquantes(
   const porte = (axe: keyof EtiquettesRequises, label: string) =>
     scoresProjet[axe].some((e) => e.label === label && e.score >= SEUIL_CONFIANCE);
 
-  return (["thematiques", "sites", "interventions"] as const).flatMap((axe) =>
-    requises[axe].filter((label) => !porte(axe, label)).map((label) => ({ axe, label })),
-  );
+  return AXES.flatMap((axe) => requises[axe].filter((label) => !porte(axe, label)).map((label) => ({ axe, label })));
 }
 
 @Injectable()

--- a/api/src/questionnaires/questionnaires.service.ts
+++ b/api/src/questionnaires/questionnaires.service.ts
@@ -5,7 +5,7 @@ import { projetQuestionnaireReponses } from "@database/schema";
 import { ProjetResponse } from "@projets/dto/projet.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { AideClassification } from "@/aides/dto/aides.dto";
-import { QUESTIONNAIRES } from "./content";
+import { QuestionnairesRepository } from "./questionnaires.repository";
 import { SEUIL_CONFIANCE, type EtiquettesRequises } from "./content/classification";
 import { calculerStatut, reconcilierReponses, type QuestionnaireDef } from "./questionnaire-contract";
 import { ProjetQuestionnairesResponse, QuestionnaireResponse } from "./dto/questionnaire.dto";
@@ -49,6 +49,7 @@ export class QuestionnairesService {
   constructor(
     private readonly dbService: DatabaseService,
     private readonly getProjetsService: GetProjetsService,
+    private readonly repository: QuestionnairesRepository,
   ) {}
 
   /**
@@ -62,7 +63,7 @@ export class QuestionnairesService {
   async etatsPourProjet(projetId: string): Promise<{ projet: ProjetResponse; etats: QuestionnaireEtat[] }> {
     const { projet } = await this.getProjetsService.findOneWithSource(projetId);
 
-    const eligibles = this.questionnairesEligibles(projet);
+    const eligibles = await this.questionnairesEligibles(projet);
     if (eligibles.length === 0) return { projet, etats: [] };
 
     const lignes = await this.dbService.database
@@ -84,11 +85,12 @@ export class QuestionnairesService {
    * aides, on ne renvoie pas 202 — la spec impose une liste vide en 200, et un questionnaire
    * n'est pas un contenu qu'on fait attendre.
    */
-  private questionnairesEligibles(projet: ProjetResponse): QuestionnaireDef[] {
+  private async questionnairesEligibles(projet: ProjetResponse): Promise<QuestionnaireDef[]> {
     const scoresProjet = projet.classificationScores;
     if (!scoresProjet) return [];
 
-    return QUESTIONNAIRES.filter((def) => etiquettesManquantes(scoresProjet, def.etiquettesRequises).length === 0);
+    const tous = await this.repository.tous();
+    return tous.filter((def) => etiquettesManquantes(scoresProjet, def.etiquettesRequises).length === 0);
   }
 
   async findForProjet(projetId: string): Promise<ProjetQuestionnairesResponse> {

--- a/api/src/recommandations/dto/recommandation.dto.ts
+++ b/api/src/recommandations/dto/recommandation.dto.ts
@@ -14,6 +14,20 @@ export class FinancementResponse {
 
   @ApiProperty({ format: "uri" })
   url!: string;
+
+  @ApiPropertyOptional({
+    description:
+      "Identifiant Aides-territoires, quand le financement désigne une AIDE PRÉCISE. Permet de " +
+      "proposer « ajouter cette aide au projet » (POST /projets/:id/aides/ajouts) sans que l'agent " +
+      "ait à la retrouver.\n\n" +
+      "ABSENT quand le financement désigne une FAMILLE d'aides (« Fonds vert », « DETR ») : leur " +
+      "`url` est une recherche, pas une fiche, et inventer un id enverrait la collectivité vers la " +
+      "mauvaise aide.\n\n" +
+      "PRÉSENT N'EST PAS GARANTI AJOUTABLE : l'ajout vérifie que l'aide est disponible sur le " +
+      "territoire du projet, et une aide régionale ne l'est pas partout. Un 400 à l'ajout n'est " +
+      "donc pas une anomalie — c'est le territoire.",
+  })
+  aideId?: number;
 }
 
 export class RessourceResponse {

--- a/api/src/services-numeriques/services-numeriques.service.ts
+++ b/api/src/services-numeriques/services-numeriques.service.ts
@@ -5,6 +5,7 @@ import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { AideClassification } from "@/aides/dto/aides.dto";
 import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
 import type { AjoutManuel, ServiceLibre } from "@/ajouts-manuels/ajout-manuel-contract";
+import { fondreAjouts } from "@/ajouts-manuels/fondre-ajouts";
 import { ProjetResponse } from "@projets/dto/projet.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import {
@@ -73,39 +74,38 @@ export class ServicesNumeriquesService {
    * Aucun service → 200 avec une liste vide, jamais 404.
    */
   async findForProjet(projetId: string, baseUrl: string, plateforme: string): Promise<ProjetServicesResponse> {
-    const { projet } = await this.getProjetsService.findOneWithSource(projetId);
-
-    const catalogue = await this.dbService.database.select().from(servicesNumeriques);
-    const ajouts = await this.ajoutsManuels.actifs(projetId, "service_numerique", plateforme);
+    // Trois lectures INDÉPENDANTES sur un chemin chaud (chaque fiche projet) : en série, c'était
+    // trois allers-retours là où une vague suffit.
+    const [{ projet }, catalogue, ajouts] = await Promise.all([
+      this.getProjetsService.findOneWithSource(projetId),
+      this.dbService.database.select().from(servicesNumeriques),
+      this.ajoutsManuels.actifs(projetId, "service_numerique", plateforme),
+    ]);
 
     const pertinents = this.scorer(projet, catalogue)
-      .filter((s) => s.score >= SEUIL_PERTINENCE && !ajouts.has(s.ligne.slug))
-      .sort((a, b) => b.score - a.score || a.ligne.nom.localeCompare(b.ligne.nom));
+      .filter((s) => s.score >= SEUIL_PERTINENCE)
+      .sort((a, b) => b.score - a.score || a.ligne.nom.localeCompare(b.ligne.nom))
+      .map(({ ligne }) => this.toResponse(ligne, baseUrl));
 
-    // Les ajouts manuels EN TÊTE : quelqu'un les a délibérément mis là. Les noyer dans le tri par
-    // score les rendrait indiscernables du résultat du moteur — or c'est précisément la distinction
-    // qu'on veut rendre visible.
-    //
-    // Un service à la fois pertinent ET ajouté à la main n'apparaît QU'UNE fois (filtré ci-dessus),
-    // avec sa marque d'ajout : le dédoublonnage doit se faire ici, pas dans le client.
     const parSlug = new Map(catalogue.map((l) => [l.slug, l]));
-    const manuels: ServiceResponse[] = [];
-
-    for (const [id, { ajout, service }] of ajouts) {
-      // Service HORS catalogue : l'agent l'a décrit lui-même, c'est lui la source.
-      if (service) {
-        manuels.push(this.libreVersResponse(id, service, ajout));
-        continue;
-      }
-      // Service DU catalogue : sa fiche reste la source de vérité. On ne recopie rien.
-      const ligne = parSlug.get(id);
-      if (ligne) manuels.push({ ...this.toResponse(ligne, baseUrl), ajoutManuel: ajout });
-    }
-
-    manuels.sort((a, b) => a.nom.localeCompare(b.nom));
 
     return {
-      services: [...manuels, ...pertinents.map(({ ligne }) => this.toResponse(ligne, baseUrl))],
+      services: fondreAjouts<ServiceResponse>({
+        ajouts,
+        resoudre: (id, ajout) => {
+          // Service HORS catalogue : l'agent l'a décrit lui-même, c'est lui la source.
+          if (ajout.horsCatalogue) {
+            const service = ajouts.get(id)?.service;
+            return service ? this.libreVersResponse(id, service, ajout) : undefined;
+          }
+          // Service DU catalogue : sa fiche reste la source de vérité. On ne recopie rien.
+          const ligne = parSlug.get(id);
+          return ligne ? { ...this.toResponse(ligne, baseUrl), ajoutManuel: ajout } : undefined;
+        },
+        duMoteur: pertinents,
+        idDe: (s) => s.id,
+        nomDe: (s) => s.nom,
+      }),
     };
   }
 

--- a/api/test/admin.e2e-spec.ts
+++ b/api/test/admin.e2e-spec.ts
@@ -20,7 +20,7 @@ const Q_ESPACES = "part-estimee-des-espaces-exterieurs";
 const RECO_HAIES = "questionnaire:atoutbiodiv-salle:haies";
 
 const appeler = async <T>(
-  methode: "GET" | "POST",
+  methode: "GET" | "POST" | "PUT" | "DELETE",
   chemin: string,
   body?: unknown,
   cle = process.env.SERVICE_MANAGEMENT_API_KEY,
@@ -84,6 +84,122 @@ describe("Back-office (e2e)", () => {
       expect(salle.etiquettesRequises.sites).toContain("Salle des fêtes, salle associative, pôle musical");
       expect(salle.recommandations.every((r) => r.condition !== undefined)).toBe(true);
       expect(body.seuils.pertinence).toBeGreaterThan(0);
+    });
+  });
+
+  describe("PUT /admin/questionnaires/:slug — l'édition depuis le back-office", () => {
+    /**
+     * LE FILET DE SÉCURITÉ, DÉPLACÉ. Tant que les questionnaires vivaient dans le dépôt, une
+     * incohérence empêchait l'API de DÉMARRER — le bug ne pouvait pas atteindre la production.
+     * Éditables en base, ce filet n'existe plus qu'ici. Ces tests le verrouillent au bout de la
+     * chaîne réelle : par HTTP, comme le fera l'éditeur.
+     */
+    // `cleanDatabase()` ne tronque PAS `questionnaires` : c'est une donnée de RÉFÉRENCE, amorcée
+    // une fois au démarrage de la suite. Les tests d'édition doivent donc nettoyer DERRIÈRE EUX,
+    // sans quoi leurs questionnaires fuiteraient dans les suites suivantes — ce qui a été
+    // découvert de la pire façon : en cassant le test qui compte les questionnaires proposés.
+    const CREES = ["essai", "vide", "coquille", "casse"];
+    afterEach(async () => {
+      for (const slug of CREES) {
+        await appeler("DELETE", `/admin/questionnaires/${slug}`);
+      }
+    });
+
+    const definition = (over: Record<string, unknown> = {}) => ({
+      sourceNom: "AtoutBiodiv",
+      banniere: { icone: "🌿", titre: "Titre", sousTitre: "Sous-titre" },
+      questions: [
+        {
+          id: "surface",
+          type: "choix-unique",
+          intitule: "Quelle surface ?",
+          options: [
+            { id: "petite", libelle: "Petite", signal: "neutre" },
+            { id: "grande", libelle: "Grande", signal: "favorable" },
+          ],
+        },
+      ],
+      recommandations: [
+        {
+          id: "haies",
+          titre: "Planter des haies",
+          description: "Des haies.",
+          condition: { question: "surface", parmi: ["grande"] },
+          financements: [],
+          ressources: [],
+          engagement: "faible",
+        },
+      ],
+      etiquettesRequises: { thematiques: [], sites: ["Place ou centre-bourg"], interventions: [] },
+      ...over,
+    });
+
+    it("enregistre un questionnaire, qui devient aussitôt proposable", async () => {
+      const { status } = await appeler("PUT", "/admin/questionnaires/essai", definition());
+      expect(status).toBe(200);
+
+      // Un projet qui porte l'étiquette requise le voit — sans redéploiement.
+      const projetId = await creerProjet({
+        thematiques: [],
+        sites: [{ label: "Place ou centre-bourg", score: 0.95 }],
+        interventions: [],
+      });
+
+      const { body } = await appeler<{ questionnaires: { slug: string; retenu: boolean }[] }>(
+        "POST",
+        "/admin/simuler",
+        { projetId },
+      );
+      expect(body.questionnaires.find((q) => q.slug === "essai")!.retenu).toBe(true);
+    });
+
+    it("REFUSE un questionnaire qui n'exige AUCUNE étiquette", async () => {
+      // Le plus dangereux, et le plus contre-intuitif : une conjonction VIDE est VRAIE. Il serait
+      // proposé à TOUS les projets de France. Le chargeur refusait de démarrer ; ici c'est un 400.
+      const { status, body } = await appeler<{ message: string }>("PUT", "/admin/questionnaires/vide", {
+        ...definition(),
+        etiquettesRequises: { thematiques: [], sites: [], interventions: [] },
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toMatch(/TOUS les projets/);
+    });
+
+    it("REFUSE une étiquette hors de la taxonomie fermée, et la nomme", async () => {
+      // Une coquille, et le questionnaire n'est JAMAIS proposé, sans le moindre message. La
+      // personne qui édite n'a pas accès au code : le message d'erreur est tout ce qu'elle a.
+      const { status, body } = await appeler<{ message: string }>("PUT", "/admin/questionnaires/coquille", {
+        ...definition(),
+        etiquettesRequises: { thematiques: [], sites: ["Place ou centre bourg"], interventions: [] },
+      });
+
+      expect(status).toBe(400);
+      expect(body.message).toMatch(/Place ou centre bourg/);
+    });
+
+    it("REFUSE une condition qui pointe une question inexistante", async () => {
+      // Autrement INDÉTECTABLE : la recommandation ne s'afficherait simplement jamais.
+      const def = definition();
+      def.recommandations[0].condition = { question: "inconnue", parmi: ["grande"] };
+
+      const { status, body } = await appeler<{ message: string }>("PUT", "/admin/questionnaires/casse", def);
+
+      expect(status).toBe(400);
+      expect(body.message).toMatch(/n'existe pas/);
+    });
+
+    it("incrémente la version à chaque édition, sans effacer les réponses des collectivités", async () => {
+      await appeler("PUT", "/admin/questionnaires/essai", definition());
+      const { body: apres } = await appeler<{ version: number }>("PUT", "/admin/questionnaires/essai", definition());
+
+      // La version n'est pas pilotée par le client : elle s'incrémente côté base. Elle n'invalide
+      // rien — `reconcilierReponses` ignore à la lecture ce qui est devenu sans objet.
+      expect(apres.version).toBeGreaterThan(1);
+    });
+
+    it("exige la clé d'ADMINISTRATION", async () => {
+      const { status } = await appeler("PUT", "/admin/questionnaires/essai", definition(), process.env.MEC_API_KEY);
+      expect(status).toBe(401);
     });
   });
 

--- a/api/test/helpers/e2e-global-setup.ts
+++ b/api/test/helpers/e2e-global-setup.ts
@@ -37,6 +37,20 @@ export default async function globalSetup() {
     },
   });
 
+  // Les questionnaires vivent désormais en BASE, éditables depuis le back-office. Ils sont amorcés
+  // ici depuis content/, comme ils le seront en production (`pnpm seed:questionnaires`).
+  //
+  // `cleanDatabase()` ne les tronque PAS : c'est une donnée de RÉFÉRENCE, au même titre que le
+  // catalogue. Les vider entre chaque test rendrait le questionnaire absent, et chaque suite
+  // devrait le réamorcer — un rite dont on finirait par oublier la raison.
+  execSync("npm run seed:questionnaires", {
+    env: {
+      ...process.env,
+      DATABASE_URL,
+    },
+    stdio: "ignore",
+  });
+
   // 2. Setup NestJS App
   const moduleFixture: TestingModule = await Test.createTestingModule({
     imports: [AppModule],

--- a/back-office/src/App.tsx
+++ b/back-office/src/App.tsx
@@ -13,7 +13,12 @@ import { Services } from "./components/Services";
 import { compterEtiquettes, type Contenu, type Simulation, type Taxonomies } from "./types";
 
 /**
- * Back-office — LECTURE et SIMULATION uniquement. Il n'écrit rien.
+ * Back-office : simuler ce que verra une collectivité, et ÉDITER les questionnaires.
+ *
+ * La simulation n'écrit rien — les réponses qu'on y saisit ne sont jamais enregistrées. L'édition,
+ * elle, écrit : elle passe par l'API, qui valide tout (étiquettes dans la taxonomie fermée,
+ * conditions résolubles, ids uniques) et refuse en 400 explicite. Aucune règle n'est rejouée ici :
+ * la dupliquer donnerait deux vérités à tenir en phase, et celle du client serait contournable.
  *
  * On simule sur un projet RÉEL, désigné par son id : un projet fabriqué à la main dirait ce
  * qu'on veut entendre. C'est exactement ce piège qui a produit un faux diagnostic sur le seuil
@@ -99,7 +104,7 @@ export default function App() {
         }
         homeLinkProps={{ href: "/", title: "Accueil - Les Communs" }}
         serviceTitle="Les Communs de la transition écologique"
-        serviceTagline="Back-office — lecture et simulation"
+        serviceTagline="Back-office — simulation et édition"
         quickAccessItems={[
           {
             buttonProps: {

--- a/back-office/src/App.tsx
+++ b/back-office/src/App.tsx
@@ -4,12 +4,13 @@ import { Header } from "@codegouvfr/react-dsfr/Header";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { Tabs } from "@codegouvfr/react-dsfr/Tabs";
-import { CleRefusee, getContenu, lireCle, oublierCle, simuler } from "./api";
+import { CleRefusee, getContenu, getTaxonomies, lireCle, oublierCle, simuler } from "./api";
 import { PorteCle } from "./components/PorteCle";
 import { Catalogue } from "./components/Catalogue";
-import { Questionnaires } from "./components/Questionnaires";
+import { QuestionnairesSimules } from "./components/QuestionnairesSimules";
+import { CatalogueQuestionnaires } from "./components/CatalogueQuestionnaires";
 import { Services } from "./components/Services";
-import { compterEtiquettes, type Contenu, type Simulation } from "./types";
+import { compterEtiquettes, type Contenu, type Simulation, type Taxonomies } from "./types";
 
 /**
  * Back-office — LECTURE et SIMULATION uniquement. Il n'écrit rien.
@@ -23,6 +24,7 @@ export default function App() {
   const [refusee, setRefusee] = useState(false);
 
   const [contenu, setContenu] = useState<Contenu | null>(null);
+  const [taxonomies, setTaxonomies] = useState<Taxonomies | null>(null);
   const [projetId, setProjetId] = useState("");
   const [simulation, setSimulation] = useState<Simulation | null>(null);
   const [chargement, setChargement] = useState(false);
@@ -38,10 +40,18 @@ export default function App() {
     setErreur(e instanceof Error ? e.message : "Erreur inattendue.");
   }, []);
 
+  const recharger = useCallback(() => {
+    getContenu().then(setContenu).catch(gererErreur);
+  }, [gererErreur]);
+
   useEffect(() => {
     if (!authentifie) return;
-    getContenu().then(setContenu).catch(gererErreur);
-  }, [authentifie, gererErreur]);
+    recharger();
+    // Les taxonomies fermées ne changent pas : un seul chargement suffit. Elles ne sont JAMAIS
+    // recopiées dans ce dépôt — une copie dérive, et on réintroduirait la coquille que la
+    // validation de l'API vient d'éliminer, du côté où personne ne la verrait.
+    getTaxonomies().then(setTaxonomies).catch(gererErreur);
+  }, [authentifie, gererErreur, recharger]);
 
   const lancer = (e: React.FormEvent) => {
     e.preventDefault();
@@ -148,7 +158,7 @@ export default function App() {
                         </div>
                       )}
 
-                      <Questionnaires questionnaires={simulation.questionnaires} />
+                      <QuestionnairesSimules questionnaires={simulation.questionnaires} />
                       <Services services={simulation.services} seuilApi={simulation.seuils.pertinence} />
                     </>
                   )}
@@ -156,7 +166,20 @@ export default function App() {
               ),
             },
             {
-              label: "Catalogue",
+              label: "Questionnaires",
+              content:
+                contenu && taxonomies ? (
+                  <CatalogueQuestionnaires
+                    questionnaires={contenu.questionnaires}
+                    taxonomies={taxonomies}
+                    onChangement={recharger}
+                  />
+                ) : (
+                  <p>Chargement…</p>
+                ),
+            },
+            {
+              label: "Services",
               content: contenu ? <Catalogue contenu={contenu} /> : <p>Chargement…</p>,
             },
           ]}

--- a/back-office/src/api.ts
+++ b/back-office/src/api.ts
@@ -1,4 +1,4 @@
-import type { Contenu, Simulation } from "./types";
+import type { Contenu, QuestionnaireEdition, Simulation, Taxonomies } from "./types";
 
 /**
  * La clé d'administration vit en sessionStorage, jamais en localStorage : elle disparaît à la
@@ -18,14 +18,14 @@ export class CleRefusee extends Error {
   }
 }
 
-async function appeler<T>(chemin: string, corps?: unknown): Promise<T> {
+async function appeler<T>(chemin: string, corps?: unknown, methode?: "GET" | "POST" | "PUT" | "DELETE"): Promise<T> {
   const cle = lireCle();
   if (!cle) throw new CleRefusee();
 
   // `/api` est réécrit par le proxy Vite (voir vite.config.ts) : pas de requête cross-origin,
   // donc rien à ouvrir côté API.
   const reponse = await fetch(`/api${chemin}`, {
-    method: corps === undefined ? "GET" : "POST",
+    method: methode ?? (corps === undefined ? "GET" : "POST"),
     headers: { Authorization: `Bearer ${cle}`, "Content-Type": "application/json" },
     ...(corps === undefined ? {} : { body: JSON.stringify(corps) }),
   });
@@ -35,9 +35,14 @@ async function appeler<T>(chemin: string, corps?: unknown): Promise<T> {
     throw new CleRefusee();
   }
   if (!reponse.ok) {
-    const detail = (await reponse.json().catch(() => null)) as { message?: string } | null;
-    throw new Error(detail?.message ?? `L'API a répondu ${reponse.status}.`);
+    // Le message de l'API est TOUT ce qu'a la personne qui édite : elle n'a pas accès au code.
+    // « lieu « Place ou centre bourg » hors de la taxonomie » se corrige ; « erreur 400 » non.
+    const detail = (await reponse.json().catch(() => null)) as { message?: string | string[] } | null;
+    const message = Array.isArray(detail?.message) ? detail.message.join(" ") : detail?.message;
+    throw new Error(message ?? `L'API a répondu ${reponse.status}.`);
   }
+  // 204 (suppression) n'a pas de corps.
+  if (reponse.status === 204) return undefined as T;
   return (await reponse.json()) as T;
 }
 
@@ -45,3 +50,11 @@ export const getContenu = (): Promise<Contenu> => appeler<Contenu>("/admin/conte
 
 export const simuler = (projetId: string, reponses?: Record<string, Record<string, string>>): Promise<Simulation> =>
   appeler<Simulation>("/admin/simuler", { projetId, ...(reponses ? { reponses } : {}) });
+
+export const getTaxonomies = (): Promise<Taxonomies> => appeler<Taxonomies>("/admin/taxonomies");
+
+export const enregistrerQuestionnaire = (slug: string, def: QuestionnaireEdition): Promise<unknown> =>
+  appeler("/admin/questionnaires/" + encodeURIComponent(slug), def, "PUT");
+
+export const supprimerQuestionnaire = (slug: string): Promise<void> =>
+  appeler<void>("/admin/questionnaires/" + encodeURIComponent(slug), undefined, "DELETE");

--- a/back-office/src/components/CatalogueQuestionnaires.tsx
+++ b/back-office/src/components/CatalogueQuestionnaires.tsx
@@ -1,0 +1,123 @@
+import { useState } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Badge } from "@codegouvfr/react-dsfr/Badge";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { Editeur } from "./Editeur";
+import { supprimerQuestionnaire } from "../api";
+import type { Axe, QuestionnaireContenu, Taxonomies } from "../types";
+
+const AXES: Axe[] = ["thematiques", "sites", "interventions"];
+const LIBELLE_AXE: Record<Axe, string> = {
+  thematiques: "thématique",
+  sites: "lieu",
+  interventions: "modalité",
+};
+
+/**
+ * Le catalogue des questionnaires, et leur édition.
+ *
+ * Ils vivaient dans le dépôt : les éditer demandait une PR et un déploiement. Ils sont désormais en
+ * base, et cet écran est la porte. L'API valide TOUT à l'écriture (les mêmes règles qui, avant,
+ * empêchaient l'API de démarrer) : ce que cet écran affiche est donc ce qui sera réellement appliqué.
+ */
+export function CatalogueQuestionnaires({
+  questionnaires,
+  taxonomies,
+  onChangement,
+}: {
+  questionnaires: QuestionnaireContenu[];
+  taxonomies: Taxonomies;
+  onChangement: () => void;
+}) {
+  const [edite, setEdite] = useState<QuestionnaireContenu | { slug: string } | null>(null);
+  const [nouveauSlug, setNouveauSlug] = useState("");
+
+  if (edite) {
+    return (
+      <Editeur
+        questionnaire={edite}
+        taxonomies={taxonomies}
+        onEnregistre={() => {
+          setEdite(null);
+          onChangement();
+        }}
+        onAnnule={() => setEdite(null)}
+      />
+    );
+  }
+
+  const supprimer = async (slug: string) => {
+    // Les réponses des collectivités ne sont PAS effacées : elles cessent d'être lues. Si le
+    // questionnaire est recréé sous le même slug, elles reviennent. Le dire, plutôt que de laisser
+    // croire à une destruction.
+    if (
+      !confirm(`Supprimer « ${slug} » ?\n\nLes réponses déjà données ne sont pas effacées : elles cessent d'être lues.`)
+    )
+      return;
+    await supprimerQuestionnaire(slug);
+    onChangement();
+  };
+
+  return (
+    <section className={fr.cx("fr-mt-4w")}>
+      {questionnaires.map((q) => (
+        <div key={q.slug} className={fr.cx("fr-card", "fr-card--no-arrow", "fr-mb-2w")}>
+          <div className={fr.cx("fr-card__body")}>
+            <div className={fr.cx("fr-card__content", "fr-py-2w")}>
+              <h3 className={fr.cx("fr-card__title", "fr-h6", "fr-mb-1w")}>
+                {q.slug} <span className={fr.cx("fr-text--sm")}>— version {q.version}</span>
+              </h3>
+
+              <p className={fr.cx("fr-text--sm", "fr-mb-1w")}>
+                Proposé si le projet porte <strong>toutes</strong> ces étiquettes :{" "}
+                {AXES.flatMap((axe) =>
+                  q.etiquettesRequises[axe].map((label) => (
+                    <span key={`${axe}-${label}`} title={LIBELLE_AXE[axe]}>
+                      <Badge severity="success" noIcon small>
+                        {label}
+                      </Badge>{" "}
+                    </span>
+                  )),
+                )}
+              </p>
+
+              <p className={fr.cx("fr-text--xs", "fr-mb-2w")}>
+                {q.questions.length} question{q.questions.length > 1 ? "s" : ""} — {q.recommandations.length}{" "}
+                recommandation{q.recommandations.length > 1 ? "s" : ""}
+              </p>
+
+              <div style={{ display: "flex", gap: "0.5rem" }}>
+                <Button size="small" onClick={() => setEdite(q)}>
+                  Éditer
+                </Button>
+                <Button size="small" priority="secondary" onClick={() => void supprimer(q.slug)}>
+                  Supprimer
+                </Button>
+              </div>
+            </div>
+          </div>
+        </div>
+      ))}
+
+      <div className={fr.cx("fr-callout", "fr-mt-4w")}>
+        <h3 className={fr.cx("fr-h6")}>Créer un questionnaire</h3>
+        <Input
+          label="Identifiant (slug)"
+          hintText="En minuscules, sans espace. Il ne change plus ensuite : les réponses des collectivités y sont attachées."
+          nativeInputProps={{
+            value: nouveauSlug,
+            onChange: (e) => setNouveauSlug(e.target.value),
+            placeholder: "atoutbiodiv-cimetiere",
+          }}
+        />
+        <Button
+          disabled={!nouveauSlug.trim() || questionnaires.some((q) => q.slug === nouveauSlug.trim())}
+          onClick={() => setEdite({ slug: nouveauSlug.trim() })}
+        >
+          Créer
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/back-office/src/components/CatalogueQuestionnaires.tsx
+++ b/back-office/src/components/CatalogueQuestionnaires.tsx
@@ -5,14 +5,7 @@ import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { Editeur } from "./Editeur";
 import { supprimerQuestionnaire } from "../api";
-import type { Axe, QuestionnaireContenu, Taxonomies } from "../types";
-
-const AXES: Axe[] = ["thematiques", "sites", "interventions"];
-const LIBELLE_AXE: Record<Axe, string> = {
-  thematiques: "thématique",
-  sites: "lieu",
-  interventions: "modalité",
-};
+import { AXES, LIBELLE_AXE, type QuestionnaireContenu, type Taxonomies } from "../types";
 
 /**
  * Le catalogue des questionnaires, et leur édition.
@@ -73,7 +66,7 @@ export function CatalogueQuestionnaires({
                 Proposé si le projet porte <strong>toutes</strong> ces étiquettes :{" "}
                 {AXES.flatMap((axe) =>
                   q.etiquettesRequises[axe].map((label) => (
-                    <span key={`${axe}-${label}`} title={LIBELLE_AXE[axe]}>
+                    <span key={`${axe}-${label}`} title={LIBELLE_AXE[axe].singulier}>
                       <Badge severity="success" noIcon small>
                         {label}
                       </Badge>{" "}

--- a/back-office/src/components/ChoixEtiquettes.tsx
+++ b/back-office/src/components/ChoixEtiquettes.tsx
@@ -2,13 +2,7 @@ import { useMemo, useState } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import type { Axe } from "../types";
-
-const LIBELLE: Record<Axe, string> = {
-  thematiques: "Thématiques",
-  sites: "Lieux",
-  interventions: "Modalités",
-};
+import { LIBELLE_AXE, type Axe } from "../types";
 
 /**
  * Choix d'étiquettes DANS LA TAXONOMIE FERMÉE, servie par l'API.
@@ -47,7 +41,8 @@ export function ChoixEtiquettes({
   return (
     <div className={fr.cx("fr-mb-3w")}>
       <p className={fr.cx("fr-text--sm", "fr-mb-1w")}>
-        <strong>{LIBELLE[axe]}</strong> <span className={fr.cx("fr-text--xs")}>({disponibles.length} disponibles)</span>
+        <strong>{LIBELLE_AXE[axe].pluriel}</strong>{" "}
+        <span className={fr.cx("fr-text--xs")}>({disponibles.length} disponibles)</span>
       </p>
 
       <div style={{ display: "flex", flexWrap: "wrap", gap: "0.25rem", marginBottom: "0.5rem" }}>
@@ -72,7 +67,7 @@ export function ChoixEtiquettes({
         nativeInputProps={{
           value: recherche,
           onChange: (e) => setRecherche(e.target.value),
-          placeholder: `Chercher une ${LIBELLE[axe].toLowerCase().replace(/s$/, "")}…`,
+          placeholder: `Chercher une ${LIBELLE_AXE[axe].singulier}…`,
         }}
       />
 

--- a/back-office/src/components/ChoixEtiquettes.tsx
+++ b/back-office/src/components/ChoixEtiquettes.tsx
@@ -1,0 +1,97 @@
+import { useMemo, useState } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Badge } from "@codegouvfr/react-dsfr/Badge";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import type { Axe } from "../types";
+
+const LIBELLE: Record<Axe, string> = {
+  thematiques: "Thématiques",
+  sites: "Lieux",
+  interventions: "Modalités",
+};
+
+/**
+ * Choix d'étiquettes DANS LA TAXONOMIE FERMÉE, servie par l'API.
+ *
+ * On ne saisit pas de texte libre, et c'est tout l'intérêt : une étiquette mal orthographiée ferait
+ * que le questionnaire n'est JAMAIS proposé, sans le moindre message. L'API le refuse (400) — mais
+ * ici on rend la faute IMPOSSIBLE, ce qui vaut mieux que de la rattraper.
+ *
+ * La liste vient de `GET /admin/taxonomies`. Elle n'est jamais recopiée dans ce dépôt : une copie
+ * dérive, et on réintroduirait la coquille du côté où personne ne la verrait.
+ */
+export function ChoixEtiquettes({
+  axe,
+  disponibles,
+  choisies,
+  onChange,
+}: {
+  axe: Axe;
+  disponibles: string[];
+  choisies: string[];
+  onChange: (etiquettes: string[]) => void;
+}) {
+  const [recherche, setRecherche] = useState("");
+
+  const suggestions = useMemo(() => {
+    const q = recherche.trim().toLowerCase();
+    if (q.length < 2) return [];
+    return disponibles.filter((label) => !choisies.includes(label) && label.toLowerCase().includes(q)).slice(0, 8);
+  }, [recherche, disponibles, choisies]);
+
+  const ajouter = (label: string) => {
+    onChange([...choisies, label]);
+    setRecherche("");
+  };
+
+  return (
+    <div className={fr.cx("fr-mb-3w")}>
+      <p className={fr.cx("fr-text--sm", "fr-mb-1w")}>
+        <strong>{LIBELLE[axe]}</strong> <span className={fr.cx("fr-text--xs")}>({disponibles.length} disponibles)</span>
+      </p>
+
+      <div style={{ display: "flex", flexWrap: "wrap", gap: "0.25rem", marginBottom: "0.5rem" }}>
+        {choisies.length === 0 && <span className={fr.cx("fr-text--xs")}>aucune</span>}
+        {choisies.map((label) => (
+          <button
+            key={label}
+            type="button"
+            title="Retirer"
+            onClick={() => onChange(choisies.filter((l) => l !== label))}
+            style={{ border: "none", background: "none", padding: 0, cursor: "pointer" }}
+          >
+            <Badge severity="success" noIcon small>
+              {label} ✕
+            </Badge>
+          </button>
+        ))}
+      </div>
+
+      <Input
+        label=""
+        nativeInputProps={{
+          value: recherche,
+          onChange: (e) => setRecherche(e.target.value),
+          placeholder: `Chercher une ${LIBELLE[axe].toLowerCase().replace(/s$/, "")}…`,
+        }}
+      />
+
+      {suggestions.length > 0 && (
+        <ul style={{ listStyle: "none", padding: 0, margin: 0 }}>
+          {suggestions.map((label) => (
+            <li key={label}>
+              <button
+                type="button"
+                className={fr.cx("fr-btn", "fr-btn--tertiary-no-outline", "fr-btn--sm")}
+                onClick={() => ajouter(label)}
+                style={{ width: "100%", justifyContent: "flex-start", textAlign: "left" }}
+              >
+                + {label}
+              </button>
+            </li>
+          ))}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/back-office/src/components/Editeur.tsx
+++ b/back-office/src/components/Editeur.tsx
@@ -1,0 +1,161 @@
+import { useState } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Alert } from "@codegouvfr/react-dsfr/Alert";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { ChoixEtiquettes } from "./ChoixEtiquettes";
+import { enregistrerQuestionnaire } from "../api";
+import type { Axe, QuestionnaireContenu, QuestionnaireEdition, Taxonomies } from "../types";
+
+const AXES: Axe[] = ["thematiques", "sites", "interventions"];
+
+const VIDE = { thematiques: [], sites: [], interventions: [] };
+
+/**
+ * Édition d'un questionnaire.
+ *
+ * DEUX PARTIES, DEUX TRAITEMENTS, et ce n'est pas un compromis paresseux :
+ *
+ * - Les ÉTIQUETTES sont éditées par sélecteur sur la taxonomie fermée. C'est là que la saisie libre
+ *   est le plus dangereuse : une coquille et le questionnaire n'est JAMAIS proposé, sans le moindre
+ *   message. Le sélecteur rend la faute impossible.
+ *
+ * - Le CONTENU (bandeau, questions, recommandations) est édité en JSON. Un formulaire structuré
+ *   serait plus agréable, mais il doit modéliser les conditions, les signaux, les financements et
+ *   les ressources : c'est un chantier à part entière, et un mauvais formulaire est pire qu'un JSON
+ *   honnête. L'API valide tout de toute façon, et ses messages s'affichent ici tels quels.
+ *
+ * LA VALIDATION N'EST PAS FAITE ICI. Elle vit dans l'API (questionnaire-validation.ts), qui est le
+ * seul endroit où l'on ne peut pas passer à côté. La rejouer dans cet écran donnerait deux règles à
+ * tenir en phase — et celle du client serait contournable.
+ */
+export function Editeur({
+  questionnaire,
+  taxonomies,
+  onEnregistre,
+  onAnnule,
+}: {
+  questionnaire: QuestionnaireContenu | { slug: string };
+  taxonomies: Taxonomies;
+  onEnregistre: () => void;
+  onAnnule: () => void;
+}) {
+  const existant = "questions" in questionnaire ? questionnaire : null;
+
+  const [sourceNom, setSourceNom] = useState(existant?.libelle ?? "AtoutBiodiv");
+  const [etiquettes, setEtiquettes] = useState<Taxonomies>(existant?.etiquettesRequises ?? VIDE);
+  const [contenu, setContenu] = useState(() =>
+    JSON.stringify(
+      {
+        banniere: existant?.banniere ?? { icone: "🌿", titre: "", sousTitre: "" },
+        questions: existant?.questions ?? [],
+        recommandations: existant?.recommandations ?? [],
+      },
+      null,
+      2,
+    ),
+  );
+
+  const [erreur, setErreur] = useState<string | null>(null);
+  const [enregistrement, setEnregistrement] = useState(false);
+
+  const total = AXES.reduce((n, axe) => n + etiquettes[axe].length, 0);
+
+  const enregistrer = async () => {
+    setErreur(null);
+
+    // Le JSON mal formé est la SEULE chose qu'on vérifie ici : sans lui, on n'aurait rien à envoyer.
+    // Tout le reste — étiquettes, conditions, ids — est jugé par l'API.
+    let parse: Omit<QuestionnaireEdition, "sourceNom" | "etiquettesRequises">;
+    try {
+      parse = JSON.parse(contenu) as typeof parse;
+    } catch (e) {
+      setErreur(`JSON invalide : ${e instanceof Error ? e.message : "erreur de syntaxe"}`);
+      return;
+    }
+
+    setEnregistrement(true);
+    try {
+      await enregistrerQuestionnaire(questionnaire.slug, {
+        sourceNom,
+        banniere: parse.banniere,
+        questions: parse.questions,
+        recommandations: parse.recommandations,
+        etiquettesRequises: etiquettes,
+      });
+      onEnregistre();
+    } catch (e) {
+      setErreur(e instanceof Error ? e.message : "Erreur inattendue.");
+    } finally {
+      setEnregistrement(false);
+    }
+  };
+
+  return (
+    <section className={fr.cx("fr-mt-3w")}>
+      <h2 className={fr.cx("fr-h5")}>
+        {existant ? "Éditer" : "Créer"} <code>{questionnaire.slug}</code>
+        {existant && <span className={fr.cx("fr-text--sm")}> — version {existant.version}</span>}
+      </h2>
+
+      {erreur && (
+        <Alert
+          severity="error"
+          title="L'API a refusé l'enregistrement"
+          description={erreur}
+          className={fr.cx("fr-mb-3w")}
+        />
+      )}
+
+      <Input
+        label="Partenaire fournissant le contenu"
+        nativeInputProps={{ value: sourceNom, onChange: (e) => setSourceNom(e.target.value) }}
+      />
+
+      <div className={fr.cx("fr-callout", "fr-my-3w")}>
+        <h3 className={fr.cx("fr-h6")}>Quand ce questionnaire est-il proposé ?</h3>
+        <p className={fr.cx("fr-text--sm")}>
+          Le projet doit porter <strong>toutes</strong> les étiquettes ci-dessous, avec une confiance ≥ 0,80.
+          {total === 0 && (
+            <>
+              {" "}
+              <strong>Aucune étiquette : l&apos;API refusera.</strong> Un questionnaire qui n&apos;exige rien serait
+              proposé à <strong>tous</strong> les projets — une conjonction vide est vraie.
+            </>
+          )}
+        </p>
+
+        {AXES.map((axe) => (
+          <ChoixEtiquettes
+            key={axe}
+            axe={axe}
+            disponibles={taxonomies[axe]}
+            choisies={etiquettes[axe]}
+            onChange={(labels) => setEtiquettes({ ...etiquettes, [axe]: labels })}
+          />
+        ))}
+      </div>
+
+      <Input
+        label="Contenu : bandeau, questions, recommandations"
+        hintText="JSON. L'API valide les conditions, les identifiants et les options — ses messages s'affichent ci-dessus."
+        textArea
+        nativeTextAreaProps={{
+          value: contenu,
+          onChange: (e) => setContenu(e.target.value),
+          rows: 22,
+          style: { fontFamily: "monospace", fontSize: "0.8rem" },
+        }}
+      />
+
+      <div style={{ display: "flex", gap: "0.5rem" }}>
+        <Button onClick={() => void enregistrer()} disabled={enregistrement}>
+          {enregistrement ? "Enregistrement…" : "Enregistrer"}
+        </Button>
+        <Button priority="secondary" onClick={onAnnule}>
+          Annuler
+        </Button>
+      </div>
+    </section>
+  );
+}

--- a/back-office/src/components/Editeur.tsx
+++ b/back-office/src/components/Editeur.tsx
@@ -5,9 +5,7 @@ import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
 import { ChoixEtiquettes } from "./ChoixEtiquettes";
 import { enregistrerQuestionnaire } from "../api";
-import type { Axe, QuestionnaireContenu, QuestionnaireEdition, Taxonomies } from "../types";
-
-const AXES: Axe[] = ["thematiques", "sites", "interventions"];
+import { AXES, type QuestionnaireContenu, type QuestionnaireEdition, type Taxonomies } from "../types";
 
 const VIDE = { thematiques: [], sites: [], interventions: [] };
 
@@ -56,6 +54,10 @@ export function Editeur({
     ),
   );
 
+  // `editePar` traversait toute la pile jusqu'à la colonne, et n'était JAMAIS renseigné : toute
+  // édition écrivait NULL. Un champ de traçabilité qui ne trace rien vaut moins que pas de champ.
+  const [editePar, setEditePar] = useState("");
+
   const [erreur, setErreur] = useState<string | null>(null);
   const [enregistrement, setEnregistrement] = useState(false);
 
@@ -82,6 +84,7 @@ export function Editeur({
         questions: parse.questions,
         recommandations: parse.recommandations,
         etiquettesRequises: etiquettes,
+        editePar: editePar.trim() || undefined,
       });
       onEnregistre();
     } catch (e) {
@@ -110,6 +113,12 @@ export function Editeur({
       <Input
         label="Partenaire fournissant le contenu"
         nativeInputProps={{ value: sourceNom, onChange: (e) => setSourceNom(e.target.value) }}
+      />
+
+      <Input
+        label="Votre nom"
+        hintText="Enregistré avec l'édition. La clé d'API ne dit pas qui vous êtes."
+        nativeInputProps={{ value: editePar, onChange: (e) => setEditePar(e.target.value) }}
       />
 
       <div className={fr.cx("fr-callout", "fr-my-3w")}>

--- a/back-office/src/components/PorteCle.tsx
+++ b/back-office/src/components/PorteCle.tsx
@@ -25,8 +25,8 @@ export function PorteCle({ onCle, refusee }: { onCle: () => void; refusee: boole
     <form onSubmit={valider} className={fr.cx("fr-container", "fr-py-8w")} style={{ maxWidth: "36rem" }}>
       <h1 className={fr.cx("fr-h3")}>Back-office</h1>
       <p className={fr.cx("fr-text--sm", "fr-mb-3w")}>
-        Outil interne de lecture et de simulation. Il n&apos;écrit rien : les réponses qu&apos;on y saisit ne sont
-        jamais enregistrées.
+        Outil interne : simuler ce que verra une collectivité, et éditer les questionnaires. Les réponses saisies en
+        simulation ne sont jamais enregistrées.
       </p>
 
       {refusee && (

--- a/back-office/src/components/QuestionnairesSimules.tsx
+++ b/back-office/src/components/QuestionnairesSimules.tsx
@@ -1,12 +1,6 @@
 import { fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
-import type { QuestionnaireSimule } from "../types";
-
-const LIBELLE_AXE: Record<string, string> = {
-  thematiques: "thématique",
-  sites: "lieu",
-  interventions: "modalité",
-};
+import { LIBELLE_AXE, type QuestionnaireSimule } from "../types";
 
 /**
  * Les questionnaires confrontés au projet, TOUS rendus — proposés comme non proposés.
@@ -45,7 +39,8 @@ export function QuestionnairesSimules({ questionnaires }: { questionnaires: Ques
                     {q.etiquettesManquantes.map((e, i) => (
                       <span key={`${e.axe}-${e.label}`}>
                         {i > 0 && ", "}
-                        <strong>{e.label}</strong> <span className={fr.cx("fr-text--xs")}>({LIBELLE_AXE[e.axe]})</span>
+                        <strong>{e.label}</strong>{" "}
+                        <span className={fr.cx("fr-text--xs")}>({LIBELLE_AXE[e.axe].singulier})</span>
                       </span>
                     ))}
                   </p>

--- a/back-office/src/components/QuestionnairesSimules.tsx
+++ b/back-office/src/components/QuestionnairesSimules.tsx
@@ -16,7 +16,7 @@ const LIBELLE_AXE: Record<string, string> = {
  * Place ou centre-bourg » dit exactement quoi regarder : soit la classification du projet est
  * fausse, soit le questionnaire vise autre chose.
  */
-export function Questionnaires({ questionnaires }: { questionnaires: QuestionnaireSimule[] }) {
+export function QuestionnairesSimules({ questionnaires }: { questionnaires: QuestionnaireSimule[] }) {
   return (
     <section className={fr.cx("fr-mt-6w")}>
       <h2 className={fr.cx("fr-h4")}>Questionnaires</h2>

--- a/back-office/src/types.ts
+++ b/back-office/src/types.ts
@@ -9,6 +9,16 @@
 
 export type Axe = "thematiques" | "sites" | "interventions";
 
+/** Les trois axes, et leurs libellés. Une seule définition : ils étaient recopiés dans quatre
+ *  fichiers, et les deux tables de libellés avaient déjà divergé (singulier contre pluriel). */
+export const AXES: Axe[] = ["thematiques", "sites", "interventions"];
+
+export const LIBELLE_AXE: Record<Axe, { singulier: string; pluriel: string }> = {
+  thematiques: { singulier: "thématique", pluriel: "Thématiques" },
+  sites: { singulier: "lieu", pluriel: "Lieux" },
+  interventions: { singulier: "modalité", pluriel: "Modalités" },
+};
+
 export interface EtiquetteScoree {
   label: string;
   score: number;

--- a/back-office/src/types.ts
+++ b/back-office/src/types.ts
@@ -84,13 +84,42 @@ export interface Simulation {
   seuils: Seuils;
 }
 
+/** Les taxonomies fermées, servies par l'API. Jamais recopiées ici : une copie dérive. */
+export type Taxonomies = Record<Axe, string[]>;
+
+export interface QuestionDef {
+  id: string;
+  type: string;
+  intitule: string;
+  options: { id: string; libelle: string; signal?: string; aide?: string }[];
+}
+
+export interface RecommandationDef {
+  id: string;
+  titre: string;
+  description?: string;
+  condition: true | { question: string; parmi: string[] };
+  [autre: string]: unknown;
+}
+
 export interface QuestionnaireContenu {
   slug: string;
   libelle: string;
   version: number;
-  etiquettesRequises: Record<Axe, string[]>;
-  questions: { id: string; libelle: string; options: { id: string; libelle: string }[] }[];
-  recommandations: { id: string; titre: string; condition: unknown }[];
+  banniere: { icone?: string; titre?: string; sousTitre?: string };
+  etiquettesRequises: Taxonomies;
+  questions: QuestionDef[];
+  recommandations: RecommandationDef[];
+}
+
+/** Le document ENTIER, tel qu'il part en PUT. Pas de PATCH : voir admin.controller.ts. */
+export interface QuestionnaireEdition {
+  sourceNom: string;
+  banniere: QuestionnaireContenu["banniere"];
+  questions: QuestionDef[];
+  recommandations: RecommandationDef[];
+  etiquettesRequises: Taxonomies;
+  editePar?: string;
 }
 
 export interface ServiceContenu {


### PR DESCRIPTION
> Suite de #527 (mergée). Ces 4 commits étaient restés sur la branche après le merge.

Les questionnaires vivaient dans le dépôt : JSON du partenaire + `classification.ts`. Impossible à éditer sans une PR et un déploiement. Ils passent en base, avec un éditeur.

## Ce qu'on perd, et qu'il fallait reconstruire

Le chargeur refusait de **démarrer** si une condition pointait une question inexistante, si une étiquette sortait de la taxonomie fermée, ou si un questionnaire n'exigeait aucune étiquette. Brutal, mais parfait : le bug ne pouvait pas atteindre la production.

Ce filet est **intégralement reconstruit à l'écriture** (`questionnaire-validation.ts`) : les mêmes vérifications, au même niveau d'exigence, rendues en **400 explicite**. Aucune n'a été assouplie — c'était la condition du déplacement.

| Refusé à l'écriture | Pourquoi c'est grave |
|---|---|
| Aucune étiquette requise | **Une conjonction vide est vraie** : proposé à *tous* les projets |
| Étiquette hors taxonomie | Le questionnaire ne serait **jamais** proposé, sans message |
| Condition sur une question absente | La recommandation ne s'afficherait **jamais**. Indétectable autrement |
| Ids de questions/options en double | La réponse de la collectivité serait ambiguë |

Chaque message **nomme le fautif** : la personne qui édite n'a pas accès au code. *« lieu « Place ou centre bourg » hors de la taxonomie »* se corrige ; *« 400 Bad Request »* ne se corrige pas.

## Les réponses des collectivités survivent

`version` s'incrémente, mais n'invalide rien : `reconcilierReponses` ignorait déjà à la lecture ce qui était devenu sans objet, sans réécrire la ligne. **Supprimer une question ne détruit pas les autres réponses.**

## L'éditeur

**Les étiquettes par sélecteur** sur la taxonomie fermée (`GET /admin/taxonomies`). C'est là que la saisie libre est le plus dangereuse : le sélecteur rend la coquille **impossible**, là où la validation ne fait que la rattraper. Les taxonomies sont **servies par l'API**, jamais recopiées — une copie dérive.

**Le contenu en JSON.** Un formulaire structuré devrait modéliser conditions, signaux, financements et ressources : c'est un chantier à part, et un mauvais formulaire est pire qu'un JSON honnête. L'API valide tout, ses messages s'affichent tels quels. **Aucune règle n'est rejouée côté client** — elle serait contournable et donnerait deux vérités à tenir en phase.

## Amorçage, pas source

`pnpm seed:questionnaires` verse `content/` en base — comme le CSV DINUM pour le catalogue de services. **Non destructif par défaut** : il n'écrase pas un questionnaire déjà présent, qui a pu être édité. `--force` pour le forcer.

## Nettoyage après revue (4 agents)

- **Le back-office n'était plus supprimable** — la contrainte de départ, cassée. L'unique chemin d'écriture vivait dans `src/admin`, réputé jetable. Le CRUD rejoint `QuestionnairesModule` ; `src/admin` ne garde que la simulation. **Vérifié en supprimant réellement le module.**
- **La fusion des ajouts manuels était écrite deux fois**, et avait déjà divergé (dédoublonnage après le classement côté aides, avant le scoring côté services). Un `fondreAjouts()` unique porte la politique.
- **`POST /decisions` permettait de contourner les gardes** des ajouts manuels : le type y est refusé, avec un message qui renvoie aux endpoints dédiés.
- **Cache** sur les questionnaires (relus 2× par fiche projet), `Promise.all` sur les lectures indépendantes du chemin chaud.

## `aideId` dans les financements

MEC peut désormais proposer « ajouter cette aide au projet » depuis une recommandation.

**Facultatif, et ce n'est pas une négligence** : sur 44 financements, **un seul** désigne une aide précise. Les autres sont des recherches, des pages de programme, ou des liens LPO/OFB — une *famille* d'aides, pas une aide. En inventer enverrait une collectivité vers la mauvaise.

Et le seul qui en désignait une **pointait vers une aide morte** : slug disparu, aide recréée pour le Fonds vert 2026. Résolu contre l'API réelle → **id 165809, « Renaturer les villes et les villages », France entière** (donc ajoutable partout : bon cas de test). ⚠️ **La correspondance est mon interprétation — à faire valider par AtoutBiodiv.**

## Tests

**540 unitaires, 76 e2e** sur les suites concernées. (Les 4 échecs de `projets`/`ressources` en local sont environnementaux : build `ressources-pages` absent et clé Anthropic factice — la CI a les deux.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)