### PR TITLE
test(mec): le test bulk ne persiste plus rien (fuite en CI)

### DIFF
--- a/api/test/projets.e2e-spec.ts
+++ b/api/test/projets.e2e-spec.ts
@@ -382,15 +382,16 @@ describe("Projets (e2e)", () => {
     // chemin MEC. Tout import MEC réel dépassait donc les 100 Ko par défaut et partait en 500
     // (PayloadTooLargeError). Ce test envoie > 100 Ko à la route MEC et vérifie qu'elle NE renvoie
     // PAS 413 : le corps doit être parsé, pas rejeté pour sa taille.
-    it("accepte un corps MEC de plus de 100 Ko sur /mec/v1/projets/bulk (pas de 413)", async () => {
-      // ~250 projets, chacun avec une description remplie : le JSON dépasse largement 100 Ko, tout
-      // en restant très loin des 50 Mo. Assez pour franchir l'ancienne limite, pas pour toucher la
-      // nouvelle.
+    it("accepte un corps de plus de 100 Ko sur /mec/v1/projets/bulk (parsé, pas rejeté pour sa taille)", async () => {
+      // Projets VOLONTAIREMENT INVALIDES (nom manquant) : on ne veut RIEN persister. cleanDatabase
+      // ne tronque pas data_mec.projets_operationnels — un test qui y écrirait polluerait les
+      // suivants (fuite constatée en CI). Le corps invalide est quand même PARSÉ avant d'être
+      // validé : c'est tout ce qu'il faut pour prouver que la taille est acceptée.
+      //
+      // ~250 entrées avec du bourrage : le JSON dépasse 100 Ko, tout en restant loin des 50 Mo.
       const bourrage = "x".repeat(400);
       const projets = Array.from({ length: 250 }, (_, i) => ({
-        nom: `Projet volumineux ${i}`,
         externalId: `bulk-taille-${i}`,
-        collectivites: [mockedDefaultCollectivite],
         description: bourrage,
       }));
       const corps = JSON.stringify({ projets });
@@ -402,9 +403,10 @@ describe("Projets (e2e)", () => {
         body: corps,
       });
 
-      // Le point du test : PAS 413. Avant le correctif, c'était 413 → 500 côté client.
-      expect(reponse.status).not.toBe(413);
-      expect(reponse.status).toBe(201);
+      // AVANT le correctif : le corps > 100 Ko échoue au parsing (PayloadTooLargeError) → 500.
+      // APRÈS : le corps est parsé, puis la validation rejette les projets sans nom → 400.
+      // C'est ce passage de 500 à 400 qui prouve le correctif, sans écrire une seule ligne.
+      expect(reponse.status).toBe(400);
     });
 
     const validProjets: { projets: CreateProjetRequest[] } = {


### PR DESCRIPTION
> Suite de #532. Le correctif du bug prod y est **déjà mergé** ; cette PR ne corrige que **le test**, qui polluait la CI.

## Ce qui se passait

Le test de régression ajouté en #532 créait **250 vrais projets MEC** pour prouver qu'un corps > 100 Ko est accepté.

Or `cleanDatabase` ne tronque **aucune** table `data_mec`. Après le test :

```
collectivites                    : 0     (nettoyé)
data_mec.projets_operationnels   : 250   ← reste en base
```

Ces 250 lignes polluaient les suites suivantes. **La CI de #532 passait, celle de `main` a échoué juste après le merge** — la signature d'une fuite d'état, réveillée par le volume que ce test introduisait. Les deux tests tombés (`reject collectivites not valid`, `reject nom empty`) échouaient sur un `duplicate key` dans leur `beforeEach`.

## Le correctif

Le test n'a **pas besoin de persister** : il lui suffit de prouver que le corps est **parsé**, pas rejeté pour sa taille. On envoie donc des projets **volontairement invalides** (sans `nom`) :

| | Corps > 100 Ko sur `/mec/v1/projets/bulk` |
|---|---|
| **avant** le correctif | > 100 Ko → PayloadTooLargeError → **500** |
| **après** | parsé → validation → **400** |

C'est ce passage de **500 à 400** qui prouve le correctif — **sans écrire une seule ligne**.

Vérifié dans les deux sens (échoue sans le fix, passe avec), et `data_mec.projets_operationnels` reste à **0** après le test. Les deux tests de validation qui tombaient en CI repassent en local.

🤖 Generated with [Claude Code](https://claude.com/claude-code)