### PR TITLE
docs(questionnaires): guide d'édition — et refus des ajouts en double

### DIFF
--- a/api/src/ajouts-manuels/ajouts-manuels.service.spec.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.service.spec.ts
@@ -24,8 +24,16 @@ describe("AjoutsManuelsService — garde du périmètre (aides)", () => {
 
   const aide = (id: number) => ({ id, name: `Aide ${id}` }) as Aide;
 
-  const construire = (aidesDuPerimetre: Aide[]) => {
+  const construire = (aidesDuPerimetre: Aide[], ajoutsDejaActifs: unknown[] = []) => {
     const decisionsService = { create: jest.fn().mockResolvedValue({ id: "decision-1" }) };
+
+    // `refuserDoublon` interroge les ajouts déjà actifs : un ajout ne doit pas pouvoir être fait
+    // deux fois (sinon retirer l'un ne fait pas disparaître l'objet — l'autre le maintient).
+    const dbService = {
+      database: {
+        select: () => ({ from: () => ({ where: () => Promise.resolve(ajoutsDejaActifs) }) }),
+      },
+    };
     const perimetre = {
       extractCodesInsee: jest.fn().mockReturnValue(["44109"]),
       fetchAidesForPerimeterCodes: jest.fn().mockResolvedValue(aidesDuPerimetre),
@@ -37,7 +45,7 @@ describe("AjoutsManuelsService — garde du périmètre (aides)", () => {
     };
 
     const service = new AjoutsManuelsService(
-      {} as unknown as DatabaseService,
+      dbService as unknown as DatabaseService,
       decisionsService as unknown as DecisionsService,
       projets as unknown as GetProjetsService,
       perimetre as unknown as AidesPerimetreService,

--- a/api/src/ajouts-manuels/ajouts-manuels.service.ts
+++ b/api/src/ajouts-manuels/ajouts-manuels.service.ts
@@ -1,5 +1,5 @@
 import { randomUUID } from "node:crypto";
-import { BadRequestException, Injectable, NotFoundException } from "@nestjs/common";
+import { BadRequestException, ConflictException, Injectable, NotFoundException } from "@nestjs/common";
 import { and, eq } from "drizzle-orm";
 import { DatabaseService } from "@database/database.service";
 import { decisions, servicesNumeriques } from "@database/schema";
@@ -53,6 +53,8 @@ export class AjoutsManuelsService {
       );
     }
 
+    await this.refuserDoublon(projetId, "aide", String(dto.aideId), plateforme, `L'aide ${dto.aideId}`);
+
     return this.enregistrer(projetId, "aide", String(dto.aideId), dto.message, dto.auteur, plateforme);
   }
 
@@ -100,12 +102,60 @@ export class AjoutsManuelsService {
         );
       }
 
+      await this.refuserDoublon(projetId, "service_numerique", dto.slug, plateforme, `Le service "${dto.slug}"`);
+
       return this.enregistrer(projetId, "service_numerique", dto.slug, dto.message, dto.auteur, plateforme);
+    }
+
+    // Un service HORS catalogue n'a pas d'identifiant stable : chaque ajout produit un UUID neuf.
+    // On dédoublonne donc sur son NOM — sans quoi un double-clic créerait deux fois le même service,
+    // et rien ne le signalerait.
+    const nom = dto.service!.nom.trim();
+    const actifs = await this.actifs(projetId, "service_numerique", plateforme);
+    const homonyme = [...actifs.values()].find(
+      (a) => a.service?.nom.trim().localeCompare(nom, undefined, { sensitivity: "base" }) === 0,
+    );
+
+    if (homonyme) {
+      throw new ConflictException(
+        `Le service « ${nom} » est déjà attaché à ce projet (ajout ${homonyme.ajout.decisionId}). ` +
+          `Retirez-le avant de le rajouter, ou modifiez son nom s'il s'agit d'un autre service.`,
+      );
     }
 
     return this.enregistrer(projetId, "service_numerique", randomUUID(), dto.message, dto.auteur, plateforme, {
       service: dto.service,
     });
+  }
+
+  /**
+   * REFUSE un ajout déjà actif, plutôt que d'en créer un second.
+   *
+   * Sans ce garde-fou, deux ajouts du même objet produisaient DEUX décisions actives. La lecture les
+   * indexe par identifiant, donc le doublon était masqué — mais le message affiché devenait
+   * arbitraire (celui de la dernière décision rencontrée), et surtout RETIRER L'UNE NE FAISAIT PAS
+   * DISPARAÎTRE L'OBJET : l'autre le maintenait. Une panne silencieuse, découverte en la
+   * reproduisant sur staging.
+   *
+   * 409, et non 400 : la requête est valide, c'est l'ÉTAT qui s'y oppose. Le message donne l'id de
+   * la décision existante — sans lui, on ne saurait pas quoi retirer pour pouvoir rajouter.
+   */
+  private async refuserDoublon(
+    projetId: string,
+    objetBType: ObjetAjoutable,
+    objetBId: string,
+    plateforme: string,
+    quoi: string,
+  ): Promise<void> {
+    const actifs = await this.actifs(projetId, objetBType, plateforme);
+    const existant = actifs.get(objetBId);
+
+    if (existant) {
+      throw new ConflictException(
+        `${quoi} est déjà attaché à ce projet (ajout ${existant.ajout.decisionId}). ` +
+          `Retirez-le d'abord si vous voulez changer son message.`,
+      );
+    }
   }
 
   private async enregistrer(

--- a/api/src/questionnaires/questionnaire-contract.ts
+++ b/api/src/questionnaires/questionnaire-contract.ts
@@ -2,9 +2,15 @@
 // Contrat des questionnaires spécialisés
 // ============================================================
 //
-// Un questionnaire est du CONTENU éditorial produit par un partenaire (AtoutBiodiv) et
-// validé avec nous : il vit en JSON dans content/questionnaires/ et content/recommandations/,
-// versionné en Git et relu en PR. Ce fichier n'en définit que la FORME et l'évaluation.
+// Un questionnaire est du CONTENU éditorial produit par un partenaire (AtoutBiodiv). Il vit EN BASE
+// (table `questionnaires`) et s'édite depuis le back-office. Les JSON de content/ ne sont plus
+// qu'un AMORÇAGE (`pnpm seed:questionnaires`), comme le CSV DINUM pour le catalogue de services.
+//
+// Ce fichier n'en définit que la FORME et l'évaluation. La validation, elle, vit dans
+// questionnaire-validation.ts et s'applique à CHAQUE écriture — elle remplace le refus de démarrage
+// qu'on avait quand les questionnaires étaient dans le dépôt.
+//
+// Documentation destinée aux éditeurs : docs/api/GUIDE_QUESTIONNAIRES.md
 //
 // Frontière stricte : `condition` (et la classification d'éligibilité) ne sortent JAMAIS de
 // l'API. Elles sont évaluées côté serveur, et les DTO de réponse ne les portent pas. Exposer
@@ -75,10 +81,9 @@ export interface BanniereDef {
 /**
  * Fichier content/questionnaires/<slug>.json, tel que le partenaire l'écrit.
  *
- * Il ne porte QUE du contenu affichable : ni éligibilité, ni condition. L'éligibilité est
- * décidée par Communs (spec §2 : « toute la logique métier vit dans Communs »), par score de
- * matching sur les trois axes de classification — voir content/classification.ts. Un fichier
- * qui porterait encore un champ `eligibilite` est rejeté au démarrage (cf. content/index.ts).
+ * Il ne porte QUE du contenu affichable : ni éligibilité, ni condition. L'éligibilité est décidée
+ * par Communs (spec §2 : « toute la logique métier vit dans Communs »), par les ÉTIQUETTES REQUISES
+ * — un critère, pas un score. Un fichier qui porterait encore un champ `eligibilite` est rejeté.
  */
 export interface QuestionnaireFichier {
   slug: string;

--- a/api/test/ajouts-manuels.e2e-spec.ts
+++ b/api/test/ajouts-manuels.e2e-spec.ts
@@ -151,6 +151,46 @@ describe("Ajouts manuels (e2e)", () => {
       expect((await ajouterService(projetId, "service-qui-nexiste-pas")).status).toBe(404);
     });
 
+    it("REFUSE d'ajouter deux fois le même service, et dit lequel retirer", async () => {
+      // Sans ce garde-fou, deux ajouts produisaient DEUX décisions actives. La lecture les indexe
+      // par identifiant, donc le doublon était masqué — mais le message affiché devenait arbitraire,
+      // et surtout RETIRER L'UN NE FAISAIT PAS DISPARAÎTRE LE SERVICE : l'autre le maintenait.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "deja-la", nom: "Déjà là", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      const premier = await ajouterService(projetId, "deja-la", "Premier message");
+      expect(premier.status).toBe(201);
+
+      const second = await appeler<{ message: string }>("POST", `/projets/${projetId}/services/ajouts`, {
+        slug: "deja-la",
+        message: "Second message",
+      });
+
+      // 409 et non 400 : la requête est valide, c'est l'ÉTAT qui s'y oppose.
+      expect(second.status).toBe(409);
+      // Le message donne l'id à retirer — sans lui, on ne saurait pas quoi faire.
+      expect(second.body.message).toContain(premier.body.decisionId);
+
+      // Et surtout : le retrait fait bien disparaître le service, puisqu'il n'y a qu'une décision.
+      await appeler("DELETE", `/projets/${projetId}/ajouts/${premier.body.decisionId}`);
+      expect(await getServices(projetId)).toEqual([]);
+    });
+
+    it("autorise de nouveau l'ajout APRÈS retrait", async () => {
+      // Le refus porte sur l'ajout ACTIF, pas sur l'objet : une fois retiré, on peut le remettre.
+      await global.testDbService.database
+        .insert(servicesNumeriques)
+        .values([service({ slug: "deja-la", nom: "Déjà là", classification: VELO })]);
+      const projetId = await creerProjet(EAU);
+
+      const premier = await ajouterService(projetId, "deja-la");
+      await appeler("DELETE", `/projets/${projetId}/ajouts/${premier.body.decisionId}`);
+
+      expect((await ajouterService(projetId, "deja-la", "Finalement si")).status).toBe(201);
+    });
+
     it("refuse un projet inconnu", async () => {
       await global.testDbService.database
         .insert(servicesNumeriques)
@@ -247,6 +287,23 @@ describe("Ajouts manuels (e2e)", () => {
 
       const { status } = await appeler("POST", `/projets/${projetId}/services/ajouts`, { message: "sans objet" });
       expect(status).toBe(400);
+    });
+
+    it("REFUSE un service hors catalogue HOMONYME d'un ajout déjà actif", async () => {
+      // Un service hors catalogue n'a pas d'identifiant stable : chaque ajout produit un UUID neuf.
+      // On dédoublonne donc sur son NOM — sans quoi un double-clic créerait deux fois le même
+      // service, et rien ne le signalerait.
+      const projetId = await creerProjet(EAU);
+
+      expect((await ajouterLibre(projetId, { nom: "Outil local", description: "Un outil." })).status).toBe(201);
+
+      const second = await appeler<{ message: string }>("POST", `/projets/${projetId}/services/ajouts`, {
+        service: { nom: "  outil LOCAL  ", description: "Le même, autrement écrit." },
+      });
+
+      // Insensible à la casse et aux espaces : c'est le même service, écrit autrement.
+      expect(second.status).toBe(409);
+      expect((await getServices(projetId)).length).toBe(1);
     });
 
     it("se retire comme n'importe quel ajout", async () => {

--- a/docs/api/GUIDE_QUESTIONNAIRES.md
+++ b/docs/api/GUIDE_QUESTIONNAIRES.md
@@ -1,0 +1,360 @@
+# Guide des questionnaires, recommandations et ajouts manuels
+
+Pour les personnes qui **éditent le contenu** (partenaires, agents Communs) et pour les
+plateformes qui **l'intègrent** (MEC, TET…).
+
+---
+
+## 1. Qu'est-ce qu'un questionnaire
+
+Un questionnaire est proposé à une collectivité **sur un projet donné**, quand ce projet
+correspond à ce qu'il traite. Ses réponses déclenchent des **recommandations** — des actions
+concrètes, avec leurs financements et leurs ressources.
+
+Il vit **en base**, et s'édite depuis le **back-office**. Les JSON du dépôt
+(`api/src/questionnaires/content/`) ne sont plus qu'un **amorçage** (`pnpm seed:questionnaires`),
+comme le CSV DINUM l'est pour le catalogue de services.
+
+> **Conséquence à connaître.** Le contenu n'est plus relu en PR. La validation à l'écriture est
+> désormais le seul filet — et elle est stricte (§6). Un questionnaire cassé ne peut pas être
+> enregistré, mais un questionnaire **médiocre**, si.
+
+---
+
+## 2. Le document, champ par champ
+
+```jsonc
+{
+  "sourceNom": "AtoutBiodiv",          // le partenaire qui fournit le contenu
+
+  "banniere": {
+    "icone": "🌿",                     // facultatif
+    "titre": "Optimisez le potentiel biodiversité de votre projet de place ou de centre-bourg",
+    "sousTitre": "Désimperméabilisation, végétalisation, corridors — identifiez les actions adaptées"
+  },
+
+  "questions": [ /* §3 */ ],
+  "recommandations": [ /* §4 */ ],
+  "etiquettesRequises": { /* §5 */ }
+}
+```
+
+**Le titre doit nommer la nature du projet** (« …de votre projet **de place ou de centre-bourg** »).
+Une collectivité doit reconnaître son projet dans le bandeau, sinon elle ne comprend pas pourquoi
+on le lui propose.
+
+`version` **n'est pas à fournir** : elle s'incrémente à chaque enregistrement. Elle n'invalide
+rien — voir §7.
+
+---
+
+## 3. Les questions
+
+```jsonc
+{
+  "id": "part-estimee-des-espaces-exterieurs",   // stable : les réponses y sont attachées
+  "type": "choix-unique",                        // seul type supporté à ce jour
+  "intitule": "Quelle part d'espaces extérieurs dans votre projet ?",
+  "options": [
+    {
+      "id": "importante-plus-de-50",             // stable, comme l'id de question
+      "libelle": "Importante — plus de 50 %",
+      "signal": "favorable",                     // favorable | vigilance | neutre
+      "aide": "Comptez les abords, parkings et cheminements.",   // facultatif
+      "feedback": {                              // facultatif : réaction immédiate
+        "ton": "success",                        // success | warning | info
+        "message": "Excellent : c'est là que se joue l'essentiel du gain biodiversité."
+      }
+    }
+  ]
+}
+```
+
+**Les `id` sont des clés, pas des libellés.** Les réponses des collectivités y sont attachées, et
+les conditions des recommandations les citent. Changer un `id`, c'est **détacher les réponses
+existantes** — elles ne sont pas détruites, mais elles cessent d'être lues (§7). Changez le
+`libelle` autant que vous voulez ; touchez à l'`id` en connaissance de cause.
+
+`signal` et `feedback` sont **de l'affichage** : ils ne décident de rien côté serveur.
+
+---
+
+## 4. Les recommandations, et comment les associer aux réponses
+
+```jsonc
+{
+  "id": "haies",                       // clé locale ; l'id exposé est « questionnaire:<slug>:haies »
+  "icone": "🌳",                       // facultatif
+  "titre": "Planter des haies bocagères",
+  "description": "Une haie d'essences locales constitue un corridor écologique…",
+  "engagement": "faible",              // texte libre : l'effort demandé
+
+  "condition": { "question": "part-estimee-des-espaces-exterieurs",
+                 "parmi": ["importante-plus-de-50", "moyenne-20-50"] },
+
+  "financements": [ /* §4.2 */ ],
+  "ressources":   [ /* §4.3 */ ]
+}
+```
+
+### 4.1 La condition — c'est elle qui associe la reco aux réponses
+
+Deux formes, et **deux seulement** :
+
+| Forme | Sens |
+|---|---|
+| `{ "question": "<id>", "parmi": ["<idOption>", …] }` | sort **si** la collectivité a répondu l'une de ces options |
+| `true` | **inconditionnelle** — sort dès que le questionnaire est *entamé* |
+
+Même `true` ne sort **pas** tant que le questionnaire est `non_commence` : une recommandation qui
+s'afficherait avant toute réponse n'aurait rien à recommander.
+
+> **Le garde-fou qui vous sauvera.** Une condition qui pointe une question ou une option
+> **inexistante** est refusée à l'enregistrement (400), avec le nom du fautif. Sans ce refus,
+> l'erreur serait **indétectable** : la recommandation ne s'afficherait simplement jamais, et
+> personne ne saurait pourquoi.
+
+**Il n'y a pas de « et », pas de « ou », pas d'imbrication.** Pour une règle composée, écrivez
+deux recommandations. C'est délibéré : un mini-langage de conditions serait vite illisible pour
+qui édite, et impossible à valider correctement.
+
+### 4.2 Les financements — et l'`aideId` qui rend l'aide **ajoutable**
+
+```jsonc
+{
+  "icone": "🌿",
+  "libelle": "Fonds vert — Renaturation des espaces publics",
+  "description": "Financement direct de la désimperméabilisation des places communales.",
+  "url": "https://aides-territoires.beta.gouv.fr/aides/…",
+  "aideId": 165809                    // ← FACULTATIF, mais c'est LUI qui compte
+}
+```
+
+**`aideId` est l'identifiant Aides-territoires.** Quand il est présent, MEC peut proposer
+**« ajouter cette aide au projet »** en un clic, sans que l'agent ait à la retrouver.
+
+**Ne le mettez que si le financement désigne une aide PRÉCISE.** Beaucoup désignent une *famille*
+(« Fonds vert », « DETR ») et leur `url` est une **recherche**, pas une fiche. En inventer un
+enverrait une collectivité vers la mauvaise aide.
+
+Trois choses à savoir, et elles comptent :
+
+1. **On ne peut pas vérifier à l'enregistrement qu'un id existe.** Aides-territoires ne sait pas
+   récupérer une aide par son identifiant. On ne valide donc que la **forme** (entier positif).
+2. **Un id valide peut légitimement échouer à l'ajout.** L'aide doit être disponible sur le
+   **territoire du projet** : une aide d'Agence de l'Eau Adour-Garonne renverra un 400 pour une
+   commune bretonne. **Ce n'est pas un bug, c'est le territoire.**
+3. **Les identifiants pourrissent.** Une aide recréée pour une nouvelle édition (Fonds vert 2025 →
+   2026) change d'id. Un `aideId` codé en dur se périmera — vérifiez-le à chaque campagne.
+
+**Comment trouver un `aideId`** : ouvrez la fiche de l'aide sur `aides-territoires.beta.gouv.fr`.
+Si l'URL est une recherche (`?text=…`), c'est qu'il n'y a pas d'aide précise : laissez `aideId`
+absent.
+
+### 4.3 Les ressources
+
+```jsonc
+{
+  "icone": "📄",
+  "source": "OFB",
+  "nom": "Guide de plantation de haies bocagères",
+  "description": "Essences locales, densités, entretien.",   // facultatif
+  "url": "https://…"
+}
+```
+
+Purement informatif : aucun effet sur la sélection.
+
+---
+
+## 5. Quand le questionnaire est-il proposé ? — les étiquettes requises
+
+```jsonc
+"etiquettesRequises": {
+  "thematiques":   [],
+  "sites":         ["Place ou centre-bourg"],
+  "interventions": []
+}
+```
+
+**Le projet doit porter TOUTES ces étiquettes**, avec une confiance ≥ **0,80** dans sa
+classification. C'est un **critère**, pas un score : la place l'est, ou elle ne l'est pas.
+
+**Toutes**, et non au moins une. Sur le questionnaire « panneaux solaires sur école »
+(thématique *Agrivoltaïsme…* **et** lieu *Ecole*), l'école seule attraperait n'importe quel projet
+d'école, et le solaire seul n'importe quelle installation photovoltaïque. **C'est la conjonction
+qui définit le questionnaire.**
+
+> **Le piège le plus dangereux, et il est contre-intuitif.** Un questionnaire qui n'exige
+> **aucune** étiquette serait proposé à **tous les projets de France** — une conjonction vide est
+> *vraie*. L'API refuse de l'enregistrer.
+
+Les étiquettes appartiennent à des **taxonomies fermées** (138 thématiques, 59 lieux, 15 modalités). Le back-office ne propose que des valeurs valides : **une coquille y est impossible**.
+Par l'API, elle est refusée (400) — parce qu'une étiquette mal orthographiée ferait que le
+questionnaire n'est **jamais** proposé, sans le moindre message.
+
+**Restez étroit.** Une version antérieure élargissait chaque questionnaire aux thématiques
+connexes (« Végétalisation d'espaces publics »…) : le questionnaire « salle des fêtes » remontait
+sur des projets qui n'en étaient pas. **Un questionnaire mal déclenché est pire qu'un
+questionnaire absent** — il demande à une collectivité de répondre à des questions qui ne la
+concernent pas.
+
+---
+
+## 6. Éditer
+
+**Depuis le back-office** (recommandé) : onglet *Questionnaires*. Les étiquettes se choisissent
+dans la taxonomie ; le contenu s'édite en JSON. Les refus de l'API s'affichent en clair.
+
+**Par l'API** :
+
+```
+PUT /admin/questionnaires/<slug>        Authorization: Bearer <clé d'administration>
+DELETE /admin/questionnaires/<slug>
+GET /admin/taxonomies                   → les 138 / 59 / 15 étiquettes valides
+```
+
+`PUT`, pas `PATCH` : on envoie **le document entier**. Un `PATCH` champ par champ autoriserait des
+états incohérents entre deux appels — une condition enregistrée avant la question qu'elle vise.
+
+**Tout est revalidé avant écriture.** Un écart est un **400 qui nomme le fautif** :
+
+| Refusé | Pourquoi |
+|---|---|
+| Aucune étiquette requise | serait proposé à **tous** les projets |
+| Étiquette hors taxonomie | ne serait **jamais** proposé, sans message |
+| Condition sur une question ou une option inexistante | la recommandation ne s'afficherait **jamais** |
+| Deux questions, deux options ou deux recos de même `id` | la réponse de la collectivité serait ambiguë |
+| Une question sans option | sans réponse possible |
+
+**Supprimer un questionnaire n'efface pas les réponses** : elles cessent d'être lues. Recréé sous
+le même slug, il les retrouve.
+
+---
+
+## 7. Ce qui arrive aux réponses quand on édite
+
+**Rien de destructeur.** `version` s'incrémente, mais les réponses déjà données ne sont ni
+migrées, ni effacées :
+
+- une réponse à une question **supprimée** est **ignorée à la lecture** ;
+- une réponse pointant une option **disparue** est ignorée de même ;
+- **toutes les autres survivent.**
+
+La ligne stockée n'est même pas réécrite tant que la collectivité ne repasse pas un `PUT`.
+
+Supprimer une question ne détruit donc pas les autres réponses. **Mais changer un `id` équivaut à
+supprimer** : l'ancienne réponse devient orpheline.
+
+---
+
+## 8. Ajouter une aide ou un service à la main
+
+Quand le moteur rate quelque chose qu'un humain sait, on l'attache au projet — avec un **message**
+qui dit pourquoi.
+
+### 8.1 Une aide
+
+```
+POST /projets/:projetId/aides/ajouts        Authorization: Bearer <clé de plateforme>
+
+{ "aideId": 165809,
+  "message": "Recommandée par la DDT lors du COPIL du 12/03",   // facultatif
+  "auteur": "j.dupont" }                                        // facultatif
+```
+
+**L'aide doit être disponible sur le territoire du projet — sinon 400.** Ce n'est pas une
+formalité : une aide n'est persistée **nulle part** (elle est rechargée depuis Aides-territoires à
+chaque lecture, filtrée par territoire), et Aides-territoires **ne sait pas** la retrouver par son
+id. Une aide hors périmètre produirait donc un ajout que la lecture ne saurait **jamais** résoudre
+— invisible, sans le moindre message. On refuse là où on peut encore l'expliquer.
+
+**Il n'existe pas d'aide « hors catalogue ».** Une aide n'existe que dans Aides-territoires : hors
+de là, aucune autorité ne la valide.
+
+Si l'aide est **clôturée ou dépubliée** plus tard, elle **cesse simplement de s'afficher**. C'est
+voulu : mieux vaut ne rien montrer que d'envoyer une collectivité candidater à une aide morte.
+
+### 8.2 Un service du catalogue
+
+```
+POST /projets/:projetId/services/ajouts
+
+{ "slug": "benefriches", "message": "Confirmé en réunion" }
+```
+
+Le slug doit exister (**404** sinon). **On ne recopie rien** : sa fiche reste la source de vérité
+et continuera d'évoluer (logo, description, lien).
+
+### 8.3 Un service **hors catalogue** — un outil local, un service pas encore benchmarké
+
+```
+POST /projets/:projetId/services/ajouts
+
+{ "service": {
+    "nom": "Cadastre solaire de la métropole",                    // requis, ≤ 300
+    "description": "Estime le potentiel photovoltaïque…",         // requis, ≤ 2000
+    "url": "https://cadastre-solaire.exemple.fr",                 // facultatif
+    "libelleLien": "Ouvrir le cadastre",                          // facultatif
+    "operateur": "Métropole",                                     // facultatif
+    "logoUrl": "https://…"                                        // facultatif
+  },
+  "message": "Outil local, pas au benchmark DINUM" }
+```
+
+**Pourquoi c'est possible pour un service et pas pour une aide.** Le catalogue de services est **le
+nôtre** : un service qui n'y figure pas **existe quand même**, et personne d'autre que vous ne peut
+le décrire — **vous êtes la source**, il n'y a aucune autorité extérieure à tenir en phase.
+
+`slug` **et** `service` ensemble → **400** (lequel afficherait-on ?). Ni l'un ni l'autre → **400**.
+
+Sa classification reste **inconnue** : `categories` et `thematiques` sortent **vides**. On ne les
+invente pas, et on ne vous les demande pas — les thématiques ne servent qu'à *sélectionner* un
+service, et ici la sélection est déjà faite. **Par vous.**
+
+### 8.4 Retirer
+
+```
+DELETE /projets/:projetId/ajouts/:decisionId
+```
+
+**Révocation, pas suppression** : le journal est *append-only*. La trace de ce qui a été fait, et
+défait, subsiste. Une plateforme ne peut retirer que **ses propres** ajouts (404 sinon).
+
+### 8.5 Ce que la plateforme reçoit
+
+Rien de nouveau à appeler : les ajouts remontent **fondus** dans `GET /aides?projetId=` et
+`GET /projets/:id/services`, **en tête**, et **ils échappent au seuil** — quelqu'un les a
+délibérément mis là.
+
+```jsonc
+"ajoutManuel": {
+  "decisionId": "018f2c4a-…",       // à fournir pour retirer
+  "message": "Recommandée par la DDT lors du COPIL",
+  "plateforme": "MEC",
+  "date": "2026-07-14T09:12:33.201Z",
+  "horsCatalogue": true             // services seulement, et seulement si vrai
+}
+```
+
+**Les ajouts sont cloisonnés par plateforme.** Un ajout fait au nom de MEC n'apparaît pas pour TET.
+La plateforme est **déduite de la clé d'API**, jamais du corps de requête : un service ne peut pas
+se faire passer pour un autre.
+
+Un objet à la fois **retenu par le moteur et ajouté à la main** n'apparaît **qu'une fois**, avec sa
+marque. Le dédoublonnage se fait côté API — sinon chaque consommateur devrait le refaire, et
+finirait par l'oublier.
+
+---
+
+## 9. Depuis le back-office
+
+Le back-office fait tout ce qui précède, plus la **simulation** : coller l'identifiant d'un projet
+réel, et voir **ce que l'API renvoie vraiment** — aides, services, questionnaires, recommandations.
+Rien n'y est recalculé : ce sont les mêmes fonctions qui servent MEC.
+
+Il permet aussi d'ajouter une aide ou un service **au nom d'une plateforme** (`POST /admin/ajouts/…`),
+puisqu'il porte la clé d'administration et n'est aucune plateforme.
+
+> Le back-office **tourne en local** et vise l'API indiquée par `VITE_API_TARGET` — l'en-tête
+> affiche laquelle (`STAGING`, `local`, `⚠ PRODUCTION`). Vérifiez-la avant d'éditer.

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -31,6 +31,12 @@ l'instance.
   doublons, statut de projet, rattachement PCAET, correction, et la révocation par `annule`. À lire
   dès que vous écrivez dans le référentiel, quelle que soit votre plateforme.
 
+- [**`GUIDE_QUESTIONNAIRES.md`**](./GUIDE_QUESTIONNAIRES.md) — **questionnaires, recommandations et
+  ajouts manuels**. Les champs d'un questionnaire, comment une condition associe une recommandation
+  aux réponses, l'`aideId` qui rend une aide **ajoutable en un clic**, et comment attacher à la main
+  une aide, un service du catalogue ou un service **hors catalogue**. À lire si vous éditez le
+  contenu, ou si vous l'intégrez.
+
 ### Interne / gouvernance
 
 - [**`DOCTRINE_ACCES_DONNEES.md`**](./DOCTRINE_ACCES_DONNEES.md) — « qui voit quoi » : scopes de


### PR DESCRIPTION
## La documentation demandée

**[`docs/api/GUIDE_QUESTIONNAIRES.md`](../blob/docs/guide-questionnaires/docs/api/GUIDE_QUESTIONNAIRES.md)** — pour qui **édite** le contenu (partenaires, agents) et pour qui **l'intègre** (MEC, TET).

- **Chaque champ** d'un questionnaire : bannière, questions, options, `signal`, `feedback`.
- **Comment une condition associe une recommandation aux réponses** — et pourquoi il n'y a ni « et », ni « ou », ni imbrication.
- **L'`aideId`** : ce qui rend une aide **ajoutable en un clic** depuis une recommandation, quand le mettre, et les trois pièges (on ne peut pas vérifier qu'il existe ; un id valide peut légitimement échouer selon le territoire ; **les identifiants pourrissent**).
- **Les étiquettes requises** : un critère, pas un score. Et le piège contre-intuitif — un questionnaire qui n'exige *aucune* étiquette serait proposé à **tous les projets de France**.
- **Ce qui arrive aux réponses quand on édite** : rien de destructeur, mais changer un `id` équivaut à supprimer.
- **Ajouter à la main** une aide, un service du catalogue, ou un service **hors catalogue** — et pourquoi cette asymétrie existe.

Écrite **depuis le code**, pas de mémoire. Chaque chiffre vérifié : les taxonomies font **138 / 59 / 15**, j'avais d'abord écrit 137/58.

## Un bug trouvé en écrivant la doc, et il était sérieux

**Rien n'empêchait d'ajouter deux fois le même objet.** Reproduit sur staging :

```
décision 1 : e01667c5-…   « PREMIER message »
décision 2 : 483fcf05-…   « SECOND message »

l'API rend : Hortilio — « SECOND message »     ← arbitraire
je retire la décision 1 → le service est-il parti ? ❌ NON — le doublon le maintient
```

Deux décisions actives. La lecture les indexe par identifiant, donc le doublon était **masqué** — mais le message affiché devenait **arbitraire**, et surtout **retirer l'une ne faisait pas disparaître l'objet**. Une panne silencieuse.

### Le correctif

**409**, et non 400 : la requête est valide, c'est **l'état** qui s'y oppose. Le message donne l'**id de la décision existante** — sans lui, on ne saurait pas quoi retirer pour pouvoir rajouter.

Un service **hors catalogue** n'a pas d'identifiant stable (chaque ajout produit un UUID neuf) : on le dédoublonne sur son **nom**, insensible à la casse et aux espaces. Sans quoi un double-clic créerait deux fois le même service, et rien ne le signalerait.

Le refus porte sur l'ajout **actif**, pas sur l'objet : une fois retiré, on peut le remettre.

## Au passage

L'en-tête de `questionnaire-contract.ts` **mentait encore** — « il vit en JSON dans `content/`, versionné en Git et relu en PR ». Faux depuis le passage en base. Corrigé, sinon la documentation aurait contredit le code.

## Tests

**540 unitaires, 79 e2e** — dont trois qui verrouillent le doublon.

🤖 Generated with [Claude Code](https://claude.com/claude-code)