### PR TITLE
fix(back-office): projetId accepte un id MEC (et pas seulement un UUID)

### DIFF
--- a/api/src/admin/dto/admin.dto.ts
+++ b/api/src/admin/dto/admin.dto.ts
@@ -7,7 +7,6 @@ import {
   IsObject,
   IsOptional,
   IsString,
-  IsUUID,
   Max,
   Min,
 } from "class-validator";
@@ -71,10 +70,11 @@ export class ContenuResponse {
 export class SimulationRequest {
   @ApiProperty({
     description:
-      "Identifiant d'un projet RÉEL. On simule sur une vraie classification, avec ses trous : " +
-      "un projet fictif composé à la main dirait ce qu'on veut entendre.",
+      "Identifiant d'un projet RÉEL : communId (UUID) ou id MEC (external_id). On simule sur une " +
+      "vraie classification, avec ses trous : un projet fictif composé à la main dirait ce qu'on veut entendre.",
   })
-  @IsUUID()
+  @IsString()
+  @IsNotEmpty()
   projetId!: string;
 
   @ApiPropertyOptional({
@@ -202,8 +202,9 @@ export class ParametresAidesDto {
 }
 
 export class ApercuRequest {
-  @ApiProperty({ description: "Identifiant d'un projet RÉEL." })
-  @IsUUID()
+  @ApiProperty({ description: "Identifiant d'un projet RÉEL : communId (UUID) ou id MEC (external_id)." })
+  @IsString()
+  @IsNotEmpty()
   projetId!: string;
 
   @ApiProperty({


### PR DESCRIPTION
## Contexte
Complément de #536. Ce dernier a ajouté la résolution `id MEC → communId` dans `admin.service`, **mais** les DTO validaient encore `projetId` en `@IsUUID` → un id MEC (ex. `200001`) était rejeté **avant** d'atteindre le service (`projetId must be a UUID`). Le back-office renvoyait donc l'erreur malgré #536.

## Correctif
`admin.dto.ts` — `SimulationRequest` et `ApercuRequest` : `projetId` passe de `@IsUUID` à `@IsString @IsNotEmpty`. La résolution `resoudreProjetId` (déjà en place) fait le tri UUID vs external_id ; un id inconnu → 404 explicite.

🤖 Generated with [Claude Code](https://claude.com/claude-code)