### PR TITLE
feat(back-office): montrer ce que l'API renvoie réellement, et non une émulation

### DIFF
--- a/api/src/admin/admin-ajouts.controller.ts
+++ b/api/src/admin/admin-ajouts.controller.ts
@@ -1,0 +1,70 @@
+import { Body, Controller, Delete, HttpCode, Param, ParseUUIDPipe, Post, Query, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
+import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
+import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
+import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
+import { AjoutCreeResponse } from "@/ajouts-manuels/dto/ajout-manuel.dto";
+import { AjoutAideAdminRequest, AjoutServiceAdminRequest } from "./dto/admin-ajouts.dto";
+
+/**
+ * Ajouter ou retirer un ajout manuel DEPUIS LE BACK-OFFICE, au nom d'une plateforme.
+ *
+ * POURQUOI CES ENDPOINTS EXISTENT, alors que les vrais sont déjà là. Sur les endpoints partenaires,
+ * la plateforme est DÉDUITE de la clé d'API — c'est ce qui empêche un service de se faire passer
+ * pour un autre. Le back-office, lui, porte la clé d'ADMINISTRATION : il n'est aucune plateforme, et
+ * doit donc dire au nom de QUI il agit.
+ *
+ * La garantie n'est pas affaiblie : elle porte sur les clés PARTENAIRES, et elle reste entière. Une
+ * console d'exploitation qui agit « au nom de » est exactement ce qu'on attend d'elle — et c'est
+ * pour ça qu'elle est derrière ServiceApiKeyGuard, jamais derrière une clé de plateforme.
+ *
+ * AUCUNE RÈGLE N'EST RÉÉCRITE ICI : on délègue à `AjoutsManuelsService`, la même porte que les
+ * endpoints partenaires. Les gardes (aide sur le périmètre du projet, slug existant au catalogue)
+ * s'appliquent donc à l'identique — sans quoi le back-office pourrait créer des ajouts que la
+ * lecture ne saurait jamais résoudre.
+ */
+@ApiBearerAuth()
+@ApiTags("Administration")
+@Controller("admin/ajouts")
+@UseGuards(ServiceApiKeyGuard)
+export class AdminAjoutsController {
+  constructor(private readonly ajouts: AjoutsManuelsService) {}
+
+  @Post("aide")
+  @ApiOperation({
+    summary: "Ajouter une aide à un projet, au nom d'une plateforme",
+    description:
+      "Mêmes gardes que l'endpoint partenaire : l'aide doit être disponible sur le territoire du " +
+      "projet (400 sinon). Une aide hors périmètre ne pourrait jamais être résolue à la lecture, et " +
+      "l'ajout resterait invisible sans le moindre message.",
+  })
+  @ApiEndpointResponses({ successStatus: 201, response: AjoutCreeResponse, description: "Ajout enregistré" })
+  ajouterAide(@Body() dto: AjoutAideAdminRequest): Promise<AjoutCreeResponse> {
+    return this.ajouts.ajouterAide(dto.projetId, dto, dto.plateforme);
+  }
+
+  @Post("service")
+  @ApiOperation({
+    summary: "Ajouter un service numérique à un projet, au nom d'une plateforme",
+    description: "`slug` (service du catalogue) OU `service` (service décrit à la main), exactement un des deux.",
+  })
+  @ApiEndpointResponses({ successStatus: 201, response: AjoutCreeResponse, description: "Ajout enregistré" })
+  ajouterService(@Body() dto: AjoutServiceAdminRequest): Promise<AjoutCreeResponse> {
+    return this.ajouts.ajouterService(dto.projetId, dto, dto.plateforme);
+  }
+
+  @Delete(":decisionId")
+  @HttpCode(200)
+  @ApiOperation({
+    summary: "Retirer un ajout manuel",
+    description:
+      "RÉVOCATION, pas suppression : le journal est append-only. `plateforme` doit être celle qui a " +
+      "fait l'ajout — on ne défait pas l'ajout d'une autre.",
+  })
+  retirer(
+    @Param("decisionId", ParseUUIDPipe) decisionId: string,
+    @Query("plateforme") plateforme: string,
+  ): Promise<AjoutCreeResponse> {
+    return this.ajouts.retirer(decisionId, plateforme);
+  }
+}

--- a/api/src/admin/admin.controller.ts
+++ b/api/src/admin/admin.controller.ts
@@ -1,9 +1,10 @@
-import { Body, Controller, Get, HttpCode, Post, UseGuards } from "@nestjs/common";
+import { Body, Controller, Get, HttpCode, Post, Req, UseGuards } from "@nestjs/common";
+import { Request } from "express";
 import { ApiBearerAuth, ApiOperation, ApiTags } from "@nestjs/swagger";
 import { ServiceApiKeyGuard } from "@/auth/service-api-key-guard";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import { AdminService } from "./admin.service";
-import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
+import { ApercuRequest, ApercuResponse, ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
 
 /**
  * Back-office : voir le contenu, et simuler ce que l'API renverrait pour un projet RÉEL.
@@ -51,6 +52,25 @@ export class AdminController {
     return this.adminService.contenu();
   }
 
+  @Post("apercu")
+  @HttpCode(200)
+  @ApiOperation({
+    summary: "Ce que l'API renvoie RÉELLEMENT pour un projet",
+    description:
+      "Les quatre réponses telles que la plateforme les reçoit : aides, services numériques, " +
+      "questionnaires, recommandations. PAS une émulation — ces sections appellent EXACTEMENT les " +
+      "fonctions qui servent MEC. Une reconstitution finirait par diverger, et un outil qui ment sur " +
+      "ce que voit la collectivité est pire que pas d'outil.\n\n" +
+      "`plateforme` est obligatoire : les ajouts manuels et les arbitrages sont CLOISONNÉS par " +
+      "plateforme. Sans elle, on afficherait une liste que personne ne reçoit.\n\n" +
+      "Les paramètres de `GET /aides` (limit, cutoff, seuils de confiance, matching textuel, et même " +
+      "le texte de la recherche) sont réglables. Les valeurs réellement appliquées sont rendues.",
+  })
+  @ApiEndpointResponses({ successStatus: 200, response: ApercuResponse, description: "Aperçu" })
+  apercu(@Req() request: Request, @Body() dto: ApercuRequest): Promise<ApercuResponse> {
+    return this.adminService.apercu(dto, origine(request));
+  }
+
   @Post("simuler")
   // POST parce qu'on envoie un corps, mais une simulation ne CRÉE rien : 200, pas 201.
   @HttpCode(200)
@@ -66,4 +86,13 @@ export class AdminController {
   simuler(@Body() dto: SimulationRequest): Promise<SimulationResponse> {
     return this.adminService.simuler(dto);
   }
+}
+
+/**
+ * Origine publique de l'API, pour rendre absolues les URLs de logos qu'elle héberge — comme le fait
+ * le vrai endpoint des services. L'aperçu doit rendre les MÊMES URLs que MEC reçoit.
+ */
+function origine(request: Request): string {
+  const protocole = (request.headers["x-forwarded-proto"] as string | undefined)?.split(",")[0] ?? request.protocol;
+  return `${protocole}://${request.get("host") ?? ""}`;
 }

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -3,6 +3,10 @@ import { DatabaseModule } from "@database/database.module";
 import { ProjetsModule } from "@projets/projets.module";
 import { AidesMatchingService } from "@/aides/aides-matching.service";
 import { QuestionnairesModule } from "@/questionnaires/questionnaires.module";
+import { AidesModule } from "@/aides/aides.module";
+import { AidesPerimetreModule } from "@/aides/aides-perimetre.module";
+import { ServicesNumeriquesModule } from "@/services-numeriques/services-numeriques.module";
+import { RecommandationsModule } from "@/recommandations/recommandations.module";
 import { AdminController } from "./admin.controller";
 import { AdminService } from "./admin.service";
 
@@ -17,7 +21,15 @@ import { AdminService } from "./admin.service";
  * questionnaires resteront lisibles et éditables par l'API, simplement plus par un écran.
  */
 @Module({
-  imports: [DatabaseModule, ProjetsModule, QuestionnairesModule],
+  imports: [
+    DatabaseModule,
+    ProjetsModule,
+    QuestionnairesModule,
+    AidesModule,
+    AidesPerimetreModule,
+    ServicesNumeriquesModule,
+    RecommandationsModule,
+  ],
   controllers: [AdminController],
   // Même moteur de score que les aides, les questionnaires et les services : la simulation doit
   // dire la VÉRITÉ. Un portage du scoring dans le back-office afficherait des chiffres faux, et

--- a/api/src/admin/admin.module.ts
+++ b/api/src/admin/admin.module.ts
@@ -8,6 +8,8 @@ import { AidesPerimetreModule } from "@/aides/aides-perimetre.module";
 import { ServicesNumeriquesModule } from "@/services-numeriques/services-numeriques.module";
 import { RecommandationsModule } from "@/recommandations/recommandations.module";
 import { AdminController } from "./admin.controller";
+import { AdminAjoutsController } from "./admin-ajouts.controller";
+import { AjoutsManuelsModule } from "@/ajouts-manuels/ajouts-manuels.module";
 import { AdminService } from "./admin.service";
 
 /**
@@ -29,8 +31,9 @@ import { AdminService } from "./admin.service";
     AidesPerimetreModule,
     ServicesNumeriquesModule,
     RecommandationsModule,
+    AjoutsManuelsModule,
   ],
-  controllers: [AdminController],
+  controllers: [AdminController, AdminAjoutsController],
   // Même moteur de score que les aides, les questionnaires et les services : la simulation doit
   // dire la VÉRITÉ. Un portage du scoring dans le back-office afficherait des chiffres faux, et
   // les seuils seraient calibrés sur un mensonge.

--- a/api/src/admin/admin.service.ts
+++ b/api/src/admin/admin.service.ts
@@ -2,6 +2,11 @@ import { Injectable } from "@nestjs/common";
 import { DatabaseService } from "@database/database.service";
 import { servicesNumeriques } from "@database/schema";
 import { AidesMatchingService } from "@/aides/aides-matching.service";
+import { AidesMoteurService } from "@/aides/aides-moteur.service";
+import { AidesProjetService } from "@/aides/aides-projet.service";
+import { ServicesNumeriquesService } from "@/services-numeriques/services-numeriques.service";
+import { QuestionnairesService } from "@/questionnaires/questionnaires.service";
+import { RecommandationsService } from "@/recommandations/recommandations.service";
 import { AideClassification, AideMatchResult } from "@/aides/dto/aides.dto";
 import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
 import { QuestionnairesRepository } from "@/questionnaires/questionnaires.repository";
@@ -9,7 +14,7 @@ import type { QuestionnaireDef } from "@/questionnaires/questionnaire-contract";
 import { calculerStatut, evaluerCondition, reconcilierReponses } from "@/questionnaires/questionnaire-contract";
 import { etiquettesManquantes } from "@/questionnaires/questionnaires.service";
 import { facteurPhase, SEUIL_PERTINENCE, type PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
-import { ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
+import { ApercuRequest, ApercuResponse, ContenuResponse, SimulationRequest, SimulationResponse } from "./dto/admin.dto";
 
 /**
  * Service d'administration : voir le contenu tel qu'il est, et SIMULER ce que l'API renverrait
@@ -46,7 +51,47 @@ export class AdminService {
     private readonly getProjetsService: GetProjetsService,
     private readonly matchingService: AidesMatchingService,
     private readonly questionnairesRepository: QuestionnairesRepository,
+    private readonly moteurAides: AidesMoteurService,
+    private readonly aidesProjet: AidesProjetService,
+    private readonly servicesNumeriques: ServicesNumeriquesService,
+    private readonly questionnaires: QuestionnairesService,
+    private readonly recommandations: RecommandationsService,
   ) {}
+
+  /**
+   * CE QUE L'API RENVOIE RÉELLEMENT à une plateforme, pour un projet.
+   *
+   * PAS UNE ÉMULATION : les quatre sections appellent EXACTEMENT les fonctions qui servent MEC. Une
+   * reconstitution, même fidèle au départ, finit par diverger — et un outil qui ment sur ce que voit
+   * la collectivité est pire que pas d'outil du tout.
+   *
+   * Les quatre lectures sont indépendantes : on les lance ensemble.
+   */
+  async apercu(dto: ApercuRequest, baseUrl: string): Promise<ApercuResponse> {
+    const p = dto.aides ?? {};
+
+    // Les défauts de GET /aides, résolus ici et RENDUS dans la réponse : sans ça, on ne saurait pas
+    // distinguer « j'ai mis le cutoff à 0 » de « je n'y ai pas touché ».
+    const reglagesAides = {
+      maxResults: p.limit ?? 20,
+      cutoff: p.cutoff ?? 0,
+      thresholds: { projet: p.projetThreshold, aide: p.aideThreshold },
+      textualEnabled: this.moteurAides.textuelActif(p.textual),
+      textualText: p.texte,
+    };
+
+    const seuilServices = dto.seuilServices ?? SEUIL_PERTINENCE;
+
+    const [aides, services, questionnaires, recommandations] = await Promise.all([
+      this.aidesProjet.pourProjet(dto.projetId, dto.plateforme, reglagesAides),
+      // Le seuil est PASSÉ à l'API, pas rejoué ici : c'est elle qui décide, avec le réglage demandé.
+      this.servicesNumeriques.findForProjet(dto.projetId, baseUrl, dto.plateforme, seuilServices),
+      this.questionnaires.findForProjet(dto.projetId),
+      this.recommandations.findForProjet(dto.projetId, dto.plateforme),
+    ]);
+
+    return { aides, services, questionnaires, recommandations, reglagesAides, seuilServices };
+  }
 
   /** Le contenu tel qu'il est réellement chargé — conditions et classifications comprises. */
   async contenu(): Promise<ContenuResponse> {

--- a/api/src/admin/dto/admin-ajouts.dto.ts
+++ b/api/src/admin/dto/admin-ajouts.dto.ts
@@ -1,0 +1,33 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { IsNotEmpty, IsString, IsUUID } from "class-validator";
+import { AjoutAideRequest, AjoutServiceRequest } from "@/ajouts-manuels/dto/ajout-manuel.dto";
+
+/**
+ * Les DTO partenaires, plus le projet et la plateforme.
+ *
+ * Sur les endpoints partenaires, ces deux-là viennent de l'URL et de la clé d'API. Le back-office
+ * n'est aucune plateforme : il doit les DÉCLARER. On étend le DTO plutôt que de le recopier — les
+ * règles de validation (instantané, exclusivité slug/service, longueur du message) restent définies
+ * une seule fois.
+ */
+export class AjoutAideAdminRequest extends AjoutAideRequest {
+  @ApiProperty({ description: "Projet auquel attacher l'aide." })
+  @IsUUID()
+  projetId!: string;
+
+  @ApiProperty({ description: "Au nom de quelle plateforme (MEC, TET…). Les ajouts sont cloisonnés par plateforme." })
+  @IsString()
+  @IsNotEmpty()
+  plateforme!: string;
+}
+
+export class AjoutServiceAdminRequest extends AjoutServiceRequest {
+  @ApiProperty({ description: "Projet auquel attacher le service." })
+  @IsUUID()
+  projetId!: string;
+
+  @ApiProperty({ description: "Au nom de quelle plateforme (MEC, TET…)." })
+  @IsString()
+  @IsNotEmpty()
+  plateforme!: string;
+}

--- a/api/src/admin/dto/admin.dto.ts
+++ b/api/src/admin/dto/admin.dto.ts
@@ -1,5 +1,16 @@
 import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
-import { IsObject, IsOptional, IsUUID } from "class-validator";
+import {
+  IsBoolean,
+  IsInt,
+  IsNotEmpty,
+  IsNumber,
+  IsObject,
+  IsOptional,
+  IsString,
+  IsUUID,
+  Max,
+  Min,
+} from "class-validator";
 import { AideClassification, AideLabelsCommuns } from "@/aides/dto/aides.dto";
 import { ProjetPhase } from "@database/schema";
 import type { PoidsParPhase } from "@/services-numeriques/service-numerique-contract";
@@ -135,4 +146,111 @@ export class SimulationResponse {
   @ApiProperty({ type: [ServiceSimuleResponse], description: "TOUS les services, y compris écartés." })
   services!: ServiceSimuleResponse[];
   @ApiProperty({ type: SeuilsResponse }) seuils!: SeuilsResponse;
+}
+
+/**
+ * L'APERÇU : ce que l'API renvoie RÉELLEMENT à une plateforme, pour un projet.
+ *
+ * PAS UNE ÉMULATION. Les quatre sections appellent EXACTEMENT les fonctions qui servent MEC
+ * (`AidesProjetService.pourProjet`, `ServicesNumeriquesService.findForProjet`,
+ * `QuestionnairesService.findForProjet`, `RecommandationsService.findForProjet`). Une
+ * reconstitution, même fidèle au départ, finit par diverger — et un outil qui ment sur ce que voit
+ * la collectivité est pire que pas d'outil.
+ *
+ * `plateforme` est OBLIGATOIRE, et ce n'est pas une formalité : les ajouts manuels et les
+ * arbitrages de recommandations sont CLOISONNÉS par plateforme. Sans elle, on afficherait une liste
+ * que personne ne reçoit.
+ */
+export class ParametresAidesDto {
+  @ApiPropertyOptional({ description: "Nombre maximal d'aides. Défaut : 20." })
+  @IsOptional()
+  @IsInt()
+  @Min(1)
+  @Max(200)
+  limit?: number;
+
+  @ApiPropertyOptional({ description: "Score minimal pour être retenu. Défaut : 0 (aucun filtrage)." })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  cutoff?: number;
+
+  @ApiPropertyOptional({ description: "Confiance minimale d'une étiquette DU PROJET. Défaut du matcher : 0,8." })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  projetThreshold?: number;
+
+  @ApiPropertyOptional({ description: "Confiance minimale d'une étiquette DE L'AIDE. Défaut du matcher : 0,8." })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  aideThreshold?: number;
+
+  @ApiPropertyOptional({ description: "Matching textuel (BM25). Défaut : le drapeau d'environnement." })
+  @IsOptional()
+  @IsBoolean()
+  textual?: boolean;
+
+  @ApiPropertyOptional({ description: "Texte de la recherche. Défaut : « nom + description » du projet." })
+  @IsOptional()
+  @IsString()
+  texte?: string;
+}
+
+export class ApercuRequest {
+  @ApiProperty({ description: "Identifiant d'un projet RÉEL." })
+  @IsUUID()
+  projetId!: string;
+
+  @ApiProperty({
+    description:
+      "Au nom de QUELLE plateforme on regarde (MEC, TET…). Les ajouts manuels et les arbitrages " +
+      "sont cloisonnés par plateforme : sans elle, on afficherait une liste que personne ne reçoit.",
+  })
+  @IsString()
+  @IsNotEmpty()
+  plateforme!: string;
+
+  @ApiPropertyOptional({ description: "Paramètres de GET /aides. Absents = les défauts de l'API." })
+  @IsOptional()
+  @IsObject()
+  aides?: ParametresAidesDto;
+
+  @ApiPropertyOptional({
+    description:
+      "Seuil de pertinence des services numériques. Absent = celui de l'API.\n\n" +
+      "Réglable ICI seulement : la route publique ne l'expose pas, parce que le contrat interdit " +
+      "de faire traverser un critère de sélection au client (« il ne filtre ni ne trie »). C'est " +
+      "l'API qui applique le seuil, pas le back-office qui le rejoue — sans quoi l'écran finirait " +
+      "par mentir sur ce que voit la collectivité.",
+  })
+  @IsOptional()
+  @IsNumber()
+  @Min(0)
+  @Max(1)
+  seuilServices?: number;
+}
+
+export class ApercuResponse {
+  @ApiProperty({ type: Object, description: "La réponse EXACTE de GET /aides?projetId=…" })
+  aides!: unknown;
+
+  @ApiProperty({ type: Object, description: "La réponse EXACTE de GET /projets/:id/services" })
+  services!: unknown;
+
+  @ApiProperty({ type: Object, description: "La réponse EXACTE de GET /projets/:id/questionnaires" })
+  questionnaires!: unknown;
+
+  @ApiProperty({ type: Object, description: "La réponse EXACTE de GET /projets/:id/recommandations" })
+  recommandations!: unknown;
+
+  @ApiProperty({ type: Object, description: "Les réglages d'aides RÉELLEMENT appliqués, défauts résolus." })
+  reglagesAides!: Record<string, unknown>;
+
+  @ApiProperty({ description: "Le seuil de services RÉELLEMENT appliqué." })
+  seuilServices!: number;
 }

--- a/api/src/aides/aides-moteur.service.ts
+++ b/api/src/aides/aides-moteur.service.ts
@@ -1,0 +1,129 @@
+import { Injectable } from "@nestjs/common";
+import { ConfigService } from "@nestjs/config";
+import { AidesMatchingService } from "./aides-matching.service";
+import { AidesTextualMatchingService } from "./aides-textual-matching.service";
+import { Aide, AideClassification, AideMatchResult, AideWithClassification, AidesListResponse } from "./dto/aides.dto";
+
+/**
+ * LE MOTEUR : scorer et classer des aides contre une classification. Rien d'autre.
+ *
+ * Il vivait en privé dans AidesController. Extrait parce qu'il a désormais TROIS appelants —
+ * `GET /aides`, `POST /aides/recherche`, et la simulation du back-office. Le recopier pour le
+ * troisième aurait donné deux implémentations d'une même règle, qui divergent : c'est exactement
+ * ce que la revue a reproché à la fusion des ajouts manuels, écrite deux fois et déjà divergente
+ * au bout d'un jour.
+ *
+ * PUR. Il ne connaît ni les ajouts manuels (qui s'appliquent SUR son résultat), ni les projets, ni
+ * les périmètres. Il prend une classification et une liste d'aides, il rend un classement.
+ */
+
+/** Pondération du score combiné quand le matching textuel est actif. */
+const W_THEMATIC = 0.85;
+const W_TEXTUAL = 0.15;
+
+/**
+ * Plancher de « repêchage » textuel : une aide sans aucun match thématique remonte quand même si
+ * son score textuel dépasse ce seuil. Sans lui, une aide non encore classifiée serait invisible
+ * même quand son intitulé colle parfaitement au projet.
+ */
+const MIN_TEXTUAL_RESCUE = 0.35;
+
+export interface ReglagesMoteur {
+  maxResults: number;
+  /** Score minimal pour qu'une aide soit retenue. 0 = aucun filtrage. */
+  cutoff: number;
+  /** Confiance minimale d'une étiquette pour compter. `undefined` = le défaut du matcher (0.8). */
+  thresholds: { projet?: number; aide?: number };
+  textualEnabled: boolean;
+  textualText: string;
+}
+
+@Injectable()
+export class AidesMoteurService {
+  constructor(
+    private readonly matchingService: AidesMatchingService,
+    private readonly textualMatchingService: AidesTextualMatchingService,
+    private readonly configService: ConfigService,
+  ) {}
+
+  /**
+   * Le matching textuel est opt-in : override par requête, sinon le drapeau d'environnement.
+   * Exposé pour que la simulation du back-office applique la MÊME règle par défaut que l'API.
+   */
+  textuelActif(override?: string | boolean): boolean {
+    if (override === true || override === "true") return true;
+    if (override === false || override === "false") return false;
+    return this.configService.get<string>("AIDES_TEXTUAL_MATCHING_ENABLED") === "true";
+  }
+
+  /**
+   * Matching thématique (+ textuel optionnel), enrichissement et tri.
+   *
+   * `total` reflète le nombre d'aides du périmètre AVANT filtrage : c'est ce qui permet de
+   * distinguer « aucune aide sur ce territoire » de « des aides existent, aucune ne colle ».
+   */
+  classer(
+    scores: AideClassification,
+    allAides: Aide[],
+    classifications: Map<string, AideClassification>,
+    reglages: ReglagesMoteur,
+  ): AidesListResponse {
+    const { maxResults, cutoff, thresholds, textualEnabled, textualText } = reglages;
+
+    // On passe allAides.length : ne rien pré-trancher avant la combinaison textuelle optionnelle.
+    const matchResults = new Map<string, AideMatchResult>();
+    for (const r of this.matchingService.match(scores, classifications, allAides.length, thresholds)) {
+      matchResults.set(r.idAt, r);
+    }
+
+    // Le textuel tourne sur TOUTES les aides du périmètre, y compris celles non classifiées —
+    // c'est précisément ce qui permet de les repêcher.
+    const textualResults = textualEnabled ? this.textualMatchingService.score(textualText, allAides) : null;
+
+    let enriched: AideWithClassification[] = allAides.map((aide) => {
+      const idAt = String(aide.id);
+      const match = matchResults.get(idAt);
+
+      const base: AideWithClassification = {
+        ...aide,
+        classification: classifications.get(idAt),
+        matchingScore: match?.score,
+        normalizedScore: match?.normalizedScore,
+        axesMatched: match?.axesMatched,
+        labelsCommuns: match?.labelsCommuns,
+      };
+
+      if (!textualResults) return base;
+
+      const textual = textualResults.get(idAt);
+      return {
+        ...base,
+        textualScore: textual?.score ?? 0,
+        combinedScore: W_THEMATIC * (match?.normalizedScore ?? 0) + W_TEXTUAL * (textual?.score ?? 0),
+        matchedTerms: textual?.matchedTerms,
+      };
+    });
+
+    if (textualEnabled) {
+      enriched = enriched
+        .filter(
+          (a) =>
+            (a.matchingScore !== undefined || (a.textualScore ?? 0) >= MIN_TEXTUAL_RESCUE) &&
+            (a.combinedScore ?? 0) >= cutoff,
+        )
+        .sort((a, b) => (b.combinedScore ?? 0) - (a.combinedScore ?? 0))
+        .slice(0, maxResults);
+    } else {
+      enriched = enriched
+        .filter((a) => a.matchingScore !== undefined && (a.normalizedScore ?? 0) >= cutoff)
+        .sort((a, b) => (b.matchingScore ?? 0) - (a.matchingScore ?? 0))
+        .slice(0, maxResults);
+    }
+
+    if (enriched.length === 0) {
+      return { status: "no_match", aides: [], total: allAides.length };
+    }
+
+    return { status: "ok", aides: enriched, total: allAides.length };
+  }
+}

--- a/api/src/aides/aides-projet.service.ts
+++ b/api/src/aides/aides-projet.service.ts
@@ -1,0 +1,101 @@
+import { Injectable } from "@nestjs/common";
+import { CustomLogger } from "@logging/logger.service";
+import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
+import { fondreAjouts } from "@/ajouts-manuels/fondre-ajouts";
+import { GetProjetsService } from "@projets/services/get-projets/get-projets.service";
+import { AideClassificationService } from "./aide-classification.service";
+import { AidesMoteurService } from "./aides-moteur.service";
+import { AidesPerimetreService } from "./aides-perimetre.service";
+import { AideWithClassification, AidesListResponse } from "./dto/aides.dto";
+
+/**
+ * « Quelles aides pour ce projet ? » — LA réponse de l'API, en un seul endroit.
+ *
+ * Cette orchestration vivait dans AidesController. Extraite parce qu'elle a désormais DEUX
+ * appelants : `GET /aides`, et l'aperçu du back-office.
+ *
+ * ET C'EST TOUT L'ENJEU. Le back-office ne doit pas ÉMULER l'API : il doit montrer ce qu'elle
+ * renvoie RÉELLEMENT. Une reconstitution, même fidèle au départ, finit par diverger — et un outil
+ * qui ment sur ce que voit la collectivité est pire que pas d'outil du tout. Il appelle donc
+ * exactement cette fonction, celle qui sert MEC.
+ *
+ * Le cas « projet non classifié » (202 + relance du job) reste au contrôleur : il touche au code
+ * HTTP et à la file d'attente, pas au contenu.
+ */
+
+export interface ParametresAides {
+  maxResults: number;
+  cutoff: number;
+  thresholds: { projet?: number; aide?: number };
+  textualEnabled: boolean;
+  /** Texte de la recherche textuelle. Par défaut « nom + description » du projet. */
+  textualText?: string;
+}
+
+@Injectable()
+export class AidesProjetService {
+  constructor(
+    private readonly projetsService: GetProjetsService,
+    private readonly perimetreService: AidesPerimetreService,
+    private readonly classificationService: AideClassificationService,
+    private readonly moteur: AidesMoteurService,
+    private readonly ajoutsManuels: AjoutsManuelsService,
+    private readonly logger: CustomLogger,
+  ) {}
+
+  /**
+   * `plateforme` vient de la clé d'API de l'appelant : les ajouts manuels sont CLOISONNÉS par
+   * plateforme, et MEC ne doit pas voir ceux d'une autre. Le back-office doit donc dire au nom de
+   * QUI il regarde — sinon il montrerait une liste que personne ne reçoit.
+   */
+  async pourProjet(projetId: string, plateforme: string, params: ParametresAides): Promise<AidesListResponse> {
+    const { projet } = await this.projetsService.findOneWithSource(projetId);
+
+    // Un projet non classifié ne matche rien. Le contrôleur, lui, en fait un 202 et relance le job.
+    if (!projet.classificationScores) {
+      return { status: "no_match", aides: [], total: 0 };
+    }
+
+    const codesInsee = this.perimetreService.extractCodesInsee(projet.collectivites);
+    if (codesInsee.length === 0) {
+      this.logger.warn(`Projet ${projetId} sans commune à code INSEE : aides récupérées sans filtre de territoire.`);
+    }
+
+    const [allAides, ajouts] = await Promise.all([
+      this.perimetreService.fetchAidesForPerimeterCodes(codesInsee),
+      this.ajoutsManuels.actifs(projetId, "aide", plateforme),
+    ]);
+
+    if (allAides.length === 0) {
+      return { status: "no_aides_on_perimeter", aides: [], total: 0 };
+    }
+
+    const classifications = await this.classificationService.getCachedClassifications(
+      allAides.map((a) => String(a.id)),
+    );
+
+    const reponse = this.moteur.classer(projet.classificationScores, allAides, classifications, {
+      ...params,
+      textualText: params.textualText ?? `${projet.nom} ${projet.description ?? ""}`,
+    });
+
+    // La fusion s'applique SUR le résultat du moteur : le moteur reste un pur scoreur/classeur, que
+    // POST /aides/recherche partage sans rien savoir des ajouts manuels.
+    const parId = new Map(allAides.map((a) => [String(a.id), a]));
+    const aides = fondreAjouts<AideWithClassification>({
+      ajouts,
+      resoudre: (idAt, ajout) => {
+        const aide = parId.get(idAt);
+        // Aide clôturée ou dépubliée depuis l'ajout : on ne sait plus la résoudre, et on ne fabrique
+        // rien. Mieux vaut ne rien montrer qu'envoyer candidater à une aide morte.
+        return aide ? { ...aide, classification: classifications.get(idAt), ajoutManuel: ajout } : undefined;
+      },
+      duMoteur: reponse.aides,
+      idDe: (a) => String(a.id),
+      nomDe: (a) => a.name,
+    });
+
+    if (aides.length === 0) return { status: "no_match", aides: [], total: allAides.length };
+    return { status: "ok", aides, total: allAides.length };
+  }
+}

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -4,6 +4,8 @@ import { Queue } from "bullmq";
 import type { Request as ExpressRequest } from "express";
 import { AidesController } from "./aides.controller";
 import { AidesPerimetreService } from "./aides-perimetre.service";
+import { AidesMoteurService } from "./aides-moteur.service";
+import { AidesProjetService } from "./aides-projet.service";
 import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
 import { AidesTerritoiresService } from "./aides-territoires.service";
 import { AideClassificationService } from "./aide-classification.service";
@@ -155,18 +157,31 @@ describe("AidesController", () => {
       actifs: jest.fn().mockResolvedValue(new Map()),
     } as unknown as jest.Mocked<AjoutsManuelsService>;
 
+    // Le VRAI moteur, construit sur les mêmes mocks : il a quitté le contrôleur, pas le
+    // comportement. Les tests continuent donc de le valider réellement.
+    const moteur = new AidesMoteurService(mockMatchingService, mockTextualMatchingService, mockConfigService);
+
+    // Le VRAI service d'orchestration, sur les mêmes mocks : il a quitté le contrôleur, pas le
+    // comportement. Les tests continuent donc de valider la chaîne réelle.
+    const aidesProjet = new AidesProjetService(
+      mockProjetsService,
+      perimetreService,
+      mockClassificationService,
+      moteur,
+      mockAjoutsManuels,
+      mockLogger,
+    );
+
     controller = new AidesController(
       mockAtService,
       mockClassificationService,
-      mockMatchingService,
-      mockTextualMatchingService,
       mockCacheService,
       perimetreService,
-      mockAjoutsManuels,
+      moteur,
+      aidesProjet,
       mockWarmupService,
       mockFeedbackService,
       mockProjetsService,
-      mockConfigService,
       mockQualificationQueue,
       mockLogger,
     );

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -13,7 +13,6 @@ import {
   BadRequestException,
 } from "@nestjs/common";
 import { ApiBearerAuth, ApiOperation, ApiQuery, ApiResponse, ApiTags } from "@nestjs/swagger";
-import { ConfigService } from "@nestjs/config";
 import { Request, Response } from "express";
 import { InjectQueue } from "@nestjs/bullmq";
 import { Queue } from "bullmq";
@@ -28,26 +27,20 @@ import {
 } from "@/projet-qualification/const";
 import { AidesTerritoiresService } from "./aides-territoires.service";
 import { AideClassificationService } from "./aide-classification.service";
-import { AidesMatchingService } from "./aides-matching.service";
-import { AidesTextualMatchingService } from "./aides-textual-matching.service";
 import { AidesCacheService } from "./aides-cache.service";
 import { AidesPerimetreService } from "./aides-perimetre.service";
-import { AjoutsManuelsService } from "@/ajouts-manuels/ajouts-manuels.service";
-import { fondreAjouts } from "@/ajouts-manuels/fondre-ajouts";
+import { AidesMoteurService } from "./aides-moteur.service";
+import { AidesProjetService } from "./aides-projet.service";
 import { AidesWarmupService } from "./aides-warmup.service";
 import { AidesFeedbackService } from "./aides-feedback.service";
 import { AideFeedbackResponse, CreateAideFeedbackRequest, DeleteAideFeedbackRequest } from "./dto/aide-feedback.dto";
 import {
-  Aide,
   AideClassification,
-  AideMatchResult,
   AidesListResponse,
   AidesSearchRequest,
   AidesSyncResponse,
-  AideWithClassification,
   ClassificationPendingResponse,
 } from "./dto/aides.dto";
-import { MatchThresholds } from "./aides-matching.service";
 
 const CLASSIFICATION_RETRY_AFTER_SECONDS = 15;
 
@@ -55,9 +48,6 @@ const CLASSIFICATION_RETRY_AFTER_SECONDS = 15;
 // plancher de "rescue" pour qu'une aide non matchée thématiquement remonte.
 // Le thématique (labels de classification) est plus fiable que le lexical :
 // il domine nettement le score combiné, le textuel reste un bonus + rescue.
-const W_THEMATIC = 0.85;
-const W_TEXTUAL = 0.15;
-const MIN_TEXTUAL_RESCUE = 0.35;
 
 @ApiBearerAuth()
 @ApiTags("Aides")
@@ -67,15 +57,13 @@ export class AidesController {
   constructor(
     private readonly atService: AidesTerritoiresService,
     private readonly classificationService: AideClassificationService,
-    private readonly matchingService: AidesMatchingService,
-    private readonly textualMatchingService: AidesTextualMatchingService,
     private readonly cacheService: AidesCacheService,
     private readonly perimetreService: AidesPerimetreService,
-    private readonly ajoutsManuels: AjoutsManuelsService,
+    private readonly moteur: AidesMoteurService,
+    private readonly aidesProjet: AidesProjetService,
     private readonly warmupService: AidesWarmupService,
     private readonly feedbackService: AidesFeedbackService,
     private readonly projetsService: GetProjetsService,
-    private readonly configService: ConfigService,
     @InjectQueue(PROJECT_QUALIFICATION_QUEUE_NAME) private readonly qualificationQueue: Queue,
     private readonly logger: CustomLogger,
   ) {}
@@ -168,11 +156,11 @@ export class AidesController {
     const aideThreshold = this.parseUnitInterval("aideThreshold", aideThresholdRaw);
     const projetThreshold = this.parseUnitInterval("projetThreshold", projetThresholdRaw);
 
-    // 1. Load project (throws 404 if not found) + détecte la source pour
-    //    pouvoir tagger correctement un éventuel job de classification.
+    // 1. Projet (404 si absent) + source, pour tagger correctement un éventuel job.
     const { projet, source } = await this.projetsService.findOneWithSource(projetId);
 
-    // 2. If not classified yet → enqueue classification + return 202
+    // 2. Non classifié → on relance le job et on répond 202. C'est le SEUL morceau qui reste ici :
+    //    il touche au code HTTP et à la file d'attente, pas au contenu.
     if (!projet.classificationScores) {
       const triggered = await this.triggerClassificationIfNeeded(projetId, source);
       res.status(202).setHeader("Retry-After", String(CLASSIFICATION_RETRY_AFTER_SECONDS));
@@ -184,62 +172,14 @@ export class AidesController {
       };
     }
 
-    // 3. Extract code_insee from project collectivités
-    const codesInsee = this.perimetreService.extractCodesInsee(projet.collectivites);
-
-    if (codesInsee.length === 0) {
-      this.logger.warn(
-        `Project ${projetId} has no collectivités with code_insee, fetching aides without territory filter`,
-      );
-    }
-
-    // 4. Fetch aides for each territory (union) — deduplicate by aide id
-    const allAides = await this.perimetreService.fetchAidesForPerimeterCodes(codesInsee);
-
-    // Les aides AJOUTÉES À LA MAIN sur ce projet. On les résout dans les aides du périmètre : une
-    // aide n'est persistée nulle part, et Aides-territoires ne sait pas la récupérer par son id.
-    // Si elle a été clôturée ou dépubliée depuis l'ajout, elle n'est plus là — elle cesse alors de
-    // s'afficher, ce qui est le comportement voulu : mieux vaut ne rien montrer que d'envoyer une
-    // collectivité candidater à une aide morte.
-    const ajouts = await this.ajoutsManuels.actifs(projetId, "aide", request.serviceType!);
-
-    if (allAides.length === 0) {
-      return { status: "no_aides_on_perimeter", aides: [], total: 0 };
-    }
-
-    // 5. Get classifications for these aides (from DB cache)
-    const aideIds = allAides.map((a) => String(a.id));
-    const classifications = await this.classificationService.getCachedClassifications(aideIds);
-
-    // 6-7. Matching thématique (+ textuel optionnel), enrichissement et tri —
-    //      logique partagée avec POST /aides/recherche.
-    const textualEnabled = this.isTextualMatchingEnabled(textualOverride);
-    const reponse = this.buildMatchedResponse(projet.classificationScores, allAides, classifications, {
+    // 3. Tout le reste est l'affaire du domaine — et c'est EXACTEMENT ce que le back-office appelle,
+    //    pour montrer ce que l'API renvoie réellement plutôt qu'une reconstitution.
+    return this.aidesProjet.pourProjet(projetId, request.serviceType!, {
       maxResults,
       cutoff,
       thresholds: { projet: projetThreshold, aide: aideThreshold },
-      textualEnabled,
-      textualText: `${projet.nom} ${projet.description ?? ""}`,
+      textualEnabled: this.moteur.textuelActif(textualOverride),
     });
-
-    // La fusion s'applique SUR le résultat du moteur, pas dedans : le moteur reste un pur
-    // scoreur/classeur, que POST /aides/recherche partage sans rien savoir des ajouts manuels.
-    const parId = new Map(allAides.map((a) => [String(a.id), a]));
-    const aides = fondreAjouts<AideWithClassification>({
-      ajouts,
-      resoudre: (idAt, ajout) => {
-        const aide = parId.get(idAt);
-        // Aide clôturée ou dépubliée depuis l'ajout : on ne sait plus la résoudre, et on ne
-        // fabrique rien. Mieux vaut ne rien montrer qu'envoyer candidater à une aide morte.
-        return aide ? { ...aide, classification: classifications.get(idAt), ajoutManuel: ajout } : undefined;
-      },
-      duMoteur: reponse.aides,
-      idDe: (a) => String(a.id),
-      nomDe: (a) => a.name,
-    });
-
-    if (aides.length === 0) return { status: "no_match", aides: [], total: allAides.length };
-    return { status: "ok", aides, total: allAides.length };
   }
 
   @TrackApiUsage()
@@ -279,109 +219,13 @@ export class AidesController {
 
     // Le texte libre ne sert qu'au matching textuel optionnel.
     const textualEnabled = dto.textual === true;
-    return this.buildMatchedResponse(searchScores, allAides, classifications, {
+    return this.moteur.classer(searchScores, allAides, classifications, {
       maxResults,
       cutoff,
       thresholds: { projet: dto.projetThreshold, aide: dto.aideThreshold },
       textualEnabled,
       textualText: dto.query ?? "",
     });
-  }
-
-  /**
-   * Matching thématique (+ textuel optionnel), enrichissement et tri d'un
-   * ensemble d'aides contre une classification. Partagé par GET /aides et
-   * POST /aides/recherche. `total` reflète le nombre d'aides du périmètre
-   * avant filtrage par le matching.
-   */
-  private buildMatchedResponse(
-    scores: AideClassification,
-    allAides: Aide[],
-    classifications: Map<string, AideClassification>,
-    options: {
-      maxResults: number;
-      cutoff: number;
-      thresholds: MatchThresholds;
-      textualEnabled: boolean;
-      textualText: string;
-    },
-  ): AidesListResponse {
-    const { maxResults, cutoff, thresholds, textualEnabled, textualText } = options;
-
-    // Matching thématique — on passe allAides.length pour ne rien pré-trancher
-    // avant la combinaison textuelle optionnelle.
-    const matchResults = new Map<string, AideMatchResult>();
-    for (const r of this.matchingService.match(scores, classifications, allAides.length, thresholds)) {
-      matchResults.set(r.idAt, r);
-    }
-
-    // Matching textuel (BM25) — opt-in. Tourne sur toutes les aides du
-    // périmètre, y compris celles non encore classifiées.
-    const textualResults = textualEnabled ? this.textualMatchingService.score(textualText, allAides) : null;
-
-    let enriched: AideWithClassification[] = allAides.map((aide) => {
-      const idAt = String(aide.id);
-      const classification = classifications.get(idAt);
-      const match = matchResults.get(idAt);
-
-      const base: AideWithClassification = {
-        ...aide,
-        classification: classification ?? undefined,
-        matchingScore: match?.score,
-        normalizedScore: match?.normalizedScore,
-        axesMatched: match?.axesMatched,
-        labelsCommuns: match?.labelsCommuns,
-      };
-
-      if (!textualResults) return base;
-
-      const textual = textualResults.get(idAt);
-      const thematicScore = match?.normalizedScore ?? 0;
-      const textualScore = textual?.score ?? 0;
-      return {
-        ...base,
-        textualScore,
-        combinedScore: W_THEMATIC * thematicScore + W_TEXTUAL * textualScore,
-        matchedTerms: textual?.matchedTerms,
-      };
-    });
-
-    if (textualEnabled) {
-      // Rescue + booster : on garde tout match thématique, plus toute aide
-      // dont le score textuel dépasse le plancher de rescue. Tri par score combiné.
-      // Le cutoff écarte les aides sous le score de pertinence minimal demandé.
-      enriched = enriched
-        .filter(
-          (a) =>
-            (a.matchingScore !== undefined || (a.textualScore ?? 0) >= MIN_TEXTUAL_RESCUE) &&
-            (a.combinedScore ?? 0) >= cutoff,
-        )
-        .sort((a, b) => (b.combinedScore ?? 0) - (a.combinedScore ?? 0))
-        .slice(0, maxResults);
-    } else {
-      // Comportement historique : matching thématique seul.
-      // Le cutoff filtre sur le score de pertinence normalisé (0-1).
-      enriched = enriched
-        .filter((a) => a.matchingScore !== undefined && (a.normalizedScore ?? 0) >= cutoff)
-        .sort((a, b) => (b.matchingScore ?? 0) - (a.matchingScore ?? 0))
-        .slice(0, maxResults);
-    }
-
-    if (enriched.length === 0) {
-      return { status: "no_match", aides: [], total: allAides.length };
-    }
-
-    return { status: "ok", aides: enriched, total: allAides.length };
-  }
-
-  /**
-   * Le matching textuel est opt-in. Override par requête (`?textual=true|false`)
-   * sinon flag d'env `AIDES_TEXTUAL_MATCHING_ENABLED` (défaut désactivé).
-   */
-  private isTextualMatchingEnabled(override?: string): boolean {
-    if (override === "true") return true;
-    if (override === "false") return false;
-    return this.configService.get<string>("AIDES_TEXTUAL_MATCHING_ENABLED") === "true";
   }
 
   /**

--- a/api/src/aides/aides.module.ts
+++ b/api/src/aides/aides.module.ts
@@ -13,6 +13,8 @@ import { AidesPerimetreModule } from "./aides-perimetre.module";
 import { AidesController } from "./aides.controller";
 import { AideClassificationService } from "./aide-classification.service";
 import { AidesMatchingService } from "./aides-matching.service";
+import { AidesMoteurService } from "./aides-moteur.service";
+import { AidesProjetService } from "./aides-projet.service";
 import { AidesTextualMatchingService } from "./aides-textual-matching.service";
 import { AidesSyncProcessor, AIDES_SYNC_QUEUE_NAME, AIDES_SYNC_JOB_NAME } from "./aides-sync.processor";
 import { AidesWarmupService } from "./aides-warmup.service";
@@ -40,12 +42,18 @@ import { AidesFeedbackService } from "./aides-feedback.service";
   providers: [
     AideClassificationService,
     AidesMatchingService,
+    AidesMoteurService,
+    AidesProjetService,
     AidesTextualMatchingService,
     AidesWarmupService,
     AidesFeedbackService,
     AidesSyncProcessor,
   ],
-  exports: [AideClassificationService],
+  // Le MOTEUR est exporté : le back-office simule le classement des aides avec des réglages
+  // arbitraires. Le recopier pour lui aurait donné deux implémentations d'une même règle.
+  // `AidesProjetService` est exporté : le back-office doit montrer ce que l'API renvoie RÉELLEMENT.
+  // Il appelle donc la MÊME fonction que GET /aides, et non une reconstitution qui divergerait.
+  exports: [AideClassificationService, AidesMoteurService, AidesProjetService],
 })
 export class AidesModule implements OnModuleInit {
   constructor(

--- a/api/src/recommandations/recommandations.module.ts
+++ b/api/src/recommandations/recommandations.module.ts
@@ -22,5 +22,8 @@ import { QuestionnaireRecommandationSource } from "./sources/questionnaire.sourc
       inject: [QuestionnaireRecommandationSource],
     },
   ],
+  // Exporté : l'aperçu du back-office doit montrer ce que l'API renvoie RÉELLEMENT, il appelle donc
+  // la MÊME fonction que GET /projets/:id/recommandations — pas une reconstitution.
+  exports: [RecommandationsService],
 })
 export class RecommandationsModule {}

--- a/api/src/services-numeriques/dto/service-numerique.dto.ts
+++ b/api/src/services-numeriques/dto/service-numerique.dto.ts
@@ -87,8 +87,12 @@ export class ProjetServicesResponse {
   @ApiProperty({
     type: [ServiceResponse],
     description:
-      "Services déjà sélectionnés, curés et ORDONNÉS par pertinence décroissante par l'API. " +
-      "Le client affiche la liste telle quelle : il ne filtre ni ne trie.",
+      "Services sélectionnés et ORDONNÉS par pertinence décroissante par l'API. Le client affiche la " +
+      "liste telle quelle : il ne trie pas, et n'a pas à refaire la sélection.\n\n" +
+      "Il peut en revanche demander un autre SEUIL (`?seuil=`) : une plateforme peut légitimement " +
+      "vouloir être plus permissive ou plus stricte. Mais c'est l'API qui l'applique — le client ne " +
+      "rejoue pas la règle de son côté, sinon deux définitions de la pertinence coexisteraient et " +
+      "finiraient par diverger.",
   })
   services!: ServiceResponse[];
 }

--- a/api/src/services-numeriques/services-numeriques.controller.ts
+++ b/api/src/services-numeriques/services-numeriques.controller.ts
@@ -1,11 +1,12 @@
-import { Controller, Get, Param, ParseUUIDPipe, Req, UseGuards } from "@nestjs/common";
-import { ApiBearerAuth, ApiOperation, ApiParam, ApiTags } from "@nestjs/swagger";
+import { BadRequestException, Controller, Get, Param, ParseUUIDPipe, Query, Req, UseGuards } from "@nestjs/common";
+import { ApiBearerAuth, ApiOperation, ApiParam, ApiQuery, ApiTags } from "@nestjs/swagger";
 import { Request } from "express";
 import { ApiKeyGuard } from "@/auth/api-key-guard";
 import { ApiEndpointResponses } from "@/shared/decorator/api-response.decorator";
 import { TrackApiUsage } from "@/shared/decorator/track-api-usage.decorator";
 import { ProjetServicesResponse } from "./dto/service-numerique.dto";
 import { ServicesNumeriquesService } from "./services-numeriques.service";
+import { SEUIL_PERTINENCE } from "./service-numerique-contract";
 
 @ApiBearerAuth()
 @ApiTags("Services numériques")
@@ -19,13 +20,27 @@ export class ServicesNumeriquesController {
   @ApiOperation({
     summary: "Services numériques pertinents pour un projet",
     description:
-      "Renvoie les services déjà sélectionnés, curés et ORDONNÉS par pertinence décroissante par l'API. " +
-      "Le client affiche la liste telle quelle : il ne filtre ni ne trie (il peut proposer des filtres par " +
-      "catégorie, purement côté client). Aucun critère de sélection n'est exposé. Aucun service → 200 avec " +
-      "une liste vide. Les services AJOUTÉS À LA MAIN sur ce projet remontent en tête, marqués " +
-      "`ajoutManuel` (avec le message de la personne qui les a ajoutés).",
+      "Services sélectionnés et ORDONNÉS par pertinence décroissante par l'API. Le client affiche la " +
+      "liste telle quelle : il ne trie pas et ne refait pas la sélection (il peut proposer des filtres " +
+      "par catégorie, purement à l'affichage).\n\n" +
+      "Le SEUIL de pertinence est réglable (`?seuil=`), avec un défaut explicite : une plateforme peut " +
+      "légitimement vouloir être plus permissive ou plus stricte. Mais c'est l'API qui l'applique — un " +
+      "client qui rejouerait la règle de son côté en créerait une seconde définition, qui divergerait.\n\n" +
+      "Aucun autre critère de sélection n'est exposé (classification, phases, curation). Aucun service " +
+      "→ 200 avec une liste vide. Les services AJOUTÉS À LA MAIN remontent en tête, marqués " +
+      "`ajoutManuel`, et échappent au seuil : quelqu'un les a délibérément mis là.",
   })
   @ApiParam({ name: "projetId", description: "Identifiant Communs du projet (UUID)." })
+  @ApiQuery({
+    name: "seuil",
+    required: false,
+    description:
+      `Score de pertinence minimal, entre 0 et 1. **Défaut : ${SEUIL_PERTINENCE}** — celui que l'API applique ` +
+      "si vous ne demandez rien, et celui sur lequel elle est réglée.\n\n" +
+      "Une plateforme peut légitimement vouloir être plus permissive (montrer davantage, quitte à " +
+      "afficher du moins pertinent) ou plus stricte. Le seuil est donc à vous — mais le DÉFAUT reste " +
+      "à nous : c'est lui qui fait foi, et c'est lui qu'on règle quand la pertinence est en cause.",
+  })
   @ApiEndpointResponses({
     successStatus: 200,
     response: ProjetServicesResponse,
@@ -34,9 +49,31 @@ export class ServicesNumeriquesController {
   findForProjet(
     @Req() request: Request,
     @Param("projetId", ParseUUIDPipe) projetId: string,
+    @Query("seuil") seuilBrut?: string,
   ): Promise<ProjetServicesResponse> {
-    return this.servicesNumeriquesService.findForProjet(projetId, origine(request), request.serviceType!);
+    return this.servicesNumeriquesService.findForProjet(
+      projetId,
+      origine(request),
+      request.serviceType!,
+      seuil(seuilBrut),
+    );
   }
+}
+
+/**
+ * Seuil demandé, ou celui de l'API.
+ *
+ * Une valeur invalide est un 400 EXPLICITE, jamais un repli silencieux sur le défaut : « ?seuil=abc »
+ * qui renverrait la liste par défaut ferait croire au client que son réglage est appliqué.
+ */
+function seuil(brut?: string): number {
+  if (brut === undefined || brut === "") return SEUIL_PERTINENCE;
+
+  const valeur = Number(brut);
+  if (Number.isNaN(valeur) || valeur < 0 || valeur > 1) {
+    throw new BadRequestException(`Paramètre "seuil" invalide : attendu un nombre entre 0 et 1, reçu "${brut}".`);
+  }
+  return valeur;
 }
 
 /**

--- a/api/src/services-numeriques/services-numeriques.module.ts
+++ b/api/src/services-numeriques/services-numeriques.module.ts
@@ -16,5 +16,8 @@ import { ServicesNumeriquesService } from "./services-numeriques.service";
     // son cron de synchronisation quotidienne.
     AidesMatchingService,
   ],
+  // Exporté : l'aperçu du back-office doit montrer ce que l'API renvoie RÉELLEMENT. Il appelle donc
+  // la MÊME fonction que GET /projets/:id/services — pas une reconstitution, qui divergerait.
+  exports: [ServicesNumeriquesService],
 })
 export class ServicesNumeriquesModule {}

--- a/api/src/services-numeriques/services-numeriques.service.ts
+++ b/api/src/services-numeriques/services-numeriques.service.ts
@@ -73,7 +73,22 @@ export class ServicesNumeriquesService {
    * `findOneWithSource` : le projet peut vivre dans public.projets, data_mec ou data_tet.
    * Aucun service → 200 avec une liste vide, jamais 404.
    */
-  async findForProjet(projetId: string, baseUrl: string, plateforme: string): Promise<ProjetServicesResponse> {
+  async findForProjet(
+    projetId: string,
+    baseUrl: string,
+    plateforme: string,
+    /**
+     * Seuil de pertinence, exposé au client (`?seuil=`). Défaut : celui de l'API.
+     *
+     * Une plateforme peut légitimement vouloir être plus permissive ou plus stricte. Le SEUIL est
+     * donc à elle ; le DÉFAUT reste à nous — c'est lui qui fait foi, et c'est lui qu'on règle quand
+     * la pertinence est en cause.
+     *
+     * Le rendre paramétrable, plutôt que de le laisser un client le rejouer de son côté, est ce qui
+     * évite l'émulation : c'est l'API qui décide, avec le réglage qu'on lui demande d'appliquer.
+     */
+    seuil: number = SEUIL_PERTINENCE,
+  ): Promise<ProjetServicesResponse> {
     // Trois lectures INDÉPENDANTES sur un chemin chaud (chaque fiche projet) : en série, c'était
     // trois allers-retours là où une vague suffit.
     const [{ projet }, catalogue, ajouts] = await Promise.all([
@@ -83,7 +98,7 @@ export class ServicesNumeriquesService {
     ]);
 
     const pertinents = this.scorer(projet, catalogue)
-      .filter((s) => s.score >= SEUIL_PERTINENCE)
+      .filter((s) => s.score >= seuil)
       .sort((a, b) => b.score - a.score || a.ligne.nom.localeCompare(b.ligne.nom))
       .map(({ ligne }) => this.toResponse(ligne, baseUrl));
 

--- a/back-office/src/App.tsx
+++ b/back-office/src/App.tsx
@@ -10,6 +10,7 @@ import { Catalogue } from "./components/Catalogue";
 import { QuestionnairesSimules } from "./components/QuestionnairesSimules";
 import { CatalogueQuestionnaires } from "./components/CatalogueQuestionnaires";
 import { Services } from "./components/Services";
+import { Apercu } from "./components/Apercu";
 import { compterEtiquettes, type Contenu, type Simulation, type Taxonomies } from "./types";
 
 /**
@@ -163,6 +164,12 @@ export default function App() {
                         </div>
                       )}
 
+                      {/* CE QUE L'API RENVOIE RÉELLEMENT — les réponses exactes des endpoints
+                          publics, produites par les mêmes fonctions qui servent MEC. */}
+                      <Apercu projetId={projet.id} />
+
+                      {/* DIAGNOSTIC — pourquoi les autres candidats sont écartés. L'aperçu ne
+                          montre que les retenus : il ne dit pas ce qui manque aux autres. */}
                       <QuestionnairesSimules questionnaires={simulation.questionnaires} />
                       <Services services={simulation.services} seuilApi={simulation.seuils.pertinence} />
                     </>

--- a/back-office/src/api.ts
+++ b/back-office/src/api.ts
@@ -1,4 +1,4 @@
-import type { Contenu, QuestionnaireEdition, Simulation, Taxonomies } from "./types";
+import type { Apercu, Contenu, QuestionnaireEdition, ReglagesAides, Simulation, Taxonomies } from "./types";
 
 /**
  * La clé d'administration vit en sessionStorage, jamais en localStorage : elle disparaît à la
@@ -58,3 +58,17 @@ export const enregistrerQuestionnaire = (slug: string, def: QuestionnaireEdition
 
 export const supprimerQuestionnaire = (slug: string): Promise<void> =>
   appeler<void>("/admin/questionnaires/" + encodeURIComponent(slug), undefined, "DELETE");
+
+/**
+ * Ce que l'API renvoie RÉELLEMENT à `plateforme`, pour ce projet.
+ *
+ * L'endpoint appelle les MÊMES fonctions que les endpoints publics : rien n'est reconstitué ici, ni
+ * côté serveur. La plateforme est obligatoire — les ajouts manuels et les arbitrages sont cloisonnés
+ * par plateforme, et sans elle on afficherait une liste que personne ne reçoit.
+ */
+export const apercu = (
+  projetId: string,
+  plateforme: string,
+  aides: ReglagesAides,
+  seuilServices?: number,
+): Promise<Apercu> => appeler<Apercu>("/admin/apercu", { projetId, plateforme, aides, seuilServices });

--- a/back-office/src/api.ts
+++ b/back-office/src/api.ts
@@ -72,3 +72,32 @@ export const apercu = (
   aides: ReglagesAides,
   seuilServices?: number,
 ): Promise<Apercu> => appeler<Apercu>("/admin/apercu", { projetId, plateforme, aides, seuilServices });
+
+// ------------------------------------------------------------
+// AJOUTS MANUELS depuis le back-office.
+//
+// Les endpoints partenaires déduisent la plateforme de la clé d'API — c'est ce qui empêche un
+// service de se faire passer pour un autre. Le back-office n'est aucune plateforme : il porte la
+// clé d'administration, et doit donc DÉCLARER au nom de qui il agit. Aucune règle n'est réécrite
+// côté serveur : les mêmes gardes s'appliquent (aide sur le périmètre, slug au catalogue).
+// ------------------------------------------------------------
+
+export const ajouterAide = (
+  projetId: string,
+  plateforme: string,
+  aideId: number,
+  message?: string,
+): Promise<{ decisionId: string }> =>
+  // `trim() || undefined` : une chaîne vide n'est pas un message. `??` ne la filtrerait pas.
+  appeler("/admin/ajouts/aide", { projetId, plateforme, aideId, message: message?.trim() ? message : undefined });
+
+export const ajouterService = (
+  projetId: string,
+  plateforme: string,
+  slug: string,
+  message?: string,
+): Promise<{ decisionId: string }> =>
+  appeler("/admin/ajouts/service", { projetId, plateforme, slug, message: message?.trim() ? message : undefined });
+
+export const retirerAjout = (decisionId: string, plateforme: string): Promise<unknown> =>
+  appeler(`/admin/ajouts/${decisionId}?plateforme=${encodeURIComponent(plateforme)}`, undefined, "DELETE");

--- a/back-office/src/components/AjoutManuel.tsx
+++ b/back-office/src/components/AjoutManuel.tsx
@@ -1,0 +1,115 @@
+import { useState } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { ajouterAide, ajouterService } from "../api";
+
+/**
+ * Ajouter à la main une aide ou un service, pour vérifier la boucle complète.
+ *
+ * L'écran n'a AUCUNE règle : il poste, et il réaffiche l'aperçu — c'est-à-dire ce que l'API renvoie
+ * réellement. C'est le seul moyen de savoir si l'ajout est réellement pris en compte, plutôt que de
+ * le croire.
+ *
+ * Les gardes de l'API restent entières, et c'est volontairement visible : une aide hors du
+ * territoire du projet est refusée (400), un slug inconnu du catalogue aussi (404). Le message
+ * s'affiche tel quel — sans lui, on ne saurait pas POURQUOI l'ajout n'a pas pris.
+ */
+export function AjoutManuel({
+  projetId,
+  plateforme,
+  onAjout,
+}: {
+  projetId: string;
+  plateforme: string;
+  onAjout: () => void;
+}) {
+  const [aideId, setAideId] = useState("");
+  const [slug, setSlug] = useState("");
+  const [message, setMessage] = useState("");
+  const [erreur, setErreur] = useState<string | null>(null);
+  const [succes, setSucces] = useState<string | null>(null);
+  const [envoi, setEnvoi] = useState(false);
+
+  const poster = async (action: () => Promise<unknown>, quoi: string) => {
+    setEnvoi(true);
+    setErreur(null);
+    setSucces(null);
+    try {
+      await action();
+      setSucces(`${quoi} ajouté au nom de ${plateforme}. L'aperçu ci-dessous est rechargé.`);
+      setAideId("");
+      setSlug("");
+      setMessage("");
+      onAjout();
+    } catch (e) {
+      setErreur(e instanceof Error ? e.message : "Erreur inattendue.");
+    } finally {
+      setEnvoi(false);
+    }
+  };
+
+  return (
+    <div className={fr.cx("fr-callout", "fr-mb-3w")}>
+      <h3 className={fr.cx("fr-callout__title", "fr-h6")}>Ajouter à la main, au nom de {plateforme}</h3>
+      <p className={fr.cx("fr-text--sm")}>
+        Pour vérifier que l&apos;ajout est réellement pris en compte : l&apos;aperçu se recharge, et affiche ce que
+        l&apos;API renvoie.
+      </p>
+
+      {erreur && (
+        <div className={fr.cx("fr-alert", "fr-alert--error", "fr-alert--sm", "fr-mb-2w")}>
+          <p>{erreur}</p>
+        </div>
+      )}
+      {succes && (
+        <div className={fr.cx("fr-alert", "fr-alert--success", "fr-alert--sm", "fr-mb-2w")}>
+          <p>{succes}</p>
+        </div>
+      )}
+
+      <Input
+        label="Message (facultatif)"
+        hintText="« Recommandée par la DDT lors du COPIL du 12/03 ». Rendu tel quel à côté de l'aide ou du service."
+        nativeInputProps={{ value: message, onChange: (e) => setMessage(e.target.value) }}
+      />
+
+      <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+        <div className={fr.cx("fr-col-12", "fr-col-md-6")}>
+          <Input
+            label="Identifiant d'aide (Aides-territoires)"
+            hintText="Elle doit être disponible sur le territoire du projet, sinon l'API refuse (400)."
+            nativeInputProps={{
+              type: "number",
+              value: aideId,
+              placeholder: "165809",
+              onChange: (e) => setAideId(e.target.value),
+            }}
+          />
+          <Button
+            size="small"
+            disabled={envoi || !aideId.trim()}
+            onClick={() => void poster(() => ajouterAide(projetId, plateforme, Number(aideId), message), "Aide")}
+          >
+            Ajouter l&apos;aide
+          </Button>
+        </div>
+
+        <div className={fr.cx("fr-col-12", "fr-col-md-6")}>
+          <Input
+            label="Slug de service (catalogue)"
+            hintText="Doit exister au catalogue, sinon l'API refuse (404)."
+            nativeInputProps={{ value: slug, placeholder: "benefriches", onChange: (e) => setSlug(e.target.value) }}
+          />
+          <Button
+            size="small"
+            disabled={envoi || !slug.trim()}
+            onClick={() => void poster(() => ajouterService(projetId, plateforme, slug.trim(), message), "Service")}
+          >
+            Ajouter le service
+          </Button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/back-office/src/components/Apercu.tsx
+++ b/back-office/src/components/Apercu.tsx
@@ -1,0 +1,286 @@
+import { useState } from "react";
+import { fr } from "@codegouvfr/react-dsfr";
+import { Badge } from "@codegouvfr/react-dsfr/Badge";
+import { Button } from "@codegouvfr/react-dsfr/Button";
+import { Input } from "@codegouvfr/react-dsfr/Input";
+import { Select } from "@codegouvfr/react-dsfr/Select";
+import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
+import { Etiquettes } from "./Etiquettes";
+import { apercu as chargerApercu } from "../api";
+import type { Apercu as ApercuType, ReglagesAides } from "../types";
+
+/**
+ * CE QUE L'API RENVOIE RÉELLEMENT, pour un projet, à une plateforme.
+ *
+ * PAS UNE ÉMULATION, et c'est tout l'enjeu de cet écran. Aucune règle n'est rejouée ici : les
+ * quatre sections sont les réponses EXACTES des endpoints publics, produites par les MÊMES
+ * fonctions qui servent MEC. Une reconstitution, même fidèle au départ, finit par diverger — et un
+ * outil qui ment sur ce que voit la collectivité est pire que pas d'outil du tout.
+ *
+ * C'est pourquoi changer un réglage demande un aller-retour, contrairement à un curseur local : on
+ * ne recalcule rien, on redemande à l'API.
+ *
+ * LA PLATEFORME EST OBLIGATOIRE. Les ajouts manuels et les arbitrages de recommandations sont
+ * cloisonnés par plateforme : sans elle, on afficherait une liste que personne ne reçoit.
+ */
+const PLATEFORMES = ["MEC", "TET", "RECOCO", "URBAN_VITALIZ", "SOS_PONTS", "FOND_VERT"];
+
+export function Apercu({ projetId }: { projetId: string }) {
+  const [plateforme, setPlateforme] = useState("MEC");
+  const [reglages, setReglages] = useState<ReglagesAides>({});
+  // Le seuil des services est ENVOYÉ à l'API, jamais rejoué ici. Une version précédente de cet
+  // écran le recalculait dans le navigateur : c'était une copie de la décision de l'API, et une
+  // copie diverge. Le passer en paramètre coûte un aller-retour, et rend l'écran incapable de mentir.
+  const [seuilServices, setSeuilServices] = useState<number | undefined>(undefined);
+  const [resultat, setResultat] = useState<ApercuType | null>(null);
+  const [chargement, setChargement] = useState(false);
+  const [erreur, setErreur] = useState<string | null>(null);
+
+  const lancer = async () => {
+    setChargement(true);
+    setErreur(null);
+    try {
+      setResultat(await chargerApercu(projetId, plateforme, reglages, seuilServices));
+    } catch (e) {
+      setErreur(e instanceof Error ? e.message : "Erreur inattendue.");
+    } finally {
+      setChargement(false);
+    }
+  };
+
+  const nombre = (cle: keyof ReglagesAides, libelle: string, aide: string) => (
+    <Input
+      label={libelle}
+      hintText={aide}
+      nativeInputProps={{
+        type: "number",
+        step: "0.05",
+        value: (reglages[cle] as number | undefined) ?? "",
+        placeholder: "défaut API",
+        onChange: (e) =>
+          setReglages({ ...reglages, [cle]: e.target.value === "" ? undefined : Number(e.target.value) }),
+      }}
+    />
+  );
+
+  return (
+    <section className={fr.cx("fr-mt-4w")}>
+      <div className={fr.cx("fr-callout", "fr-mb-3w")}>
+        <h2 className={fr.cx("fr-callout__title", "fr-h5")}>Ce que l&apos;API renvoie réellement</h2>
+        <p className={fr.cx("fr-text--sm")}>
+          Les réponses <strong>exactes</strong> des endpoints publics, produites par les mêmes fonctions qui servent
+          MEC. Rien n&apos;est rejoué ici : changer un réglage redemande à l&apos;API, il ne recalcule pas.
+        </p>
+
+        <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+          <div className={fr.cx("fr-col-12", "fr-col-md-4")}>
+            <Select
+              label="Au nom de quelle plateforme ?"
+              hint="Les ajouts manuels et les arbitrages sont cloisonnés par plateforme."
+              nativeSelectProps={{ value: plateforme, onChange: (e) => setPlateforme(e.target.value) }}
+            >
+              {PLATEFORMES.map((p) => (
+                <option key={p} value={p}>
+                  {p}
+                </option>
+              ))}
+            </Select>
+          </div>
+          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
+            {nombre("cutoff", "Cutoff", "Score minimal. 0 = aucun filtrage.")}
+          </div>
+          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
+            {nombre("projetThreshold", "Confiance projet", "Sous ce seuil, l'étiquette ne compte pas.")}
+          </div>
+          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
+            {nombre("aideThreshold", "Confiance aide", "Sous ce seuil, l'étiquette ne compte pas.")}
+          </div>
+          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>{nombre("limit", "Max aides", "Défaut : 20.")}</div>
+          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
+            <Input
+              label="Seuil services"
+              hintText="Appliqué PAR l'API. Défaut : 0,30."
+              nativeInputProps={{
+                type: "number",
+                step: "0.05",
+                value: seuilServices ?? "",
+                placeholder: "défaut API",
+                onChange: (e) => setSeuilServices(e.target.value === "" ? undefined : Number(e.target.value)),
+              }}
+            />
+          </div>
+        </div>
+
+        <ToggleSwitch
+          label="Matching textuel (BM25)"
+          helperText="Repêche les aides dont l'intitulé colle au projet, même sans recouvrement d'étiquettes."
+          checked={reglages.textual ?? false}
+          onChange={(v) => setReglages({ ...reglages, textual: v })}
+          inputTitle="textuel"
+          showCheckedHint={false}
+        />
+
+        {reglages.textual && (
+          <Input
+            label="Texte de la recherche"
+            hintText="Vide = « nom + description » du projet, comme l'API."
+            nativeInputProps={{
+              value: reglages.texte ?? "",
+              placeholder: "nom + description du projet",
+              onChange: (e) => setReglages({ ...reglages, texte: e.target.value || undefined }),
+            }}
+          />
+        )}
+
+        <div className={fr.cx("fr-mt-2w")} style={{ display: "flex", gap: "0.5rem" }}>
+          <Button onClick={() => void lancer()} disabled={chargement}>
+            {chargement ? "Appel de l'API…" : "Appeler l'API"}
+          </Button>
+          <Button
+            priority="secondary"
+            onClick={() => {
+              setReglages({});
+              setSeuilServices(undefined);
+            }}
+            disabled={Object.keys(reglages).length === 0 && seuilServices === undefined}
+          >
+            Revenir aux défauts
+          </Button>
+        </div>
+      </div>
+
+      {erreur && (
+        <div className={fr.cx("fr-alert", "fr-alert--error", "fr-mb-3w")}>
+          <p>{erreur}</p>
+        </div>
+      )}
+
+      {resultat && (
+        <>
+          <h3 className={fr.cx("fr-h5")}>
+            Aides{" "}
+            <Badge severity={resultat.aides.status === "ok" ? "success" : "warning"} noIcon>
+              {resultat.aides.status}
+            </Badge>
+          </h3>
+          <p className={fr.cx("fr-text--xs")}>
+            {resultat.aides.aides.length} rendue(s) sur {resultat.aides.total} du territoire — appliqué : cutoff{" "}
+            {resultat.reglagesAides.cutoff} · confiance projet {resultat.reglagesAides.thresholds?.projet ?? "0,8"} ·
+            confiance aide {resultat.reglagesAides.thresholds?.aide ?? "0,8"} · textuel{" "}
+            {resultat.reglagesAides.textualEnabled ? "oui" : "non"} · max {resultat.reglagesAides.maxResults}
+          </p>
+
+          <div className={fr.cx("fr-table", "fr-table--sm")}>
+            <table>
+              <thead>
+                <tr>
+                  <th scope="col">Aide</th>
+                  <th scope="col">Score</th>
+                  {resultat.reglagesAides.textualEnabled && <th scope="col">Textuel</th>}
+                  <th scope="col">Étiquettes partagées</th>
+                </tr>
+              </thead>
+              <tbody>
+                {resultat.aides.aides.map((a) => (
+                  <tr key={a.id}>
+                    <td>
+                      {a.url ? (
+                        <a href={a.url} target="_blank" rel="noreferrer">
+                          {a.name}
+                        </a>
+                      ) : (
+                        a.name
+                      )}
+                      {a.ajoutManuel && (
+                        <>
+                          {" "}
+                          <Badge severity="info" noIcon small>
+                            ajout manuel
+                          </Badge>
+                          {a.ajoutManuel.message && (
+                            <div className={fr.cx("fr-text--xs")}>« {a.ajoutManuel.message} »</div>
+                          )}
+                        </>
+                      )}
+                      <div className={fr.cx("fr-text--xs")}>id {a.id}</div>
+                    </td>
+                    <td>{a.normalizedScore?.toFixed(2) ?? "—"}</td>
+                    {resultat.reglagesAides.textualEnabled && <td>{a.textualScore?.toFixed(2) ?? "—"}</td>}
+                    <td>
+                      <Etiquettes communes={a.labelsCommuns ?? { thematiques: [], sites: [], interventions: [] }} />
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+          {resultat.aides.aides.length === 0 && (
+            <p className={fr.cx("fr-text--sm")}>
+              Aucune aide rendue.{" "}
+              {resultat.aides.total > 0 && "Des aides existent sur le territoire : c'est le matching qui les écarte."}
+            </p>
+          )}
+
+          <h3 className={fr.cx("fr-h5", "fr-mt-4w")}>Services numériques</h3>
+          <p className={fr.cx("fr-text--xs")}>
+            {resultat.services.services.length} rendu(s), seuil appliqué {resultat.seuilServices.toFixed(2)}. Ce seuil
+            est appliqué <strong>par l&apos;API</strong>, pas recalculé ici — et la route publique ne l&apos;expose pas
+            : le contrat interdit de faire traverser un critère de sélection au client.
+          </p>
+          <ul>
+            {resultat.services.services.map((s) => (
+              <li key={s.id}>
+                <strong>{s.nom}</strong>
+                {s.ajoutManuel && (
+                  <>
+                    {" "}
+                    <Badge severity="info" noIcon small>
+                      {s.ajoutManuel.horsCatalogue ? "ajout manuel, hors catalogue" : "ajout manuel"}
+                    </Badge>
+                    {s.ajoutManuel.message && (
+                      <span className={fr.cx("fr-text--xs")}> « {s.ajoutManuel.message} »</span>
+                    )}
+                  </>
+                )}
+              </li>
+            ))}
+          </ul>
+          {resultat.services.services.length === 0 && <p className={fr.cx("fr-text--sm")}>Aucun service rendu.</p>}
+
+          <h3 className={fr.cx("fr-h5", "fr-mt-4w")}>Questionnaires</h3>
+          <ul>
+            {resultat.questionnaires.questionnaires.map((q) => (
+              <li key={q.slug}>
+                <strong>{q.slug}</strong> (v{q.version}, {q.statut}) — {q.banniere.titre}
+              </li>
+            ))}
+          </ul>
+          {resultat.questionnaires.questionnaires.length === 0 && (
+            <p className={fr.cx("fr-text--sm")}>Aucun questionnaire proposé.</p>
+          )}
+
+          <h3 className={fr.cx("fr-h5", "fr-mt-4w")}>Recommandations</h3>
+          <ul>
+            {resultat.recommandations.recommandations.map((r) => (
+              <li key={r.id}>
+                <strong>{r.titre}</strong>
+                {/* `aideId` est ce qui permet à MEC de proposer « ajouter cette aide au projet ». */}
+                {r.financements
+                  ?.filter((f) => f.aideId)
+                  .map((f) => (
+                    <span key={f.libelle} className={fr.cx("fr-text--xs")}>
+                      {" "}
+                      — aide {f.aideId} : {f.libelle}
+                    </span>
+                  ))}
+              </li>
+            ))}
+          </ul>
+          {resultat.recommandations.recommandations.length === 0 && (
+            <p className={fr.cx("fr-text--sm")}>Aucune recommandation.</p>
+          )}
+        </>
+      )}
+    </section>
+  );
+}

--- a/back-office/src/components/Apercu.tsx
+++ b/back-office/src/components/Apercu.tsx
@@ -6,7 +6,8 @@ import { Input } from "@codegouvfr/react-dsfr/Input";
 import { Select } from "@codegouvfr/react-dsfr/Select";
 import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 import { Etiquettes } from "./Etiquettes";
-import { apercu as chargerApercu } from "../api";
+import { apercu as chargerApercu, retirerAjout } from "../api";
+import { AjoutManuel } from "./AjoutManuel";
 import type { Apercu as ApercuType, ReglagesAides } from "../types";
 
 /**
@@ -45,6 +46,16 @@ export function Apercu({ projetId }: { projetId: string }) {
       setErreur(e instanceof Error ? e.message : "Erreur inattendue.");
     } finally {
       setChargement(false);
+    }
+  };
+
+  const retirer = async (decisionId: string) => {
+    setErreur(null);
+    try {
+      await retirerAjout(decisionId, plateforme);
+      await lancer();
+    } catch (e) {
+      setErreur(e instanceof Error ? e.message : "Erreur inattendue.");
     }
   };
 
@@ -155,6 +166,10 @@ export function Apercu({ projetId }: { projetId: string }) {
         </div>
       )}
 
+      {/* Ajouter à la main, puis constater dans l'aperçu. C'est le seul moyen de savoir si l'ajout
+          est pris en compte, plutôt que de le croire. */}
+      <AjoutManuel projetId={projetId} plateforme={plateforme} onAjout={() => void lancer()} />
+
       {resultat && (
         <>
           <h3 className={fr.cx("fr-h5")}>
@@ -200,6 +215,12 @@ export function Apercu({ projetId }: { projetId: string }) {
                           {a.ajoutManuel.message && (
                             <div className={fr.cx("fr-text--xs")}>« {a.ajoutManuel.message} »</div>
                           )}
+                          <button
+                            className={fr.cx("fr-link", "fr-link--sm")}
+                            onClick={() => void retirer(a.ajoutManuel!.decisionId)}
+                          >
+                            retirer
+                          </button>
                         </>
                       )}
                       <div className={fr.cx("fr-text--xs")}>id {a.id}</div>

--- a/back-office/src/components/Services.tsx
+++ b/back-office/src/components/Services.tsx
@@ -1,100 +1,55 @@
-import { useMemo, useState } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 import { Badge } from "@codegouvfr/react-dsfr/Badge";
-import { ToggleSwitch } from "@codegouvfr/react-dsfr/ToggleSwitch";
 import { Etiquettes } from "./Etiquettes";
-import { retenuAuSeuil, type ServiceSimule } from "../types";
+import type { ServiceSimule } from "../types";
 
 const pourcent = (n: number) => `${(n * 100).toFixed(0)} %`;
 
 /**
- * Le catalogue de services confronté à un projet, avec un curseur de seuil.
+ * DIAGNOSTIC : pourquoi tel service est écarté.
  *
- * POURQUOI UN CURSEUR. L'API renvoie TOUS les candidats avec leur score, pas seulement les
- * retenus : rejouer la sélection à un autre seuil est donc de l'arithmétique locale, sans rappel
- * réseau. On voit l'effet d'un réglage avant de le figer dans le code — c'est la seule façon
- * honnête de choisir un seuil, plutôt que de le deviner puis de le constater en production.
+ * Ce n'est PAS ce que voit la collectivité — pour ça, il y a l'aperçu, qui rend la réponse réelle
+ * de l'API, réglages compris.
  *
- * Le score seul décide : il n'y a pas de repêchage. Une liste vide est une réponse légitime.
+ * CET ÉCRAN PORTAIT UN CURSEUR QUI RECALCULAIT `retenu` DANS LE NAVIGATEUR. C'était une copie de la
+ * décision de l'API, et une copie diverge : le jour où le serveur change sa règle, l'écran continue
+ * d'afficher l'ancienne sans que rien ne casse. Un outil qui ment sur ce que voit la collectivité
+ * est pire que pas d'outil. Le seuil est désormais un PARAMÈTRE de l'API, réglable depuis l'aperçu :
+ * c'est elle qui décide, avec le réglage qu'on lui demande d'appliquer.
+ *
+ * Ce qui reste ici, et qui a de la valeur : voir les candidats ÉCARTÉS avec leur score, tel que le
+ * serveur l'a calculé. L'aperçu, lui, ne montre que les retenus — il ne dit donc pas pourquoi les
+ * autres manquent.
  */
 export function Services({ services, seuilApi }: { services: ServiceSimule[]; seuilApi: number }) {
-  const [seuil, setSeuil] = useState(seuilApi);
-  const [masquerEcartes, setMasquerEcartes] = useState(true);
-
-  const { comptes, visibles } = useMemo(() => {
-    const avecVerdict = services.map((s) => ({ ...s, affiche: retenuAuSeuil(s, seuil) }));
-
-    return {
-      comptes: {
-        affiches: avecVerdict.filter((s) => s.affiche).length,
-        // Le vrai diagnostic : un service qui ne partage AUCUNE étiquette avec le projet ne peut
-        // pas remonter, quel que soit le seuil. Baisser le curseur ne joue que sur les autres.
-        sansRecouvrement: avecVerdict.filter((s) => s.score === 0).length,
-      },
-      visibles: masquerEcartes ? avecVerdict.filter((s) => s.affiche) : avecVerdict,
-    };
-  }, [services, seuil, masquerEcartes]);
-
-  const deplace = Math.abs(seuil - seuilApi) > 0.001;
+  const retenus = services.filter((s) => s.retenu).length;
+  // LE vrai diagnostic : un service sans aucune étiquette commune ne peut pas remonter, quel que
+  // soit le seuil. C'est la classification qu'il faut réparer, pas le réglage.
+  const sansRecouvrement = services.filter((s) => s.score === 0).length;
+  const candidats = services.filter((s) => s.score > 0 || s.retenu);
 
   return (
     <section className={fr.cx("fr-mt-6w")}>
-      <h2 className={fr.cx("fr-h4")}>Services numériques</h2>
+      <h2 className={fr.cx("fr-h4")}>Services — diagnostic</h2>
 
       <div className={fr.cx("fr-callout", "fr-mb-3w")}>
-        <label className={fr.cx("fr-label")} htmlFor="seuil">
-          Seuil de pertinence : <strong>{seuil.toFixed(2)}</strong>{" "}
-          {deplace ? (
-            <span className={fr.cx("fr-text--sm")}>
-              — simulé (l&apos;API applique {seuilApi.toFixed(2)}){" "}
-              <button className={fr.cx("fr-link", "fr-link--sm")} onClick={() => setSeuil(seuilApi)}>
-                revenir
-              </button>
-            </span>
-          ) : (
-            <span className={fr.cx("fr-text--sm")}>— celui de l&apos;API</span>
-          )}
-        </label>
-        <input
-          id="seuil"
-          type="range"
-          min={0}
-          max={0.6}
-          step={0.01}
-          value={seuil}
-          onChange={(e) => setSeuil(Number(e.target.value))}
-          style={{ width: "100%", maxWidth: "32rem" }}
-        />
-
-        <p className={fr.cx("fr-mt-2w", "fr-mb-0")}>
-          <Badge severity={comptes.affiches > 0 ? "success" : "warning"} noIcon>
-            {comptes.affiches} affiché{comptes.affiches > 1 ? "s" : ""} sur {services.length}
-          </Badge>
+        <p className={fr.cx("fr-text--sm", "fr-mb-1w")}>
+          Seuil de l&apos;API : <strong>{seuilApi.toFixed(2)}</strong>.{" "}
+          <Badge severity={retenus > 0 ? "success" : "warning"} noIcon>
+            {retenus} retenu(s) sur {services.length}
+          </Badge>{" "}
+          <span className={fr.cx("fr-text--xs")}>
+            (pour tester un autre seuil, utilisez l&apos;aperçu : c&apos;est l&apos;API qui l&apos;applique)
+          </span>
         </p>
-
-        <p className={fr.cx("fr-text--sm", "fr-mt-2w", "fr-mb-0")}>
-          {comptes.sansRecouvrement} des {services.length} services ne partagent <strong>aucune</strong> étiquette avec
-          ce projet : aucun seuil ne les fera remonter. Le curseur ne joue que sur les{" "}
-          {services.length - comptes.sansRecouvrement} autres.
+        <p className={fr.cx("fr-text--sm", "fr-mb-0")}>
+          <strong>{sansRecouvrement}</strong> services ne partagent <strong>aucune</strong> étiquette avec ce projet :
+          aucun seuil ne les fera remonter. C&apos;est la classification qu&apos;il faut corriger, pas le réglage. Ils
+          ne sont pas listés ci-dessous.
         </p>
-
-        {comptes.affiches === 0 && (
-          <p className={fr.cx("fr-text--sm", "fr-mt-2w", "fr-mb-0")}>
-            Une liste vide est une réponse légitime : elle dit que le catalogue n&apos;a rien pour ce projet, ce qui est
-            une information. C&apos;est plus utile qu&apos;une liste de remplissage.
-          </p>
-        )}
       </div>
 
-      <ToggleSwitch
-        label="Masquer les services écartés"
-        checked={masquerEcartes}
-        onChange={setMasquerEcartes}
-        inputTitle="masquer-ecartes"
-        showCheckedHint={false}
-      />
-
-      <div className={fr.cx("fr-table", "fr-table--sm", "fr-mt-2w")}>
+      <div className={fr.cx("fr-table", "fr-table--sm")}>
         <table>
           <thead>
             <tr>
@@ -103,12 +58,12 @@ export function Services({ services, seuilApi }: { services: ServiceSimule[]; se
               <th scope="col" title="Le score brut est modulé par l'adéquation à la phase du projet">
                 dont phase
               </th>
-              <th scope="col">Statut</th>
+              <th scope="col">Verdict de l&apos;API</th>
               <th scope="col">Étiquettes partagées avec le projet</th>
             </tr>
           </thead>
           <tbody>
-            {visibles.map((s) => (
+            {candidats.map((s) => (
               <tr key={s.slug}>
                 <td>{s.nom}</td>
                 <td>
@@ -116,8 +71,8 @@ export function Services({ services, seuilApi }: { services: ServiceSimule[]; se
                 </td>
                 <td className={fr.cx("fr-text--xs")}>{s.facteurPhase < 1 ? `× ${pourcent(s.facteurPhase)}` : "—"}</td>
                 <td>
-                  <Badge severity={s.affiche ? "success" : "warning"} noIcon small>
-                    {s.affiche ? "affiché" : "écarté"}
+                  <Badge severity={s.retenu ? "success" : "warning"} noIcon small>
+                    {s.retenu ? "rendu" : "écarté"}
                   </Badge>
                 </td>
                 <td>
@@ -129,7 +84,9 @@ export function Services({ services, seuilApi }: { services: ServiceSimule[]; se
         </table>
       </div>
 
-      {visibles.length === 0 && <p className={fr.cx("fr-text--sm")}>Aucun service remonté à ce seuil.</p>}
+      {candidats.length === 0 && (
+        <p className={fr.cx("fr-text--sm")}>Aucun service ne partage la moindre étiquette avec ce projet.</p>
+      )}
     </section>
   );
 }

--- a/back-office/src/types.ts
+++ b/back-office/src/types.ts
@@ -67,17 +67,13 @@ export interface ServiceSimule {
 }
 
 /**
- * Rejoue la sélection du serveur à un seuil arbitraire.
+ * Le score et le verdict viennent du SERVEUR. On ne rejoue rien ici.
  *
- * C'est LA raison d'être de cet écran. `/admin/simuler` renvoie tous les candidats avec leur
- * score, jamais seulement les retenus : déplacer le seuil est donc de l'arithmétique côté
- * navigateur, sans rappeler l'API. On voit l'effet d'un réglage avant de le figer dans le code.
- *
- * Le score seul décide — il n'y a pas de repêchage. Cette fonction doit rester la copie exacte
- * de la règle appliquée dans api/src/services-numeriques/services-numeriques.service.ts, sinon
- * l'écran ment sur ce que verra la collectivité.
+ * Une version précédente de cet écran recalculait `retenu` dans le navigateur, avec un curseur de
+ * seuil : c'était une COPIE de la décision de l'API, et une copie diverge. L'aperçu montre
+ * désormais ce que l'API renvoie réellement ; ce panneau-ci ne sert plus qu'au DIAGNOSTIC — voir
+ * les candidats écartés et leur score, tels que le serveur les a calculés.
  */
-export const retenuAuSeuil = (service: ServiceSimule, seuil: number): boolean => service.score >= seuil;
 
 export interface ProjetSimule {
   id: string;
@@ -156,3 +152,71 @@ export const compterEtiquettes = (c: Classification | EtiquettesCommunes | null)
 
 /** Les étiquettes d'un match, à plat, dans l'ordre de poids des axes. */
 export const aplatir = (c: EtiquettesCommunes): string[] => [...c.thematiques, ...c.sites, ...c.interventions];
+
+// ------------------------------------------------------------
+// L'APERÇU : ce que l'API renvoie RÉELLEMENT à une plateforme.
+//
+// PAS UNE ÉMULATION. Ces quatre sections sont les réponses EXACTES des endpoints publics — le
+// back-office ne rejoue aucune règle. Une reconstitution, même fidèle au départ, finit par
+// diverger, et un outil qui ment sur ce que voit la collectivité est pire que pas d'outil.
+// ------------------------------------------------------------
+
+/** Réglages de GET /aides. Un champ absent = « le défaut de l'API ». */
+export interface ReglagesAides {
+  limit?: number;
+  cutoff?: number;
+  projetThreshold?: number;
+  aideThreshold?: number;
+  textual?: boolean;
+  texte?: string;
+}
+
+export interface AideRendue {
+  id: number;
+  name: string;
+  url?: string;
+  normalizedScore?: number;
+  textualScore?: number;
+  combinedScore?: number;
+  labelsCommuns?: EtiquettesCommunes;
+  ajoutManuel?: { decisionId: string; message?: string; plateforme: string; date: string };
+}
+
+export interface ServiceRendu {
+  id: string;
+  nom: string;
+  description: string;
+  categories: string[];
+  ajoutManuel?: { decisionId: string; message?: string; plateforme: string; horsCatalogue?: boolean };
+}
+
+export interface QuestionnaireRendu {
+  slug: string;
+  version: number;
+  statut: string;
+  banniere: { titre?: string; sousTitre?: string };
+  questions: { id: string; intitule: string }[];
+}
+
+export interface RecommandationRendue {
+  id: string;
+  titre: string;
+  description?: string;
+  financements?: { libelle: string; url: string; aideId?: number }[];
+}
+
+export interface Apercu {
+  aides: { status: string; total: number; aides: AideRendue[] };
+  services: { services: ServiceRendu[] };
+  questionnaires: { questionnaires: QuestionnaireRendu[] };
+  recommandations: { recommandations: RecommandationRendue[] };
+  /** Les réglages d'aides RÉELLEMENT appliqués — défauts de l'API résolus. */
+  reglagesAides: {
+    maxResults?: number;
+    cutoff?: number;
+    thresholds?: { projet?: number; aide?: number };
+    textualEnabled?: boolean;
+  };
+  /** Le seuil de services RÉELLEMENT appliqué par l'API. */
+  seuilServices: number;
+}


### PR DESCRIPTION
Le back-office **émulait** l'API à deux endroits. C'était le défaut de fond.

- Côté **services**, un curseur de seuil recalculait `retenu` **dans le navigateur** : une copie de la décision de l'API. Une copie diverge — le jour où le serveur change sa règle, l'écran continue d'afficher l'ancienne, et rien ne casse.
- Côté **aides**, l'endpoint de simulation **reconstituait** l'orchestration de `GET /aides` au lieu de l'exécuter.

Un outil qui ment sur ce que voit la collectivité est pire que pas d'outil.

## Ce qui remplace ça

**`POST /admin/apercu`** — les quatre réponses **exactes** des endpoints publics (aides, services, questionnaires, recommandations), produites par les **mêmes fonctions qui servent MEC**. Rien n'est reconstitué, ni côté serveur, ni côté écran.

`plateforme` y est **obligatoire** : les ajouts manuels et les arbitrages sont cloisonnés par plateforme. Sans elle, on afficherait une liste que personne ne reçoit.

## Le seuil des services devient un paramètre public

`GET /projets/:id/services?seuil=` — avec un **défaut explicite**.

C'est ce qui tue l'émulation à la racine : au lieu de rejouer la règle dans l'écran, on demande à l'API de l'appliquer. Une plateforme peut légitimement vouloir être plus permissive ou plus stricte — **le seuil est à elle, le défaut reste à nous**.

Une valeur invalide est un **400 explicite**, jamais un repli silencieux : `?seuil=abc` qui renverrait la liste par défaut ferait croire au client que son réglage est appliqué.

| Requête | Résultat (projet « friche ») |
|---|---|
| *(défaut)* | 0 service — seuil 0,30 |
| `?seuil=0.1` | **5 services** — Bénéfriches, Mutafriches, Cartofriches… |
| `?seuil=abc` | **400** — « attendu un nombre entre 0 et 1 » |

Le contrat disait « le client ne filtre ni ne trie ». C'est devenu faux : corrigé, plutôt que de le laisser mentir.

## Deux extractions, pour que l'écran appelle le vrai code

- **`AidesMoteurService`** — scorer et classer. Il vivait en privé dans le contrôleur et a désormais **trois** appelants (`GET /aides`, `POST /aides/recherche`, l'aperçu). Le recopier pour le troisième aurait donné deux implémentations d'une même règle.
- **`AidesProjetService`** — toute l'orchestration « quelles aides pour ce projet ». Le contrôleur ne garde que ce qui est HTTP : le 202 de classification et les paramètres.

C'est en passant par les **vraies** fonctions que deux modules ont révélé qu'ils n'exportaient pas leurs services. Une émulation n'aurait rien réclamé — et aurait « marché » en mentant.

## Ajouter depuis l'écran, pour vérifier la boucle

```
POST   /admin/ajouts/aide     { projetId, plateforme, aideId, message? }
POST   /admin/ajouts/service  { projetId, plateforme, slug | service, message? }
DELETE /admin/ajouts/:decisionId?plateforme=
```

Sur les endpoints partenaires, la plateforme est **déduite de la clé** — c'est ce qui empêche un service de se faire passer pour un autre. Le back-office n'est aucune plateforme : il **déclare** au nom de qui il agit. La garantie n'est pas affaiblie ; elle porte sur les clés partenaires, et reste entière.

Aucune règle n'est réécrite : on délègue à `AjoutsManuelsService`, la même porte que les endpoints partenaires.

**Vérifié de bout en bout, contre l'API réelle :** ajout avec message → rendu et marqué ; TET ne le voit pas (cloisonnement) ; retrait → disparaît ; aide hors territoire → 400 explicite.

## Tests

540 unitaires, 76 e2e.

🤖 Generated with [Claude Code](https://claude.com/claude-code)