### PR TITLE
fix(back-office): rendre l'écran lisible — cible, réglages, service hors catalogue

### DIFF
--- a/back-office/src/App.tsx
+++ b/back-office/src/App.tsx
@@ -95,6 +95,10 @@ export default function App() {
 
   return (
     <>
+      {/* SUR QUELLE API SUIS-JE ? Rien ne le disait, et c'est un vrai piège : le back-office tourne
+          en local mais peut viser n'importe quelle API (locale, staging), figée au lancement par
+          VITE_API_TARGET. On perd un temps fou à croire qu'une clé est mauvaise alors qu'on parle à
+          la mauvaise machine. */}
       <Header
         brandTop={
           <>
@@ -105,7 +109,7 @@ export default function App() {
         }
         homeLinkProps={{ href: "/", title: "Accueil - Les Communs" }}
         serviceTitle="Les Communs de la transition écologique"
-        serviceTagline="Back-office — simulation et édition"
+        serviceTagline={`Back-office — ${cible()}`}
         quickAccessItems={[
           {
             buttonProps: {
@@ -199,4 +203,18 @@ export default function App() {
       </div>
     </>
   );
+}
+
+/**
+ * L'API que ce back-office interroge, telle qu'elle a été fixée au lancement.
+ *
+ * `VITE_API_TARGET` est lue au démarrage du serveur de dev et ne peut pas changer ensuite : la
+ * changer impose de relancer `pnpm dev`. L'afficher évite l'erreur qui coûte le plus cher — croire
+ * que sa clé est refusée alors qu'on parle à la mauvaise API.
+ */
+function cible(): string {
+  const url = (import.meta.env.VITE_API_TARGET as string | undefined) ?? "http://localhost:3000";
+  if (url.includes("staging")) return "STAGING";
+  if (url.includes("prod")) return "⚠ PRODUCTION";
+  return `local (${url})`;
 }

--- a/back-office/src/api.ts
+++ b/back-office/src/api.ts
@@ -99,5 +99,27 @@ export const ajouterService = (
 ): Promise<{ decisionId: string }> =>
   appeler("/admin/ajouts/service", { projetId, plateforme, slug, message: message?.trim() ? message : undefined });
 
+/**
+ * Un service HORS CATALOGUE, décrit par l'agent lui-même.
+ *
+ * LÉGITIME ICI, ET PAS POUR UNE AIDE : le catalogue de services est LE NÔTRE. Un service qui n'y
+ * figure pas existe quand même — un outil local, un service partenaire pas encore benchmarké — et
+ * personne d'autre que l'agent ne peut le décrire. Une aide, elle, n'existe que dans
+ * Aides-territoires : hors de là, aucune autorité ne la valide, et nous n'aurions aucun moyen de la
+ * tenir à jour.
+ */
+export const ajouterServiceLibre = (
+  projetId: string,
+  plateforme: string,
+  service: { nom: string; description: string; url?: string; operateur?: string },
+  message?: string,
+): Promise<{ decisionId: string }> =>
+  appeler("/admin/ajouts/service", {
+    projetId,
+    plateforme,
+    service,
+    message: message?.trim() ? message : undefined,
+  });
+
 export const retirerAjout = (decisionId: string, plateforme: string): Promise<unknown> =>
   appeler(`/admin/ajouts/${decisionId}?plateforme=${encodeURIComponent(plateforme)}`, undefined, "DELETE");

--- a/back-office/src/components/AjoutManuel.tsx
+++ b/back-office/src/components/AjoutManuel.tsx
@@ -2,19 +2,30 @@ import { useState } from "react";
 import { fr } from "@codegouvfr/react-dsfr";
 import { Button } from "@codegouvfr/react-dsfr/Button";
 import { Input } from "@codegouvfr/react-dsfr/Input";
-import { ajouterAide, ajouterService } from "../api";
+import { RadioButtons } from "@codegouvfr/react-dsfr/RadioButtons";
+import { ajouterAide, ajouterService, ajouterServiceLibre } from "../api";
 
 /**
  * Ajouter à la main une aide ou un service, pour vérifier la boucle complète.
  *
- * L'écran n'a AUCUNE règle : il poste, et il réaffiche l'aperçu — c'est-à-dire ce que l'API renvoie
- * réellement. C'est le seul moyen de savoir si l'ajout est réellement pris en compte, plutôt que de
- * le croire.
+ * L'écran n'a AUCUNE règle : il poste, et l'aperçu se recharge — c'est-à-dire qu'il réaffiche ce que
+ * l'API renvoie. C'est le seul moyen de savoir si l'ajout est réellement pris en compte, plutôt que
+ * de le croire.
  *
- * Les gardes de l'API restent entières, et c'est volontairement visible : une aide hors du
- * territoire du projet est refusée (400), un slug inconnu du catalogue aussi (404). Le message
- * s'affiche tel quel — sans lui, on ne saurait pas POURQUOI l'ajout n'a pas pris.
+ * L'ASYMÉTRIE ENTRE AIDES ET SERVICES EST DÉLIBÉRÉE, et elle se voit ici.
+ *
+ * Un service peut être ajouté HORS CATALOGUE : le catalogue est LE NÔTRE, donc un service qui n'y
+ * figure pas existe quand même (un outil local, un service partenaire pas encore benchmarké), et
+ * personne d'autre que l'agent ne peut le décrire. Il est alors la source de vérité — il n'y a
+ * aucune autorité extérieure à tenir en phase.
+ *
+ * Une aide, elle, n'existe que dans Aides-territoires, et doit être disponible sur le TERRITOIRE du
+ * projet. Hors de là, aucune autorité ne la valide, et l'ajout serait impossible à résoudre à la
+ * lecture — donc invisible. L'API le refuse (400), et c'est volontairement visible à l'écran :
+ * sans le message, on ne saurait pas pourquoi l'ajout n'a pas pris.
  */
+type Mode = "catalogue" | "libre";
+
 export function AjoutManuel({
   projetId,
   plateforme,
@@ -25,8 +36,14 @@ export function AjoutManuel({
   onAjout: () => void;
 }) {
   const [aideId, setAideId] = useState("");
+  const [mode, setMode] = useState<Mode>("catalogue");
   const [slug, setSlug] = useState("");
+  const [nom, setNom] = useState("");
+  const [description, setDescription] = useState("");
+  const [url, setUrl] = useState("");
+  const [operateur, setOperateur] = useState("");
   const [message, setMessage] = useState("");
+
   const [erreur, setErreur] = useState<string | null>(null);
   const [succes, setSucces] = useState<string | null>(null);
   const [envoi, setEnvoi] = useState(false);
@@ -40,6 +57,10 @@ export function AjoutManuel({
       setSucces(`${quoi} ajouté au nom de ${plateforme}. L'aperçu ci-dessous est rechargé.`);
       setAideId("");
       setSlug("");
+      setNom("");
+      setDescription("");
+      setUrl("");
+      setOperateur("");
       setMessage("");
       onAjout();
     } catch (e) {
@@ -48,6 +69,8 @@ export function AjoutManuel({
       setEnvoi(false);
     }
   };
+
+  const libreComplet = nom.trim() !== "" && description.trim() !== "";
 
   return (
     <div className={fr.cx("fr-callout", "fr-mb-3w")}>
@@ -70,15 +93,17 @@ export function AjoutManuel({
 
       <Input
         label="Message (facultatif)"
-        hintText="« Recommandée par la DDT lors du COPIL du 12/03 ». Rendu tel quel à côté de l'aide ou du service."
+        hintText="« Recommandé par la DDT lors du COPIL du 12/03 ». Rendu tel quel à côté de l'aide ou du service."
         nativeInputProps={{ value: message, onChange: (e) => setMessage(e.target.value) }}
       />
 
-      <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
-        <div className={fr.cx("fr-col-12", "fr-col-md-6")}>
+      <fieldset className={fr.cx("fr-fieldset", "fr-mt-2w")}>
+        <legend className={fr.cx("fr-fieldset__legend", "fr-text--bold")}>Une aide</legend>
+
+        <div style={{ maxWidth: "20rem" }}>
           <Input
-            label="Identifiant d'aide (Aides-territoires)"
-            hintText="Elle doit être disponible sur le territoire du projet, sinon l'API refuse (400)."
+            label="Identifiant Aides-territoires"
+            hintText="Elle doit être disponible sur le territoire du projet — sinon l'API refuse (400)."
             nativeInputProps={{
               type: "number",
               value: aideId,
@@ -86,30 +111,135 @@ export function AjoutManuel({
               onChange: (e) => setAideId(e.target.value),
             }}
           />
-          <Button
-            size="small"
-            disabled={envoi || !aideId.trim()}
-            onClick={() => void poster(() => ajouterAide(projetId, plateforme, Number(aideId), message), "Aide")}
-          >
-            Ajouter l&apos;aide
-          </Button>
         </div>
+        <p className={fr.cx("fr-text--xs")}>
+          Pas d&apos;aide « hors catalogue » : une aide n&apos;existe que dans Aides-territoires. Hors de là, rien ne la
+          valide, et l&apos;ajout serait impossible à résoudre à la lecture.
+        </p>
+        <Button
+          size="small"
+          disabled={envoi || !aideId.trim()}
+          onClick={() => void poster(() => ajouterAide(projetId, plateforme, Number(aideId), message), "Aide")}
+        >
+          Ajouter l&apos;aide
+        </Button>
+      </fieldset>
 
-        <div className={fr.cx("fr-col-12", "fr-col-md-6")}>
-          <Input
-            label="Slug de service (catalogue)"
-            hintText="Doit exister au catalogue, sinon l'API refuse (404)."
-            nativeInputProps={{ value: slug, placeholder: "benefriches", onChange: (e) => setSlug(e.target.value) }}
-          />
-          <Button
-            size="small"
-            disabled={envoi || !slug.trim()}
-            onClick={() => void poster(() => ajouterService(projetId, plateforme, slug.trim(), message), "Service")}
-          >
-            Ajouter le service
-          </Button>
-        </div>
-      </div>
+      <fieldset className={fr.cx("fr-fieldset", "fr-mt-2w")}>
+        <legend className={fr.cx("fr-fieldset__legend", "fr-text--bold")}>Un service numérique</legend>
+
+        <RadioButtons
+          orientation="horizontal"
+          options={[
+            {
+              label: "Du catalogue",
+              nativeInputProps: { checked: mode === "catalogue", onChange: () => setMode("catalogue") },
+            },
+            {
+              label: "Hors catalogue — je le décris",
+              nativeInputProps: { checked: mode === "libre", onChange: () => setMode("libre") },
+            },
+          ]}
+        />
+
+        {mode === "catalogue" ? (
+          <>
+            <div style={{ maxWidth: "24rem" }}>
+              <Input
+                label="Slug"
+                hintText="Doit exister au catalogue — sinon l'API refuse (404). Sa fiche reste la source : on ne recopie rien."
+                nativeInputProps={{
+                  value: slug,
+                  placeholder: "benefriches",
+                  onChange: (e) => setSlug(e.target.value),
+                }}
+              />
+            </div>
+            <Button
+              size="small"
+              disabled={envoi || !slug.trim()}
+              onClick={() => void poster(() => ajouterService(projetId, plateforme, slug.trim(), message), "Service")}
+            >
+              Ajouter le service
+            </Button>
+          </>
+        ) : (
+          <>
+            <p className={fr.cx("fr-text--xs")}>
+              Un outil local, un service partenaire pas encore benchmarké : il existe, et vous êtes le seul à pouvoir le
+              décrire. Ses informations sont figées — c&apos;est vous la source. Sa classification reste inconnue :
+              l&apos;API n&apos;en invente aucune.
+            </p>
+
+            <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+              <div className={fr.cx("fr-col-12", "fr-col-md-6")}>
+                <Input
+                  label="Nom"
+                  nativeInputProps={{
+                    value: nom,
+                    placeholder: "Cadastre solaire de la métropole",
+                    onChange: (e) => setNom(e.target.value),
+                  }}
+                />
+              </div>
+              <div className={fr.cx("fr-col-12", "fr-col-md-6")}>
+                <Input
+                  label="Opérateur (facultatif)"
+                  nativeInputProps={{
+                    value: operateur,
+                    placeholder: "Métropole",
+                    onChange: (e) => setOperateur(e.target.value),
+                  }}
+                />
+              </div>
+              <div className={fr.cx("fr-col-12")}>
+                <Input
+                  label="Description"
+                  nativeInputProps={{
+                    value: description,
+                    placeholder: "Estime le potentiel photovoltaïque de chaque toiture du territoire.",
+                    onChange: (e) => setDescription(e.target.value),
+                  }}
+                />
+              </div>
+              <div className={fr.cx("fr-col-12")}>
+                <Input
+                  label="Lien (facultatif)"
+                  nativeInputProps={{
+                    value: url,
+                    placeholder: "https://cadastre-solaire.exemple.fr",
+                    onChange: (e) => setUrl(e.target.value),
+                  }}
+                />
+              </div>
+            </div>
+
+            <Button
+              size="small"
+              disabled={envoi || !libreComplet}
+              onClick={() =>
+                void poster(
+                  () =>
+                    ajouterServiceLibre(
+                      projetId,
+                      plateforme,
+                      {
+                        nom: nom.trim(),
+                        description: description.trim(),
+                        url: url.trim() || undefined,
+                        operateur: operateur.trim() || undefined,
+                      },
+                      message,
+                    ),
+                  "Service hors catalogue",
+                )
+              }
+            >
+              Ajouter ce service
+            </Button>
+          </>
+        )}
+      </fieldset>
     </div>
   );
 }

--- a/back-office/src/components/Apercu.tsx
+++ b/back-office/src/components/Apercu.tsx
@@ -83,65 +83,91 @@ export function Apercu({ projetId }: { projetId: string }) {
           MEC. Rien n&apos;est rejoué ici : changer un réglage redemande à l&apos;API, il ne recalcule pas.
         </p>
 
-        <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
-          <div className={fr.cx("fr-col-12", "fr-col-md-4")}>
-            <Select
-              label="Au nom de quelle plateforme ?"
-              hint="Les ajouts manuels et les arbitrages sont cloisonnés par plateforme."
-              nativeSelectProps={{ value: plateforme, onChange: (e) => setPlateforme(e.target.value) }}
-            >
-              {PLATEFORMES.map((p) => (
-                <option key={p} value={p}>
-                  {p}
-                </option>
-              ))}
-            </Select>
+        {/* GROUPÉ PAR DOMAINE. Tous ces réglages étaient alignés dans une seule grille, et rien ne
+            disait lequel agissait sur quoi : « confiance aide » et « seuil services » côte à côte,
+            sans frontière. Un écran de réglage qu'on ne sait pas lire ne sert à rien. */}
+        <div style={{ maxWidth: "22rem" }}>
+          <Select
+            label="Au nom de quelle plateforme ?"
+            hint="S'applique à tout : les ajouts manuels et les arbitrages sont cloisonnés par plateforme."
+            nativeSelectProps={{ value: plateforme, onChange: (e) => setPlateforme(e.target.value) }}
+          >
+            {PLATEFORMES.map((p) => (
+              <option key={p} value={p}>
+                {p}
+              </option>
+            ))}
+          </Select>
+        </div>
+
+        <fieldset className={fr.cx("fr-fieldset", "fr-mt-3w")}>
+          <legend className={fr.cx("fr-fieldset__legend", "fr-text--bold")}>
+            Aides <span className={fr.cx("fr-text--sm")}>— paramètres de GET /aides</span>
+          </legend>
+
+          <div className={fr.cx("fr-grid-row", "fr-grid-row--gutters")}>
+            <div className={fr.cx("fr-col-6", "fr-col-md-3")}>
+              {nombre("cutoff", "Cutoff", "Score minimal d'une aide. 0 = aucun filtrage.")}
+            </div>
+            <div className={fr.cx("fr-col-6", "fr-col-md-3")}>
+              {nombre("projetThreshold", "Confiance — étiquette du projet", "Sous ce seuil, elle ne compte pas.")}
+            </div>
+            <div className={fr.cx("fr-col-6", "fr-col-md-3")}>
+              {nombre("aideThreshold", "Confiance — étiquette de l'aide", "Sous ce seuil, elle ne compte pas.")}
+            </div>
+            <div className={fr.cx("fr-col-6", "fr-col-md-3")}>
+              {nombre("limit", "Nombre maximal d'aides", "Défaut : 20.")}
+            </div>
           </div>
-          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
-            {nombre("cutoff", "Cutoff", "Score minimal. 0 = aucun filtrage.")}
-          </div>
-          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
-            {nombre("projetThreshold", "Confiance projet", "Sous ce seuil, l'étiquette ne compte pas.")}
-          </div>
-          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
-            {nombre("aideThreshold", "Confiance aide", "Sous ce seuil, l'étiquette ne compte pas.")}
-          </div>
-          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>{nombre("limit", "Max aides", "Défaut : 20.")}</div>
-          <div className={fr.cx("fr-col-6", "fr-col-md-2")}>
+
+          <ToggleSwitch
+            label="Matching textuel (BM25)"
+            helperText="Repêche les aides dont l'intitulé colle au projet, même sans recouvrement d'étiquettes."
+            checked={reglages.textual ?? false}
+            onChange={(v) => setReglages({ ...reglages, textual: v })}
+            inputTitle="textuel"
+            showCheckedHint={false}
+          />
+
+          {reglages.textual && (
             <Input
-              label="Seuil services"
-              hintText="Appliqué PAR l'API. Défaut : 0,30."
+              label="Texte de la recherche"
+              hintText="Vide = « nom + description » du projet, comme l'API."
+              nativeInputProps={{
+                value: reglages.texte ?? "",
+                placeholder: "nom + description du projet",
+                onChange: (e) => setReglages({ ...reglages, texte: e.target.value || undefined }),
+              }}
+            />
+          )}
+        </fieldset>
+
+        <fieldset className={fr.cx("fr-fieldset", "fr-mt-2w")}>
+          <legend className={fr.cx("fr-fieldset__legend", "fr-text--bold")}>
+            Services numériques <span className={fr.cx("fr-text--sm")}>— paramètre de GET /projets/:id/services</span>
+          </legend>
+
+          <div style={{ maxWidth: "18rem" }}>
+            <Input
+              label="Seuil de pertinence"
+              hintText="Appliqué PAR l'API, pas recalculé ici. Défaut : 0,30."
               nativeInputProps={{
                 type: "number",
                 step: "0.05",
                 value: seuilServices ?? "",
-                placeholder: "défaut API",
+                placeholder: "défaut API (0,30)",
                 onChange: (e) => setSeuilServices(e.target.value === "" ? undefined : Number(e.target.value)),
               }}
             />
           </div>
-        </div>
+        </fieldset>
 
-        <ToggleSwitch
-          label="Matching textuel (BM25)"
-          helperText="Repêche les aides dont l'intitulé colle au projet, même sans recouvrement d'étiquettes."
-          checked={reglages.textual ?? false}
-          onChange={(v) => setReglages({ ...reglages, textual: v })}
-          inputTitle="textuel"
-          showCheckedHint={false}
-        />
-
-        {reglages.textual && (
-          <Input
-            label="Texte de la recherche"
-            hintText="Vide = « nom + description » du projet, comme l'API."
-            nativeInputProps={{
-              value: reglages.texte ?? "",
-              placeholder: "nom + description du projet",
-              onChange: (e) => setReglages({ ...reglages, texte: e.target.value || undefined }),
-            }}
-          />
-        )}
+        {/* Information autonome, et non une note du bloc « Services » : elle ne parle ni des aides
+            ni des services. Sans elle, on cherche un curseur qui n'existera jamais. */}
+        <p className={fr.cx("fr-text--sm", "fr-mt-2w", "fr-mb-0")}>
+          Les questionnaires et les recommandations n&apos;ont <strong>aucun réglage</strong> : leur éligibilité est un
+          critère, pas un score. Le projet porte l&apos;étiquette qui déclenche le questionnaire, ou il ne la porte pas.
+        </p>
 
         <div className={fr.cx("fr-mt-2w")} style={{ display: "flex", gap: "0.5rem" }}>
           <Button onClick={() => void lancer()} disabled={chargement}>


### PR DESCRIPTION
Quatre défauts d'ergonomie, dont un qui a réellement fait perdre du temps.

## 1. La cible n'était pas affichée — et c'est le pire

Le back-office tourne **en local** mais peut viser **n'importe quelle API** (locale, staging, demain la prod), figée au lancement par `VITE_API_TARGET`. **Rien à l'écran ne le disait.**

Résultat vécu : *« Clé refusée par l'API »* — alors que la clé était bonne, et qu'on parlait simplement à la mauvaise machine.

L'en-tête affiche désormais la cible :

| Cible | En-tête |
|---|---|
| API locale | `Back-office — local (http://localhost:3999)` |
| Staging | `Back-office — STAGING` |
| Production | `Back-office — ⚠ PRODUCTION` |

L'avertissement sur la prod n'est pas décoratif : c'est le seul endroit où le contenu est éditable **sans relecture en PR**.

## 2. Les réglages étaient mélangés

« Confiance aide » et « Seuil services » côte à côte dans la même grille, sans frontière : rien ne disait lequel agissait sur quoi. **Un écran de réglage qu'on ne sait pas lire ne sert à rien.**

Groupés par domaine, avec l'endpoint concerné en légende :

- **Aides** — *paramètres de `GET /aides`* : cutoff, confiance (étiquette du projet), confiance (étiquette de l'aide), nombre maximal, matching textuel + son texte.
- **Services numériques** — *paramètre de `GET /projets/:id/services`* : seuil de pertinence.

## 3. L'information qui manquait

> Les questionnaires et les recommandations n'ont **aucun réglage** : leur éligibilité est un critère, pas un score. Le projet porte l'étiquette qui déclenche le questionnaire, ou il ne la porte pas.

Sans ça, on cherche un curseur qui n'existera jamais. Ce n'est pas un réglage manquant, c'est une **nature différente**.

## 4. On ne pouvait pas ajouter un service hors catalogue

Alors que **l'API le permet depuis le début** : c'était une omission du formulaire, pas une limite.

L'asymétrie avec les aides est délibérée, et elle se voit désormais à l'écran :

- Le catalogue de **services** est **le nôtre**. Un service qui n'y figure pas existe quand même — un outil local, un service partenaire pas encore benchmarké — et personne d'autre que l'agent ne peut le décrire. **Il est alors la source de vérité.**
- Une **aide** n'existe que dans Aides-territoires, et doit être disponible sur le **territoire du projet**. Hors de là, rien ne la valide, et l'ajout serait impossible à résoudre à la lecture — donc **invisible**. Le formulaire le dit, plutôt que de laisser chercher un champ qui n'existera pas.

## Vérifié contre staging, de bout en bout

```
✅ Cadastre solaire de la métropole  [HORS CATALOGUE]
   « Outil local, pas au benchmark DINUM »
   categories = []   ← vide : on n'invente aucune classification
→ retrait → disparaît de la réponse de l'API
```

Aucun changement côté API : uniquement `back-office/src`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)