### PR TITLE
fix(mec): lever la limite de corps sur /mec/v1/projets/bulk (500 en prod)

### DIFF
--- a/api/src/setup-app.ts
+++ b/api/src/setup-app.ts
@@ -4,7 +4,7 @@ import { RequestLoggingInterceptor } from "@/logging/request-logging.interceptor
 import { GlobalExceptionFilter } from "@/exceptions/global-exception-filter";
 import { CustomLogger } from "@/logging/logger.service";
 import { MatomoService } from "@/matomo";
-import { json } from "express";
+import { json, type NextFunction, type Request, type Response } from "express";
 import { ProjetsModule } from "@projets/projets.module";
 import { ServicesModule } from "./services/services.module";
 import { ProjetQualificationModule } from "@/projet-qualification/projet-qualification.module";
@@ -24,9 +24,21 @@ export function setupApp(app: INestApplication) {
 
   app.useLogger(logger);
 
-  // Bulk endpoint accepts large payloads (80k+ projects from MEC CRTE)
-  app.use("/projets/bulk", json({ limit: "50mb" }));
-  app.use(json({ limit: "100kb" }));
+  // Les endpoints « bulk » reçoivent d'énormes corps (80k+ projets du CRTE de MEC) ; tout le reste
+  // est plafonné bas pour se protéger.
+  //
+  // ON DÉCIDE SUR LE SUFFIXE DU CHEMIN, pas sur un préfixe fixe. Le premier essai posait
+  // l'override sur `/projets/bulk` — mais Express matche `app.use(chemin, …)` par PRÉFIXE, et le
+  // bulk de MEC vit à `/mec/v1/projets/bulk`. Ce chemin ne matchait donc pas, retombait sur les
+  // 100 Ko, et tout import MEC réel partait en 500 (PayloadTooLargeError). Vu en prod.
+  //
+  // `endsWith` couvre les DEUX bulk existants (public et MEC) et tout futur `.../projets/bulk`,
+  // sans qu'on ait à réénumérer les chemins — c'est exactement ce que l'ancien code oubliait.
+  const corpsVolumineux = json({ limit: "50mb" });
+  const corpsStandard = json({ limit: "100kb" });
+  app.use((req: Request, res: Response, next: NextFunction) =>
+    (req.path.endsWith("/projets/bulk") ? corpsVolumineux : corpsStandard)(req, res, next),
+  );
 
   app.useGlobalFilters(new GlobalExceptionFilter(logger));
 

--- a/api/test/projets.e2e-spec.ts
+++ b/api/test/projets.e2e-spec.ts
@@ -2,6 +2,7 @@
 
 import { getFormattedDate } from "./helpers/get-formatted-date";
 import { createApiClient } from "@test/helpers/api-client";
+import { E2E_BASE_URL } from "@test/helpers/e2e-port";
 import { CompetenceCode, Levier } from "@/shared/types";
 import { mockedDefaultCollectivite, mockProjetPayload } from "@test/mocks/mockProjetPayload";
 import { collectivites, PhaseStatut, ProjetPhase } from "@database/schema";
@@ -376,6 +377,36 @@ describe("Projets (e2e)", () => {
   });
 
   describe("POST /projets/bulk", () => {
+    // RÉGRESSION PROD (juillet 2026). Le bulk de MEC vit à `/mec/v1/projets/bulk`, mais l'override
+    // de corps volumineux (50 Mo) était posé sur `/projets/bulk` — un PRÉFIXE qui ne matche pas le
+    // chemin MEC. Tout import MEC réel dépassait donc les 100 Ko par défaut et partait en 500
+    // (PayloadTooLargeError). Ce test envoie > 100 Ko à la route MEC et vérifie qu'elle NE renvoie
+    // PAS 413 : le corps doit être parsé, pas rejeté pour sa taille.
+    it("accepte un corps MEC de plus de 100 Ko sur /mec/v1/projets/bulk (pas de 413)", async () => {
+      // ~250 projets, chacun avec une description remplie : le JSON dépasse largement 100 Ko, tout
+      // en restant très loin des 50 Mo. Assez pour franchir l'ancienne limite, pas pour toucher la
+      // nouvelle.
+      const bourrage = "x".repeat(400);
+      const projets = Array.from({ length: 250 }, (_, i) => ({
+        nom: `Projet volumineux ${i}`,
+        externalId: `bulk-taille-${i}`,
+        collectivites: [mockedDefaultCollectivite],
+        description: bourrage,
+      }));
+      const corps = JSON.stringify({ projets });
+      expect(corps.length).toBeGreaterThan(100 * 1024);
+
+      const reponse = await fetch(`${E2E_BASE_URL}/mec/v1/projets/bulk`, {
+        method: "POST",
+        headers: { Authorization: `Bearer ${process.env.MEC_API_KEY}`, "Content-Type": "application/json" },
+        body: corps,
+      });
+
+      // Le point du test : PAS 413. Avant le correctif, c'était 413 → 500 côté client.
+      expect(reponse.status).not.toBe(413);
+      expect(reponse.status).toBe(201);
+    });
+
     const validProjets: { projets: CreateProjetRequest[] } = {
       projets: [mockProjetPayload({ externalId: "bulk-projet-1" }), mockProjetPayload({ externalId: "bulk-projet-2" })],
     };


### PR DESCRIPTION
> 🚨 **Panne de production active.** L'import en masse de MEC échoue en 500. À déployer.

## Symptôme

Dans les logs de prod, quatre `500` identiques :

```
Unhandled Exception: PayloadTooLargeError: request entity too large
path: /mec/v1/projets/bulk
```

## Cause

L'override de corps volumineux (50 Mo, pour les 80k+ projets du CRTE) était posé sur `/projets/bulk` :

```ts
app.use("/projets/bulk", json({ limit: "50mb" }));   // ← préfixe
app.use(json({ limit: "100kb" }));                    // défaut
```

Express matche `app.use(chemin, …)` **par préfixe**. Le bulk de MEC vit à **`/mec/v1/projets/bulk`** — qui ne commence pas par `/projets/bulk`. Ce chemin retombait donc sur les **100 Ko** par défaut, et le moindre lot MEC réel les dépassait.

Il y a bien **deux** endpoints bulk, et un seul était couvert :

| Chemin | Avant |
|---|---|
| `POST /projets/bulk` | 50 Mo ✅ |
| `POST /mec/v1/projets/bulk` | **100 Ko ❌** → 500 |

## Correctif

On décide la limite sur le **suffixe** du chemin, pas sur un préfixe fixe :

```ts
req.path.endsWith("/projets/bulk") ? corpsVolumineux(50mb) : corpsStandard(100kb)
```

`endsWith` couvre les **deux** bulk existants **et** tout futur `.../projets/bulk`, sans réénumérer les chemins — c'est exactement ce que l'ancien code oubliait.

## Test de régression, vérifié dans les deux sens

Un corps > 100 Ko envoyé à `/mec/v1/projets/bulk` :

- **sans** le correctif → **500** (reproduit la panne)
- **avec** le correctif → **201**

🤖 Generated with [Claude Code](https://claude.com/claude-code)