### PR TITLE
fix(aides): 500 sur /aides — jobId BullMQ + résilience aux 401 Aides-Territoires

### DIFF
--- a/api/src/aides/aides-territoires.service.ts
+++ b/api/src/aides/aides-territoires.service.ts
@@ -53,10 +53,32 @@ export class AidesTerritoiresService {
   }
 
   /**
-   * Fetch a single page from AT API with retry on transient errors (429, 502, 503, 504).
+   * Oublie le bearer token en cache pour forcer une ré-authentification au prochain appel.
+   * Notre TTL de 23h n'est qu'une hypothèse : si AT invalide le token plus tôt (rotation,
+   * incident, redémarrage côté AT), il faut pouvoir en redemander un sans attendre l'échéance.
    */
-  private async fetchPage(url: string, token: string): Promise<AidesTerritoiresResponse> {
+  private invalidateBearerToken(): void {
+    this.bearerToken = null;
+    this.bearerExpiresAt = 0;
+  }
+
+  /**
+   * Fetch a single page from AT API, robuste aux défaillances d'Aides-Territoires.
+   *
+   * AT renvoie des 401 de DEUX natures, qu'on traite différemment :
+   *   1. token réellement périmé avant notre TTL de 23h → il faut ré-authentifier ;
+   *   2. 401 INTERMITTENT sur un token pourtant valide (backend AT flaky : un même token est
+   *      accepté puis rejeté à quelques secondes d'intervalle, observé en prod) → il faut
+   *      simplement retenter.
+   * On combine les deux : au 1er 401/403 on jette le token en cache et on rejoue tout de suite
+   * (couvre le cas 1, gratuit) ; si AT continue de renvoyer 401/403, on le traite comme une
+   * erreur transitoire (429/5xx) et on retente avec backoff — au lieu de laisser un hoquet d'AT
+   * remonter en 500 chez l'appelant.
+   */
+  private async fetchPage(url: string): Promise<AidesTerritoiresResponse> {
+    let reauthed = false;
     for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+      const token = await this.getBearerToken();
       const response = await fetch(url, {
         headers: { Authorization: `Bearer ${token}` },
       });
@@ -65,7 +87,22 @@ export class AidesTerritoiresService {
         return (await response.json()) as AidesTerritoiresResponse;
       }
 
-      if (!RETRYABLE_STATUS_CODES.includes(response.status) || attempt === MAX_RETRIES) {
+      const isAuthError = response.status === 401 || response.status === 403;
+
+      // Cas 1 — 1er 401/403 : le token est peut-être périmé. On le jette et on rejoue
+      // immédiatement avec un token frais, sans consommer de tentative ni attendre.
+      if (isAuthError && !reauthed) {
+        reauthed = true;
+        this.invalidateBearerToken();
+        this.logger.warn(`AT API ${response.status} on ${url}, re-authenticating and retrying`);
+        attempt--;
+        continue;
+      }
+
+      // Cas 2 — 401/403 persistant (AT flaky) ou erreur transitoire (429/5xx) : on retente
+      // avec backoff. Tout le reste (4xx applicatif) échoue immédiatement.
+      const retryable = isAuthError || RETRYABLE_STATUS_CODES.includes(response.status);
+      if (!retryable || attempt === MAX_RETRIES) {
         throw new Error(`AT API error: ${response.status} ${response.statusText}`);
       }
 
@@ -86,7 +123,6 @@ export class AidesTerritoiresService {
    * @returns All aides matching the query
    */
   async fetchAides(params: Record<string, string> = {}): Promise<Aide[]> {
-    const token = await this.getBearerToken();
     const allAides: Aide[] = [];
     let page = 1;
     let hasMore = true;
@@ -95,7 +131,7 @@ export class AidesTerritoiresService {
       const queryParams = new URLSearchParams({ ...params, page_size: "50", page: String(page) });
       const url = `${this.baseUrl}/aids/?${queryParams}`;
 
-      const data = await this.fetchPage(url, token);
+      const data = await this.fetchPage(url);
       allAides.push(...data.results);
 
       hasMore = data.next !== null;

--- a/api/src/aides/aides.controller.spec.ts
+++ b/api/src/aides/aides.controller.spec.ts
@@ -138,7 +138,7 @@ describe("AidesController", () => {
 
     mockQualificationQueue = {
       getJob: jest.fn().mockResolvedValue(null),
-      add: jest.fn().mockResolvedValue({ id: "auto-classify:test-id" }),
+      add: jest.fn().mockResolvedValue({ id: "auto-classify-test-id" }),
     } as unknown as jest.Mocked<Queue>;
 
     mockFeedbackService = {
@@ -274,8 +274,12 @@ describe("AidesController", () => {
       expect(mockQualificationQueue.add).toHaveBeenCalledWith(
         PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
         { projetId: "test-id" },
-        expect.objectContaining({ jobId: "auto-classify:test-id" }),
+        expect.objectContaining({ jobId: "auto-classify-test-id" }),
       );
+      // Garde anti-régression : BullMQ rejette tout jobId contenant `:` (séparateur de clés Redis).
+      // Le mock ne valide pas cette règle, d'où le 500 passé inaperçu — on l'ancre donc ici.
+      const enqueuedOpts = mockQualificationQueue.add.mock.calls[0][2] as { jobId: string };
+      expect(enqueuedOpts.jobId).not.toContain(":");
     });
 
     it("should tag the classification job with schema=data_mec when projet comes from data_mec", async () => {
@@ -294,7 +298,7 @@ describe("AidesController", () => {
       expect(mockQualificationQueue.add).toHaveBeenCalledWith(
         PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
         { projetId: "test-id", schema: "data_mec" },
-        expect.objectContaining({ jobId: "auto-classify:test-id" }),
+        expect.objectContaining({ jobId: "auto-classify-test-id" }),
       );
     });
 
@@ -314,7 +318,7 @@ describe("AidesController", () => {
       expect(mockQualificationQueue.add).toHaveBeenCalledWith(
         PROJECT_QUALIFICATION_CLASSIFICATION_JOB,
         { ficheActionId: "test-id" },
-        expect.objectContaining({ jobId: "auto-classify:test-id" }),
+        expect.objectContaining({ jobId: "auto-classify-test-id" }),
       );
     });
 

--- a/api/src/aides/aides.controller.ts
+++ b/api/src/aides/aides.controller.ts
@@ -252,7 +252,10 @@ export class AidesController {
    * Returns true if a new job was enqueued, false if one was already in flight.
    */
   private async triggerClassificationIfNeeded(projetId: string, source: ProjetSource): Promise<boolean> {
-    const jobId = `auto-classify:${projetId}`;
+    // Pas de `:` dans le jobId : BullMQ (>=5) le réserve comme séparateur de clés Redis et rejette
+    // tout id custom qui en contient (« Custom Id cannot contain : »). Un `:` ici faisait donc lever
+    // une exception à l'enqueue → 500 sur GET /aides pour tout projet non encore classifié.
+    const jobId = `auto-classify-${projetId}`;
     const existing = await this.qualificationQueue.getJob(jobId);
 
     if (existing) {

--- a/api/test/projets.e2e-spec.ts
+++ b/api/test/projets.e2e-spec.ts
@@ -382,15 +382,16 @@ describe("Projets (e2e)", () => {
     // chemin MEC. Tout import MEC réel dépassait donc les 100 Ko par défaut et partait en 500
     // (PayloadTooLargeError). Ce test envoie > 100 Ko à la route MEC et vérifie qu'elle NE renvoie
     // PAS 413 : le corps doit être parsé, pas rejeté pour sa taille.
-    it("accepte un corps MEC de plus de 100 Ko sur /mec/v1/projets/bulk (pas de 413)", async () => {
-      // ~250 projets, chacun avec une description remplie : le JSON dépasse largement 100 Ko, tout
-      // en restant très loin des 50 Mo. Assez pour franchir l'ancienne limite, pas pour toucher la
-      // nouvelle.
+    it("accepte un corps de plus de 100 Ko sur /mec/v1/projets/bulk (parsé, pas rejeté pour sa taille)", async () => {
+      // Projets VOLONTAIREMENT INVALIDES (nom manquant) : on ne veut RIEN persister. cleanDatabase
+      // ne tronque pas data_mec.projets_operationnels — un test qui y écrirait polluerait les
+      // suivants (fuite constatée en CI). Le corps invalide est quand même PARSÉ avant d'être
+      // validé : c'est tout ce qu'il faut pour prouver que la taille est acceptée.
+      //
+      // ~250 entrées avec du bourrage : le JSON dépasse 100 Ko, tout en restant loin des 50 Mo.
       const bourrage = "x".repeat(400);
       const projets = Array.from({ length: 250 }, (_, i) => ({
-        nom: `Projet volumineux ${i}`,
         externalId: `bulk-taille-${i}`,
-        collectivites: [mockedDefaultCollectivite],
         description: bourrage,
       }));
       const corps = JSON.stringify({ projets });
@@ -402,9 +403,10 @@ describe("Projets (e2e)", () => {
         body: corps,
       });
 
-      // Le point du test : PAS 413. Avant le correctif, c'était 413 → 500 côté client.
-      expect(reponse.status).not.toBe(413);
-      expect(reponse.status).toBe(201);
+      // AVANT le correctif : le corps > 100 Ko échoue au parsing (PayloadTooLargeError) → 500.
+      // APRÈS : le corps est parsé, puis la validation rejette les projets sans nom → 400.
+      // C'est ce passage de 500 à 400 qui prouve le correctif, sans écrire une seule ligne.
+      expect(reponse.status).toBe(400);
     });
 
     const validProjets: { projets: CreateProjetRequest[] } = {


### PR DESCRIPTION
## Contexte

Vague de **500 sur `GET /aides`** en prod et staging. Diagnostic : deux bugs distincts empilés, plus un fix de fuite CI.

## Correctifs

### 1. `fix(aides)` — jobId de classification sans `:` (le vrai 500 déterministe)
BullMQ (≥5) réserve `:` comme séparateur de clés Redis et rejette tout jobId custom qui en contient (`Custom Id cannot contain :`). Le jobId `auto-classify:<uuid>` levait donc une exception à l'enqueue → **500 sur `GET /aides` pour tout projet non encore classifié** (branche 202). Séparateur `:` → `-`.

Passé inaperçu car les tests **mockent la file** (la validation BullMQ ne s'exécute jamais). Ajout d'une **garde anti-régression** ancrant l'invariant « jobId sans `:` ».

### 2. `fix(aides)` — ré-auth + retry sur 401/403 d'Aides-Territoires
AT renvoie des 401 de deux natures : token périmé avant notre TTL de 23h, et **401 intermittent** sur un token pourtant valide (backend flaky, observé en prod ET staging). Avant, un 401 sur `/aids/` n'était ni retryable ni recouvrable : le bearer restait figé en cache et le service 401ait jusqu'au redémarrage → 500 sur cache miss.

`fetchPage` : au 1er 401/403 on jette le bearer et on rejoue avec un token frais ; si AT continue de 401, on retente avec backoff (comme un 429/5xx). Un hoquet d'AT ne remonte plus en 500.

### 3. `test(mec)` — le test bulk ne persiste plus rien (fuite en CI)
Déjà présent sur la branche ; inclus car il corrige une fuite de données en CI.

## Vérification
- `pnpm validate` (type-check + lint + format) vert sur tout le workspace.
- Staging : après nettoyage BDD d'une ligne shadow + restart, `GET /aides` sur un projet MEC renvoie de nouveau des aides pertinentes (`status: ok`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)